### PR TITLE
Fix expected type for BMI configuration

### DIFF
--- a/pyDeltaRCM/bmi_delta.py
+++ b/pyDeltaRCM/bmi_delta.py
@@ -88,7 +88,7 @@ class BmiDelta(Bmi):
         'model_output__opt_velocity_grids': {'name': 'save_velocity_grids',
             'type': 'bool', 'default': False},
         'model_output__opt_time_interval': {'name': 'save_dt',
-            'type': 'float', 'default': 50},
+            'type': 'int', 'default': 50},
         'coeff__surface_smoothing': {'name': 'Csmooth',
             'type': 'float', 'default': 0.9},
         'coeff__under_relaxation__water_surface': {'name': 'omega_sfc',


### PR DESCRIPTION
Was getting the following warning when running the `run_pyDeltaRCM_as_BMI.py` script:

> Input for model_output__opt_time_interval not of the right type. model_output__opt_time_interval needs to be of type <class 'float'>

So the super minor commit in this PR just addresses that by changing the expected type for time to be 'int' instead of 'float' to match the convention in the non-BMI method. I don't see anything in the CSDMS BMI naming convention that suggests the "time_interval" variable must be a 'float'. 