### PR TITLE
Test consistent

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -221,7 +221,7 @@ class init_tools(object):
         # self.prefix
         self.prefix = self.out_dir
 
-        if self.out_dir[-1] is not '/':
+        if self.out_dir[-1] != '/':
             self.prefix = self.out_dir + '/'
         if self.site_prefix:
             self.prefix += self.site_prefix + '_'

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -1,0 +1,23 @@
+# unit tests for consistent model outputs
+
+import pytest
+
+import sys
+import os
+import numpy as np
+
+from pyDeltaRCM.deltaRCM_driver import pyDeltaRCM
+
+# need to create a simple case of pydeltarcm object to test these functions
+delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
+
+
+def test_bed_after_one_update():
+    """
+    """
+    delta.update()
+    # slice is: delta.eta[:5, 4]
+    print(delta.eta[:5, 4])
+
+    _exp = np.array([-1., -0.82951754, -0.9981775 , -1., -1.])
+    assert np.all(delta.eta[:5, 4] == pytest.approx(_exp))

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -9,15 +9,15 @@ import numpy as np
 from pyDeltaRCM.deltaRCM_driver import pyDeltaRCM
 
 # need to create a simple case of pydeltarcm object to test these functions
-delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
 
 
 def test_bed_after_one_update():
     """
     """
+    delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
     delta.update()
     # slice is: delta.eta[:5, 4]
-    print(delta.eta[:5, 4])
+    # print(delta.eta[:5, 4])
 
-    _exp = np.array([-1., -0.82951754, -0.9981775 , -1., -1.])
+    _exp = np.array([-1., -0.840265, -0.9976036, -1., -1.])
     assert np.all(delta.eta[:5, 4] == pytest.approx(_exp))

--- a/tests/test_deltaRCM_driver.py
+++ b/tests/test_deltaRCM_driver.py
@@ -9,18 +9,19 @@ import numpy as np
 from pyDeltaRCM.deltaRCM_driver import pyDeltaRCM
 
 # need to create a simple case of pydeltarcm object to test these functions
-delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
 
 
 def test_init():
     """
     test the deltaRCM_driver init (happened when delta.initialize was run)
     """
+    delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
     assert delta._time == 0.
     assert delta._is_finalized == False
 
 
 def test_update():
+    delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
     delta.update()
     assert delta._time == 1.0
     assert delta._is_finalized == False

--- a/tests/test_deltaRCM_driver.py
+++ b/tests/test_deltaRCM_driver.py
@@ -20,8 +20,11 @@ def test_init():
     assert delta._is_finalized == False
 
 
+delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
+
+
 def test_update():
-    delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
+    
     delta.update()
     assert delta._time == 1.0
     assert delta._is_finalized == False

--- a/tests/test_yaml_parsing.py
+++ b/tests/test_yaml_parsing.py
@@ -113,6 +113,7 @@ def test_random_seed_settings_value(tmp_path):
     assert delta.seed == 9999
     _postval_same = np.random.uniform()
     assert _preval_same == _postval_same
+    assert delta.seed == 9999
 
 
 def test_random_seed_settings_noaction_default(tmp_path):


### PR DESCRIPTION
add a test to check a small slice of the `eta` matrix, so we can be sure the model is not changed by any of our steps (or at least we can tell when things are changed...).

Fix a small warning about literal checking.

@ericbarefoot can you verify the test passes on your local?