### PR TITLE
Adding command line interface to model

### DIFF
--- a/pyDeltaRCM/__main__.py
+++ b/pyDeltaRCM/__main__.py
@@ -1,0 +1,4 @@
+from pyDeltaRCM import command_line
+
+if __name__ == '__main__':
+    command_line.run_model()

--- a/pyDeltaRCM/command_line.py
+++ b/pyDeltaRCM/command_line.py
@@ -1,8 +1,8 @@
 import os
 import argparse
 
-import pyDeltaRCM as deltaModule
-from pyDeltaRCM.deltaRCM_driver import pyDeltaRCM
+import pyDeltaRCM
+from . import deltaRCM_driver
 
 
 def run_model():
@@ -10,23 +10,22 @@ def run_model():
     parser = argparse.ArgumentParser(description='Options for running pyDeltaRCM from command line')
 
     parser.add_argument('--config', help='Path to a config file that you would like to use.')
-    parser.add_argument('--version', action='version', version='pyDeltaRCM ' + deltaModule.__version__, help='Prints the version of pyDeltaRCM.')
+    parser.add_argument('--version', action='version', version='pyDeltaRCM ' + pyDeltaRCM.__version__, help='Prints the version of pyDeltaRCM.')
 
     args = parser.parse_args()
 
     cmdlineargs = vars(args)
 
     if cmdlineargs['config'] is not None:
-        delta = pyDeltaRCM(input_file=cmdlineargs['config'])
+        delta = deltaRCM_driver.pyDeltaRCM(input_file=cmdlineargs['config'])
     else:
-        delta = pyDeltaRCM()
+        delta = deltaRCM_driver.pyDeltaRCM()
 
     for time in range(0, delta.timesteps):
 
-        print(delta._time)
         delta.update()
 
-        delta.finalize()
+    delta.finalize()
 
 
 if __name__ == '__main__':

--- a/pyDeltaRCM/command_line.py
+++ b/pyDeltaRCM/command_line.py
@@ -1,0 +1,37 @@
+import os
+import argparse
+
+import pyDeltaRCM as deltaModule
+from pyDeltaRCM.deltaRCM_driver import pyDeltaRCM
+
+
+def run_model(use_test_yaml=False):
+
+    parser = argparse.ArgumentParser(description='Options for running pyDeltaRCM from command line')
+
+    parser.add_argument('--config', help='Path to a config file that you would like to use.')
+    parser.add_argument('--version', action='version', version='pyDeltaRCM ' + deltaModule.__version__, help='Prints the version of pyDeltaRCM.')
+
+    args = parser.parse_args()
+
+    cmdlineargs = vars(args)
+
+    if cmdlineargs['config'] is not None:
+        delta = pyDeltaRCM(input_file=cmdlineargs['config'])
+    # elif use_test_yaml:
+    #     test_yaml = os.path.join(os.path.dirname(__file__), '..', 'tests', 'test_output.yaml')
+    #     delta = pyDeltaRCM(input_file=os.path.abspath(test_yaml))
+    else:
+        delta = pyDeltaRCM()
+
+    for time in range(0, delta.timesteps):
+
+        print(delta._time)
+        delta.update()
+
+        delta.finalize()
+
+
+if __name__ == '__main__':
+
+    run_model()

--- a/pyDeltaRCM/command_line.py
+++ b/pyDeltaRCM/command_line.py
@@ -5,7 +5,7 @@ import pyDeltaRCM as deltaModule
 from pyDeltaRCM.deltaRCM_driver import pyDeltaRCM
 
 
-def run_model(use_test_yaml=False):
+def run_model():
 
     parser = argparse.ArgumentParser(description='Options for running pyDeltaRCM from command line')
 
@@ -18,9 +18,6 @@ def run_model(use_test_yaml=False):
 
     if cmdlineargs['config'] is not None:
         delta = pyDeltaRCM(input_file=cmdlineargs['config'])
-    # elif use_test_yaml:
-    #     test_yaml = os.path.join(os.path.dirname(__file__), '..', 'tests', 'test_output.yaml')
-    #     delta = pyDeltaRCM(input_file=os.path.abspath(test_yaml))
     else:
         delta = pyDeltaRCM()
 

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -142,3 +142,6 @@ coeff_U_ero_sand:
 alpha:
   type: ['float', 'int']
   default: 0.1
+timesteps:
+  type: ['float', 'int']
+  default: 10

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 
 from pyDeltaRCM import shared_tools
+import pyDeltaRCM
 
 setup(name='pyDeltaRCM',
       version=shared_tools._get_version(),
@@ -14,4 +15,7 @@ setup(name='pyDeltaRCM',
       url='https://github.com/DeltaRCM/pyDeltaRCM',
       install_requires=['matplotlib', 'netCDF4',
                         'basic-modeling-interface', 'scipy', 'numpy', 'pyyaml'],
+      entry_points={
+                  'console_scripts': ['run_pyDeltaRCM=pyDeltaRCM.command_line:run_model'],
+      }
       )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 from setuptools import setup, find_packages
 
 from pyDeltaRCM import shared_tools
-from pyDeltaRCM import command_line
 
 setup(name='pyDeltaRCM',
       version=shared_tools._get_version(),
@@ -16,6 +15,6 @@ setup(name='pyDeltaRCM',
       install_requires=['matplotlib', 'netCDF4',
                         'basic-modeling-interface', 'scipy', 'numpy', 'pyyaml'],
       entry_points={
-                  'console_scripts': ['run_pyDeltaRCM=command_line:run_model'],
+                  'console_scripts': ['run_pyDeltaRCM=pyDeltaRCM.command_line:run_model'],
       }
       )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 from pyDeltaRCM import shared_tools
-import pyDeltaRCM
+from pyDeltaRCM import command_line
 
 setup(name='pyDeltaRCM',
       version=shared_tools._get_version(),
@@ -16,6 +16,6 @@ setup(name='pyDeltaRCM',
       install_requires=['matplotlib', 'netCDF4',
                         'basic-modeling-interface', 'scipy', 'numpy', 'pyyaml'],
       entry_points={
-                  'console_scripts': ['run_pyDeltaRCM=pyDeltaRCM.command_line:run_model'],
+                  'console_scripts': ['run_pyDeltaRCM=command_line:run_model'],
       }
       )

--- a/tests/test_command_line_tool.py
+++ b/tests/test_command_line_tool.py
@@ -1,0 +1,36 @@
+
+import pytest
+
+import os
+import shutil
+import numpy as np
+import subprocess
+
+import pyDeltaRCM as deltaModule
+from pyDeltaRCM import command_line
+
+
+def test_call():
+    """
+    test calling the command line feature with a config file.
+    """
+    subprocess.run(['run_pyDeltaRCM', '--config', os.path.join(os.getcwd(), 'tests', 'test_output.yaml')])
+    assert os.path.isfile(os.path.join(os.getcwd(), 'test', 'eta_0.0.png'))
+    shutil.rmtree(os.path.join(os.getcwd(), 'test'))
+
+
+def test_version_call():
+    """
+    test calling the command line feature to query the version.
+    """
+    printed = subprocess.run(['run_pyDeltaRCM', '--version'], capture_output=True, text=True)
+    assert printed.stdout == 'pyDeltaRCM ' + deltaModule.__version__ + '\n'
+
+
+# def test_run_model():
+#     """
+#     test calling the command line feature with a config file.
+#     """
+#     command_line.run_model(use_test_yaml=True)
+#     assert os.path.isfile(os.path.join(os.getcwd(), 'test', 'eta_0.0.png'))
+#     shutil.rmtree(os.path.join(os.getcwd(), 'test'))

--- a/tests/test_command_line_tool.py
+++ b/tests/test_command_line_tool.py
@@ -3,6 +3,7 @@ import pytest
 
 import os
 import shutil
+import locale
 import numpy as np
 import subprocess
 
@@ -23,9 +24,10 @@ def test_version_call():
     """
     test calling the command line feature to query the version.
     """
-    printed1 = subprocess.run(['run_pyDeltaRCM', '--version'], capture_output=True, text=True)
+    encoding = locale.getpreferredencoding()
+    printed1 = subprocess.run(['run_pyDeltaRCM', '--version'], stdout=subprocess.PIPE, encoding=encoding)
     assert printed1.stdout == 'pyDeltaRCM ' + deltaModule.__version__ + '\n'
-    printed2 = subprocess.run(['python', '-m', 'pyDeltaRCM', '--version'], capture_output=True, text=True)
+    printed2 = subprocess.run(['python', '-m', 'pyDeltaRCM', '--version'], stdout=subprocess.PIPE, encoding=encoding)
     assert printed2.stdout == 'pyDeltaRCM ' + deltaModule.__version__ + '\n'
 
 

--- a/tests/test_command_line_tool.py
+++ b/tests/test_command_line_tool.py
@@ -23,14 +23,16 @@ def test_version_call():
     """
     test calling the command line feature to query the version.
     """
-    printed = subprocess.run(['run_pyDeltaRCM', '--version'], capture_output=True, text=True)
-    assert printed.stdout == 'pyDeltaRCM ' + deltaModule.__version__ + '\n'
+    printed1 = subprocess.run(['run_pyDeltaRCM', '--version'], capture_output=True, text=True)
+    assert printed1.stdout == 'pyDeltaRCM ' + deltaModule.__version__ + '\n'
+    printed2 = subprocess.run(['python', '-m', 'pyDeltaRCM', '--version'], capture_output=True, text=True)
+    assert printed2.stdout == 'pyDeltaRCM ' + deltaModule.__version__ + '\n'
 
 
-# def test_run_model():
-#     """
-#     test calling the command line feature with a config file.
-#     """
-#     command_line.run_model(use_test_yaml=True)
-#     assert os.path.isfile(os.path.join(os.getcwd(), 'test', 'eta_0.0.png'))
-#     shutil.rmtree(os.path.join(os.getcwd(), 'test'))
+def test_python_call():
+    """
+    test calling the python hook command line feature with a config file.
+    """
+    subprocess.run(['python', '-m', 'pyDeltaRCM', '--config', os.path.join(os.getcwd(), 'tests', 'test_output.yaml')])
+    assert os.path.isfile(os.path.join(os.getcwd(), 'test', 'eta_0.0.png'))
+    shutil.rmtree(os.path.join(os.getcwd(), 'test'))

--- a/tests/test_output.yaml
+++ b/tests/test_output.yaml
@@ -20,7 +20,7 @@ C0_percent: 0.1
 toggle_subsidence: False
 sigma_max: 0.0
 start_subsidence: 50.
-save_eta_figs: False
+save_eta_figs: True
 save_stage_figs: False
 save_depth_figs: False
 save_discharge_figs: False


### PR DESCRIPTION
### 📣 New Feature 📣 
Per thoughts from @amoodie, I'm adding here a set of interfaces into the pyDeltaRCM model that allow users to interface through the command line. 

The two new basic ways to do this are 
(1) through a command-line entry point and 
(2) through `__main__.py`. Both are demo-ed below.
```bash
# interface 1
run_pyDeltaRCM                                  # runs the model using default values
run_pyDeltaRCM --version                        # returns the version
run_pyDeltaRCM --config <path_to_config_here>   # runs the model using a config file
```
This method works by establishing a `console_scripts` entry point in the `setup.py` file, so when the user `pip install`s, they get a command line hook. (see [this line](https://github.com/ericbarefoot/pyDeltaRCM_WMT/blob/b5a19c22f6df3493b01200805bd98f0d237195de/setup.py#L19))
```bash
# interface 2
python -m pyDeltaRCM                                  # runs the model using default values
python -m pyDeltaRCM --version                        # returns the version
python -m pyDeltaRCM --config <path_to_config_here>   # runs the model using a config file
```
This method works by simply calling the same command line script function in a `__main__.py` file, so the two are essentially just aliases for each other. 

#### Other new things

In addition to the main feature, to make this work as a default, I [included a new `timesteps` parameter in the `default.yml`](https://github.com/ericbarefoot/pyDeltaRCM_WMT/blob/b5a19c22f6df3493b01200805bd98f0d237195de/pyDeltaRCM/default.yml#L145-L147), which lets the user specify timesteps for the simplest case of running the model with no special stuff. 

I also added a new `test.yml` because I'm not really sure how to test stuff from within the command line, so I figured a good way would be to output a file, and check that file. In the future, we can think about having this file be data output, and if necessary, load it and a saved version and check for congruence. 

This PR mostly fixes #22, but doesn't include the last component, which is the matrix expansion of defaults. I suggest we postpone that, and make it a new issue. 