### PR TITLE
specify integer type to be compatible with 32-bit systems.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,10 @@ jobs:
         (cd docs && make docs)
     - name: Debug
       run: |
-        echo REF
-        echo EVENT_NAME
+        echo $REF
+        echo $EVENT_NAME
+        echo ${{ github.event_name }}
+        echo ${{ github.ref }}
         echo ${{ github.event_name == 'push' && github.ref == 'develop' }}
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@3.5.5

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -110,7 +110,7 @@ class init_tools(object):
         """
         if self.seed is None:
             # generate a random seed for reproducibility
-            self.seed = np.random.randint((2**32) - 1)
+            self.seed = np.random.randint((2**32) - 1, dtype='u8')
 
         _msg = 'Setting random seed to: %s ' % str(self.seed)
         self.logger.info(_msg)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -17,7 +17,7 @@ from utilities import test_DeltaModel
 # test yaml parsing
 
 def test_override_from_testfile(test_DeltaModel):
-    out_path = test_DeltaModel.out_dir.split('/')
+    out_path = test_DeltaModel.out_dir.split(os.path.sep)
     assert out_path[-1] == 'out_dir'
     assert test_DeltaModel.Length == 10
 
@@ -143,7 +143,7 @@ def test_entry_point_installed_call(tmp_path):
     utilities.write_parameter_to_file(f, 'save_eta_figs', True)
     f.close()
     subprocess.check_output(['pyDeltaRCM',
-                             '--config', p])
+                             '--config', str(p)])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
     exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
@@ -170,7 +170,7 @@ def test_entry_point_python_main_call(tmp_path):
     utilities.write_parameter_to_file(f, 'save_eta_figs', True)
     f.close()
     subprocess.check_output(['python', '-m', 'pyDeltaRCM',
-                             '--config', p])
+                             '--config', str(p)])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
     exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
@@ -192,7 +192,7 @@ def test_entry_point_python_main_call_dryrun(tmp_path):
     utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
     f.close()
     subprocess.check_output(['python', '-m', 'pyDeltaRCM',
-                             '--config', p,
+                             '--config', str(p),
                              '--dryrun'])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
@@ -214,7 +214,7 @@ def test_entry_point_python_main_call_timesteps(tmp_path):
     utilities.write_parameter_to_file(f, 'save_eta_figs', True)
     f.close()
     subprocess.check_output(['python', '-m', 'pyDeltaRCM',
-                             '--config', p,
+                             '--config', str(p),
                              '--timesteps', '2'])
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
@@ -229,7 +229,7 @@ def test_error_if_no_timesteps(tmp_path):
     f.close()
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_output(['python', '-m', 'pyDeltaRCM',
-                                 '--config', p])
+                                 '--config', str(p)])
 
 
 import pyDeltaRCM as _pyimportedalias


### PR DESCRIPTION
Fixes #64 

I think that the random seed issue was a 32-bit issue, rather than a Windows issue. However, after fixing that, windows build still failed, due to some path issues in the tests. Fixed those too.