### PR TITLE
Refactor plotting behavior and grid/plot saving routines

### DIFF
--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -75,7 +75,7 @@ save_depth_figs:
   default: False
 save_discharge_figs:
   type: 'bool'
-  default: True
+  default: False
 save_velocity_figs:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -79,6 +79,9 @@ save_discharge_figs:
 save_velocity_figs:
   type: 'bool'
   default: False
+save_figs_sequential:
+  type: 'bool'
+  default: True
 save_eta_grids:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -242,82 +242,76 @@ class Tools(sed_tools, water_tools, init_tools, object):
 
         """
 
-        timestep = self._time
+        _timestep = self._time
 
-        if timestep % self.save_dt == 0:
+        if _timestep % self.save_dt == 0:
 
-            if (self.save_eta_grids or
-                    self.save_depth_grids or
-                    self.save_stage_grids or
-                    self.save_discharge_grids or
-                    self.save_velocity_grids or
-                    self.save_strata):
-
-                timestep = self._time
-                shape = self.output_netcdf.variables['time'].shape
-                self.output_netcdf.variables['time'][shape[0]] = timestep
+            _timestep = self._time
 
             # ------------------ Figures ------------------
-            if self.save_eta_figs:
+            if self._save_any_figs:
 
-                plt.pcolor(self.eta)
-                plt.clim(self.clim_eta[0], self.clim_eta[1])
-                plt.colorbar()
-                plt.axis('equal')
-                self.save_figure(os.path.join(self.prefix, 'eta_' + str(timestep)))
+                _msg = 'Saving figures'
+                self.logger.info(_msg)
+                if self.verbose >= 2:
+                    print(_msg)
+            
+                if self.save_eta_figs:
+                    plt.pcolor(self.eta)
+                    plt.clim(np.min(self.eta), 1.1*np.max(self.eta))
+                    plt.colorbar()
+                    plt.axis('equal')
+                    self.save_figure(os.path.join(self.prefix, 'eta_' + str(_timestep)))
 
-            if self.save_stage_figs:
+                if self.save_stage_figs:
+                    plt.pcolor(self.stage)
+                    plt.colorbar()
+                    plt.axis('equal')
+                    self.save_figure(os.path.join(self.prefix, 'stage_' + str(_timestep)))
 
-                plt.pcolor(self.stage)
-                plt.colorbar()
-                plt.axis('equal')
-                self.save_figure(os.path.join(self.prefix, 'stage_' + str(timestep)))
+                if self.save_depth_figs:
+                    plt.pcolor(self.depth)
+                    plt.colorbar()
+                    plt.axis('equal')
+                    self.save_figure(os.path.join(self.prefix, 'depth_' + str(_timestep)))
 
-            if self.save_depth_figs:
+                if self.save_discharge_figs:
+                    plt.pcolor(self.qw)
+                    plt.colorbar()
+                    plt.axis('equal')
+                    self.save_figure(os.path.join(self.prefix, 'discharge_' + str(_timestep)))
 
-                plt.pcolor(self.depth)
-                plt.colorbar()
-                plt.axis('equal')
-                self.save_figure(os.path.join(self.prefix, 'depth_' + str(timestep)))
-
-            if self.save_discharge_figs:
-
-                plt.pcolor(self.qw)
-                plt.colorbar()
-                plt.axis('equal')
-                self.save_figure(os.path.join(self.prefix, 'discharge_' + str(timestep)))
-
-            if self.save_velocity_figs:
-                plt.pcolor(self.uw)
-                plt.colorbar()
-                plt.axis('equal')
-                self.save_figure(os.path.join(self.prefix, 'velocity_' + str(timestep)))
+                if self.save_velocity_figs:
+                    plt.pcolor(self.uw)
+                    plt.colorbar()
+                    plt.axis('equal')
+                    self.save_figure(os.path.join(self.prefix, 'velocity_' + str(_timestep)))
 
             # ------------------ grids ------------------
-            if self.save_eta_grids:
-                if self.verbose >= 2:
-                    self.logger.info('Saving grid: eta')
-                self.save_grids('eta', self.eta, shape[0])
+            if self._save_any_grids:
 
-            if self.save_depth_grids:
-                if self.verbose >= 2:
-                    self.logger.info('Saving grid: depth')
-                self.save_grids('depth', self.depth, shape[0])
+                shape = self.output_netcdf.variables['time'].shape
+                self.output_netcdf.variables['time'][shape[0]] = _timestep
 
-            if self.save_stage_grids:
+                _msg = 'Saving grids'
+                self.logger.info(_msg)
                 if self.verbose >= 2:
-                    self.logger.info('Saving grid: stage')
-                self.save_grids('stage', self.stage, shape[0])
+                    print(_msg)
 
-            if self.save_discharge_grids:
-                if self.verbose >= 2:
-                    self.logger.info('Saving grid: discharge')
-                self.save_grids('discharge', self.qw, shape[0])
+                if self.save_eta_grids:
+                    self.save_grids('eta', self.eta, shape[0])
 
-            if self.save_velocity_grids:
-                if self.verbose >= 2:
-                    self.logger.info('Saving grid: velocity')
-                self.save_grids('velocity', self.uw, shape[0])
+                if self.save_depth_grids:
+                    self.save_grids('depth', self.depth, shape[0])
+
+                if self.save_stage_grids:
+                    self.save_grids('stage', self.stage, shape[0])
+
+                if self.save_discharge_grids:
+                    self.save_grids('discharge', self.qw, shape[0])
+
+                if self.save_velocity_grids:
+                    self.save_grids('velocity', self.uw, shape[0])
 
     def output_strata(self):
         """Save stratigraphy as sparse matrix to file.
@@ -411,8 +405,10 @@ class Tools(sed_tools, water_tools, init_tools, object):
             directory = '.'
 
         if not os.path.exists(directory):
+            _msg = 'No dir for figures, creating output directory'
+            self.logger.info(_msg)
             if self.verbose >= 2:
-                self.logger.info('Creating output directory')
+                print(_msg)
             os.makedirs(directory)
 
         savepath = os.path.join(directory, filename)
@@ -446,5 +442,5 @@ class Tools(sed_tools, water_tools, init_tools, object):
         try:
             self.output_netcdf.variables[var_name][ts, :, :] = var
         except:
-            self.logger.info('Error: Cannot save grid to netCDF file.')
+            self.logger.error('Cannot save grid to netCDF file.')
             warnings.warn(UserWarning('Cannot save grid to netCDF file.'))

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -243,7 +243,6 @@ class Tools(sed_tools, water_tools, init_tools, object):
         """
 
         _timestep = self._time
-
         if _timestep % self.save_dt == 0:
 
             _timestep = int(self._time)
@@ -259,27 +258,32 @@ class Tools(sed_tools, water_tools, init_tools, object):
                 if self.save_eta_figs:
                     _fe = self.make_figure('eta')
                     self.save_figure(_fe, directory=self.prefix,
-                                     filename='eta_' + str(_timestep).zfill(5))
+                                     filename_root='eta_',
+                                     timestep=_timestep)
 
                 if self.save_stage_figs:
                     _fs = self.make_figure('stage')
                     self.save_figure(_fs, directory=self.prefix,
-                                     filename='stage_' + str(_timestep).zfill(5))
+                                     filename_root='stage_',
+                                     timestep=_timestep)
 
                 if self.save_depth_figs:
                     _fh = self.make_figure('depth')
                     self.save_figure(_fh, directory=self.prefix,
-                                     filename='depth_' + str(_timestep).zfill(5))
+                                     filename_root='depth_',
+                                     timestep=_timestep)
 
                 if self.save_discharge_figs:
                     _fq = self.make_figure('qw')
                     self.save_figure(_fq, directory=self.prefix,
-                                     filename='discharge_' + str(_timestep).zfill(5))
+                                     filename_root='discharge_',
+                                     timestep=_timestep)
 
                 if self.save_velocity_figs:
                     _fu = self.make_figure('uw')
                     self.save_figure(_fu, directory=self.prefix,
-                                     filename='velocity_' + str(_timestep).zfill(5))
+                                     filename_root='velocity_',
+                                     timestep=_timestep)
 
             # ------------------ grids ------------------
             if self._save_any_grids:
@@ -399,7 +403,8 @@ class Tools(sed_tools, water_tools, init_tools, object):
 
         return fig
 
-    def save_figure(self, fig, directory, filename, ext='.png', close=True):
+    def save_figure(self, fig, directory, filename_root,
+                    timestep, ext='.png', close=True):
         """Save a figure.
 
         Parameters
@@ -420,10 +425,16 @@ class Tools(sed_tools, water_tools, init_tools, object):
         -------
 
         """
-
-        savepath = os.path.join(directory, filename + ext)
+        if self._save_figs_sequential:
+            # save as a padded number with the timestep
+            savepath = os.path.join(directory,
+                                    filename_root + str(timestep).zfill(5) + ext)
+        else:
+            # save as "latest"
+            savepath = os.path.join(directory,
+                                    filename_root + 'latest' + ext)
+        
         fig.savefig(savepath)
-
         if close:
             plt.close()
 

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -256,31 +256,31 @@ class Tools(sed_tools, water_tools, init_tools, object):
                     print(_msg)
 
                 if self.save_eta_figs:
-                    _fe = self.make_figure('eta')
+                    _fe = self.make_figure('eta', _timestep)
                     self.save_figure(_fe, directory=self.prefix,
                                      filename_root='eta_',
                                      timestep=_timestep)
 
                 if self.save_stage_figs:
-                    _fs = self.make_figure('stage')
+                    _fs = self.make_figure('stage', _timestep)
                     self.save_figure(_fs, directory=self.prefix,
                                      filename_root='stage_',
                                      timestep=_timestep)
 
                 if self.save_depth_figs:
-                    _fh = self.make_figure('depth')
+                    _fh = self.make_figure('depth', _timestep)
                     self.save_figure(_fh, directory=self.prefix,
                                      filename_root='depth_',
                                      timestep=_timestep)
 
                 if self.save_discharge_figs:
-                    _fq = self.make_figure('qw')
+                    _fq = self.make_figure('qw', _timestep)
                     self.save_figure(_fq, directory=self.prefix,
                                      filename_root='discharge_',
                                      timestep=_timestep)
 
                 if self.save_velocity_figs:
-                    _fu = self.make_figure('uw')
+                    _fu = self.make_figure('uw', _timestep)
                     self.save_figure(_fu, directory=self.prefix,
                                      filename_root='velocity_',
                                      timestep=_timestep)
@@ -378,7 +378,7 @@ class Tools(sed_tools, water_tools, init_tools, object):
             if self.verbose >= 2:
                 print(_msg)
 
-    def make_figure(self, var):
+    def make_figure(self, var, timestep):
         """Create a figure.
 
         Parameters
@@ -398,7 +398,7 @@ class Tools(sed_tools, water_tools, init_tools, object):
         fig, ax = plt.subplots()
         pc = ax.pcolor(_data)
         fig.colorbar(pc)
-        ax.set_title(var)
+        ax.set_title(var + ' --- ' + 'time = ' + str(timestep))
         ax.axis('equal')
 
         return fig

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -346,8 +346,6 @@ class init_tools(object):
         self.inlet = list(np.unique(np.where(self.cell_type == 1)[1]))
         self.eta[:] = self.stage - self.depth
 
-        self.clim_eta = (-self.h0 - 1, 0.05)
-
     def init_stratigraphy(self):
         """Creates sparse array to store stratigraphy data.
         """

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -252,6 +252,12 @@ class init_tools(object):
         self.diffusion_multiplier = (self.dt / self.N_crossdiff * self.alpha
                                      * 0.5 / self.dx**2)
 
+        self._save_any_grids = (self.save_eta_grids or self.save_depth_grids or
+                                self.save_stage_grids or self.save_discharge_grids or
+                                self.save_velocity_grids)
+        self._save_any_figs = (self.save_eta_figs or self.save_depth_figs or
+                               self.save_stage_figs or self.save_discharge_figs or
+                               self.save_velocity_figs)
         self._is_finalized = False
 
     def create_domain(self):

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -258,6 +258,7 @@ class init_tools(object):
         self._save_any_figs = (self.save_eta_figs or self.save_depth_figs or
                                self.save_stage_figs or self.save_discharge_figs or
                                self.save_velocity_figs)
+        self._save_figs_sequential = self.save_figs_sequential  # copy as private
         self._is_finalized = False
 
     def create_domain(self):

--- a/tests/test_deltaRCM_tools.py
+++ b/tests/test_deltaRCM_tools.py
@@ -377,6 +377,53 @@ def test_save_all_figures_no_grids(tmp_path):
     assert os.path.isfile(exp_path_png4)
 
 
+def test_save_all_figures_sequential_false(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'h0', 1.0)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.5)
+    utilities.write_parameter_to_file(f, 'C0_percent', 0.1)
+    utilities.write_parameter_to_file(f, 'save_eta_figs', True)
+    utilities.write_parameter_to_file(f, 'save_discharge_figs', True)
+    utilities.write_parameter_to_file(f, 'save_velocity_figs', True)
+    utilities.write_parameter_to_file(f, 'save_stage_figs', True)
+    utilities.write_parameter_to_file(f, 'save_depth_figs', True)
+    utilities.write_parameter_to_file(f, 'save_figs_sequential', False)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    utilities.write_parameter_to_file(f, 'save_strata', False)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert not os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 5):
+        _delta.update()
+    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'depth_00000.png')
+    exp_path_png0_latest = os.path.join(tmp_path / 'out_dir', 'eta_latest.png')
+    exp_path_png1_latest = os.path.join(tmp_path / 'out_dir', 'depth_latest.png')
+    exp_path_png2_latest = os.path.join(tmp_path / 'out_dir', 'stage_latest.png')
+    exp_path_png3_latest = os.path.join(tmp_path / 'out_dir', 'velocity_latest.png')
+    exp_path_png4_latest = os.path.join(tmp_path / 'out_dir', 'discharge_latest.png')
+    assert not os.path.isfile(exp_path_png0)
+    assert not os.path.isfile(exp_path_png1)
+    assert os.path.isfile(exp_path_png0_latest)
+    assert os.path.isfile(exp_path_png1_latest)
+    assert os.path.isfile(exp_path_png2_latest)
+    assert os.path.isfile(exp_path_png3_latest)
+    assert os.path.isfile(exp_path_png4_latest)
+
+
 def test_save_eta_grids(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)

--- a/tests/test_deltaRCM_tools.py
+++ b/tests/test_deltaRCM_tools.py
@@ -283,9 +283,9 @@ def test_save_one_fig_no_grids(tmp_path):
     assert _delta._time == 2.0
 
     exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
-    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_0.0.png')
-    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'eta_1.0.png')
-    exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'eta_2.0.png')
+    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'eta_00001.png')
+    exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'eta_00002.png')
     assert not os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png0)
     assert os.path.isfile(exp_path_png1)
@@ -365,11 +365,11 @@ def test_save_all_figures_no_grids(tmp_path):
     for _ in range(0, 2):
         _delta.update()
 
-    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_0.0.png')
-    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'depth_0.0.png')
-    exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'stage_0.0.png')
-    exp_path_png3 = os.path.join(tmp_path / 'out_dir', 'velocity_0.0.png')
-    exp_path_png4 = os.path.join(tmp_path / 'out_dir', 'discharge_0.0.png')
+    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'depth_00000.png')
+    exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'stage_00000.png')
+    exp_path_png3 = os.path.join(tmp_path / 'out_dir', 'velocity_00000.png')
+    exp_path_png4 = os.path.join(tmp_path / 'out_dir', 'discharge_00000.png')
     assert os.path.isfile(exp_path_png0)
     assert os.path.isfile(exp_path_png1)
     assert os.path.isfile(exp_path_png2)

--- a/tests/test_deltaRCM_tools.py
+++ b/tests/test_deltaRCM_tools.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 
 import glob
+import netCDF4
 
 from pyDeltaRCM.model import DeltaModel
 
@@ -208,3 +209,324 @@ def test_logger_random_seed_always_recorded(tmp_path):
             raise ValueError('Could not convert the seed to int')
 
         assert _intseed >= 0
+
+
+def test_save_no_figs_no_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'h0', 1.0)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.5)
+    utilities.write_parameter_to_file(f, 'C0_percent', 0.1)
+    utilities.write_parameter_to_file(f, 'save_dt', 5)
+    utilities.write_parameter_to_file(f, 'save_strata', False)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    img_glob = glob.glob(os.path.join(_delta.prefix, '*.png'))
+    nc_glob = glob.glob(os.path.join(_delta.prefix, '*.nc'))
+    assert len(img_glob) == 0
+    assert len(nc_glob) == 0
+
+    for _t in range(0, 4):
+        _delta.update()
+    assert _delta._time == 4.0
+    img_glob = glob.glob(os.path.join(_delta.prefix, '*.png'))
+    nc_glob = glob.glob(os.path.join(_delta.prefix, '*.nc'))
+    assert len(img_glob) == 0
+    assert len(nc_glob) == 0
+
+    _delta.update()
+    assert _delta._time == 5.0
+    img_glob = glob.glob(os.path.join(_delta.prefix, '*.png'))
+    nc_glob = glob.glob(os.path.join(_delta.prefix, '*.nc'))
+    assert len(img_glob) == 0
+    assert len(nc_glob) == 0
+
+
+def test_save_one_fig_no_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'h0', 1.0)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.5)
+    utilities.write_parameter_to_file(f, 'C0_percent', 0.1)
+    utilities.write_parameter_to_file(f, 'save_eta_figs', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    utilities.write_parameter_to_file(f, 'save_strata', False)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    img_glob = glob.glob(os.path.join(_delta.prefix, '*.png'))
+    nc_glob = glob.glob(os.path.join(_delta.prefix, '*.nc'))
+    assert len(img_glob) == 0
+    assert len(nc_glob) == 0
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta._time == 2.0
+
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_0.0.png')
+    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'eta_1.0.png')
+    exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'eta_2.0.png')
+    assert not os.path.isfile(exp_path_nc)
+    assert os.path.isfile(exp_path_png0)
+    assert os.path.isfile(exp_path_png1)
+    assert not os.path.isfile(exp_path_png2)
+
+
+def test_save_one_fig_one_grid(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'h0', 1.0)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.5)
+    utilities.write_parameter_to_file(f, 'C0_percent', 0.1)
+    utilities.write_parameter_to_file(f, 'save_discharge_figs', True)
+    utilities.write_parameter_to_file(f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    utilities.write_parameter_to_file(f, 'save_strata', True)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+    nc_size_before = os.path.getsize(exp_path_nc)
+    assert nc_size_before > 0
+
+    # update a couple times, should not increase size until finalize()
+    for _ in range(0, 2):
+        _delta.update()
+    nc_size_middle = os.path.getsize(exp_path_nc)
+    assert _delta._time == 2.0
+    assert nc_size_middle == nc_size_before
+
+    # now finalize, and then file size should increase
+    _delta.finalize()
+    nc_size_after = os.path.getsize(exp_path_nc)
+    assert _delta._time == 2.0
+    assert nc_size_after > nc_size_middle
+    assert nc_size_after > nc_size_before
+
+
+def test_save_all_figures_no_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'h0', 1.0)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.5)
+    utilities.write_parameter_to_file(f, 'C0_percent', 0.1)
+    utilities.write_parameter_to_file(f, 'save_eta_figs', True)
+    utilities.write_parameter_to_file(f, 'save_discharge_figs', True)
+    utilities.write_parameter_to_file(f, 'save_velocity_figs', True)
+    utilities.write_parameter_to_file(f, 'save_stage_figs', True)
+    utilities.write_parameter_to_file(f, 'save_depth_figs', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    utilities.write_parameter_to_file(f, 'save_strata', False)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert not os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+
+    exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_0.0.png')
+    exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'depth_0.0.png')
+    exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'stage_0.0.png')
+    exp_path_png3 = os.path.join(tmp_path / 'out_dir', 'velocity_0.0.png')
+    exp_path_png4 = os.path.join(tmp_path / 'out_dir', 'discharge_0.0.png')
+    assert os.path.isfile(exp_path_png0)
+    assert os.path.isfile(exp_path_png1)
+    assert os.path.isfile(exp_path_png2)
+    assert os.path.isfile(exp_path_png3)
+    assert os.path.isfile(exp_path_png4)
+
+
+def test_save_eta_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta._time == 2.0
+    _delta.finalize()
+
+    ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")
+    _arr = ds.variables['eta']
+    assert _arr.shape[1] == _delta.eta.shape[0]
+    assert _arr.shape[2] == _delta.eta.shape[1]
+
+
+def test_save_depth_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'save_depth_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta._time == 2.0
+    _delta.finalize()
+
+    ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")
+    _arr = ds.variables['depth']
+    assert _arr.shape[1] == _delta.depth.shape[0]
+    assert _arr.shape[2] == _delta.depth.shape[1]
+
+
+def test_save_velocity_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'save_velocity_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta._time == 2.0
+    _delta.finalize()
+
+    ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")
+    _arr = ds.variables['velocity']
+    assert _arr.shape[1] == _delta.eta.shape[0]
+    assert _arr.shape[2] == _delta.eta.shape[1]
+
+
+def test_save_stage_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'save_stage_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta._time == 2.0
+    _delta.finalize()
+
+    ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")
+    _arr = ds.variables['stage']
+    assert _arr.shape[1] == _delta.eta.shape[0]
+    assert _arr.shape[2] == _delta.eta.shape[1]
+
+
+def test_save_discharge_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'save_discharge_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta._time == 2.0
+    _delta.finalize()
+
+    ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")
+    _arr = ds.variables['discharge']
+    assert _arr.shape[1] == _delta.eta.shape[0]
+    assert _arr.shape[2] == _delta.eta.shape[1]

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -306,7 +306,3 @@ def test_sfc_visit(test_DeltaModel):
 
 def test_sfc_sum(test_DeltaModel):
     assert np.any(test_DeltaModel.sfc_sum) == 0
-
-
-def test_clim_eta(test_DeltaModel):
-    assert test_DeltaModel.clim_eta == (-2, 0.05)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -144,8 +144,8 @@ def test_entry_point_installed_call(tmp_path):
     subprocess.check_output(['pyDeltaRCM',
                              '--config', p])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-    exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_0.0.png')
-    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_1.0.png')
+    exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png0)
     assert os.path.isfile(exp_path_png1)
@@ -171,8 +171,8 @@ def test_entry_point_python_main_call(tmp_path):
     subprocess.check_output(['python', '-m', 'pyDeltaRCM',
                              '--config', p])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-    exp_path_png = os.path.join(tmp_path / 'test', 'eta_0.0.png')
-    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_1.0.png')
+    exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png)
     assert not os.path.isfile(exp_path_png1)
@@ -194,7 +194,7 @@ def test_entry_point_python_main_call_dryrun(tmp_path):
                              '--config', p,
                              '--dryrun'])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-    exp_path_png = os.path.join(tmp_path / 'test', 'eta_0.0.png')
+    exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
     assert os.path.isfile(exp_path_nc)
     assert not os.path.isfile(exp_path_png)  # does not exist because --dryrun
 
@@ -216,7 +216,7 @@ def test_entry_point_python_main_call_timesteps(tmp_path):
                              '--config', p,
                              '--timesteps', '2'])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-    exp_path_png = os.path.join(tmp_path / 'test', 'eta_0.0.png')
+    exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png)
 
@@ -327,9 +327,9 @@ def test_python_highlevelapi_call_with_args(tmp_path):
     assert len(pp.job_list) == 1
     assert pp.job_list[0]._is_completed == True
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-    exp_path_png = os.path.join(tmp_path / 'test', 'eta_0.0.png')
-    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_1.0.png')
-    exp_path_png3 = os.path.join(tmp_path / 'test', 'eta_3.0.png')
+    exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+    exp_path_png3 = os.path.join(tmp_path / 'test', 'eta_00003.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png)
     assert os.path.isfile(exp_path_png1)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -329,7 +329,7 @@ def test_python_highlevelapi_call_with_args(tmp_path):
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
     exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
-    exp_path_png3 = os.path.join(tmp_path / 'test', 'eta_00003.png')
+    exp_path_png3 = os.path.join(tmp_path / 'test', 'eta_00002.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png)
     assert os.path.isfile(exp_path_png1)

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -63,7 +63,6 @@ def test_DeltaModel(tmp_path):
     write_parameter_to_file(f, 'save_velocity_grids', False)
     write_parameter_to_file(f, 'save_dt', 50)
     write_parameter_to_file(f, 'save_strata', True)
-    write_parameter_to_file(f, 'timesteps', 1)
     f.close()
     _delta = DeltaModel(input_file=p)
     return _delta


### PR DESCRIPTION
Refactor plotting according to #28.

## defaults
I went with defaults all false:
```yaml
save_eta_figs: False
save_stage_figs: False
save_depth_figs: False
save_discharge_figs: False
save_velocity_figs: False
save_eta_grids: False
save_stage_grids: False
save_depth_grids: False
save_discharge_grids: False
save_velocity_grids: False
```

## sequential saving
I went with sequential saving by default (`eta_00000.png`, `eta_00001.png`), and there is now a flag called `save_figs_sequential` that takes a boolean. Setting this to `False` gives  `eta_latest.png` which is repeatedly overwritten. 

## refactoring
* wrap each of the `make_figure` and `save_figure` operations into functions
* remove color bar limit from `eta` plotting
* add variable name and timestep as title of plots
* added a bunch of tests for grid and plot saving