### PR TITLE
Fix: random seed set to int if not provided, support reproducible runs

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -108,14 +108,16 @@ class init_tools(object):
 
         Writes the seed to the log for record.
         """
-        if self.seed is not None:
+        if self.seed is None:
+            # generate a random seed for reproducibility
+            self.seed = np.random.randint((2**32) - 1)
 
-            _msg = 'Setting random seed to: %s ' % str(self.seed)
-            self.logger.info(_msg)
-            if self.verbose >= 2:
-                print(_msg)
+        _msg = 'Setting random seed to: %s ' % str(self.seed)
+        self.logger.info(_msg)
+        if self.verbose >= 2:
+            print(_msg)
 
-            shared_tools.set_random_seed(self.seed)
+        shared_tools.set_random_seed(self.seed)
 
         # always write the seed to file for record and reproducability
         self.logger.info('Random seed is: %s ' % str(self.seed))

--- a/tests/test_deltaRCM_tools.py
+++ b/tests/test_deltaRCM_tools.py
@@ -179,7 +179,6 @@ def test_logger_has_timestep_lines(tmp_path):
         assert not '---- Timestep 2.0 ----' in _lines
 
 
-@pytest.mark.xfail(raises=ValueError, strict=True)
 def test_logger_random_seed_always_recorded(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -111,15 +111,16 @@ def test_random_seed_settings_value(tmp_path):
     assert delta.seed == 9999
 
 
-def test_random_seed_settings_noaction_default(tmp_path):
+def test_random_seed_settings_newinteger_default(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)
     utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
     utilities.write_parameter_to_file(f, 'S0', 0.005)
     f.close()
     delta = DeltaModel(input_file=p)
-    assert delta.seed is None
-    assert np.random.seed is not 0
+    assert delta.seed is not None
+    assert delta.seed <= (2**32) - 1
+    assert isinstance(int(delta.seed), int)
 
 
 # test the entry points


### PR DESCRIPTION
set random seed to an int in 0 to (2**32)-1 if it is not specified in the YAML configuration file. This enables runs to be reproducible, even if the seed is not set explicitly.

closes #58 