### PR TITLE
Swap xfail for pytest.raises

### DIFF
--- a/tests/test_deltaRCM_driver.py
+++ b/tests/test_deltaRCM_driver.py
@@ -24,7 +24,7 @@ delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
 
 
 def test_update():
-    
+
     delta.update()
     assert delta._time == 1.0
     assert delta._is_finalized == False
@@ -35,14 +35,14 @@ def test_finalize():
     assert delta._is_finalized == True
 
 
-@pytest.mark.xfail(raises=RuntimeError, strict=True)
 def test_multifinalization_error():
     err_delta = pyDeltaRCM(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
     err_delta.update()
     # test will Fail if any assertion is wrong
-    assert err_delta._time == 1.0 
+    assert err_delta._time == 1.0
     assert err_delta._is_finalized == False
     err_delta.finalize()
     assert err_delta._is_finalized == True
-    # next line should throw RuntimeError and test will xFail
-    err_delta.update()
+    # next line should throw RuntimeError
+    with pytest.raises(RuntimeError):
+        err_delta.update()

--- a/tests/test_shared_tools.py
+++ b/tests/test_shared_tools.py
@@ -160,10 +160,11 @@ def test_custom_unravel_rectangle():
     assert y == 4
 
 
-@pytest.mark.xfail(raises=IndexError, strict=True)
 def test_custom_unravel_exceed_error():
     arr = np.arange(9).reshape((3, 3))
-    x, y = shared_tools.custom_unravel(99, arr.shape)
+    # next line should throw IndexError
+    with pytest.raises(IndexError):
+        x, y = shared_tools.custom_unravel(99, arr.shape)
 
 
 def test_check_for_loops():

--- a/tests/test_yaml_parsing.py
+++ b/tests/test_yaml_parsing.py
@@ -34,9 +34,9 @@ def test_override_from_testfile():
     assert delta.Length == 10
 
 
-@pytest.mark.xfail(raises=FileNotFoundError, strict=True)
 def test_error_if_no_file_found():
-    delta = pyDeltaRCM(input_file='./nonexisting_file.yaml')
+    with pytest.raises(FileNotFoundError):
+        delta = pyDeltaRCM(input_file='./nonexisting_file.yaml')
 
 
 def test_override_single_default(tmp_path):
@@ -59,22 +59,22 @@ def test_override_two_defaults(tmp_path):
     assert delta.Np_sed == 2
 
 
-@pytest.mark.xfail(raises=TypeError, strict=True)
 def test_override_bad_type_float_string(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = create_temporary_file(tmp_path, file_name)
     write_parameter_to_file(f, 'S0', 'a string?!')
     f.close()
-    delta = pyDeltaRCM(input_file=p)
+    with pytest.raises(TypeError):
+        delta = pyDeltaRCM(input_file=p)
 
 
-@pytest.mark.xfail(raises=TypeError, strict=True)
 def test_override_bad_type_int_float(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = create_temporary_file(tmp_path, file_name)
     write_parameter_to_file(f, 'beta', 24.4234)
     f.close()
-    delta = pyDeltaRCM(input_file=p)
+    with pytest.raises(TypeError):
+        delta = pyDeltaRCM(input_file=p)
 
 
 def test_not_creating_illegal_attributes(tmp_path):


### PR DESCRIPTION
Just flips the syntax for the few tests that were setup to x-fail so they use `pytest.raises` instead.