### PR TITLE
fix doc deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         echo ${{ github.ref }}
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@3.5.5
-      if: ${{ github.event_name == 'push' && github.ref == 'ref/heads/develop' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,6 @@ jobs:
         echo ${{ github.event_name == 'push' }}
         echo ${{ github.ref == 'refs/heads/develop' }}
         echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-        echo ${{ github.event_name }}
-        echo ${{ github.ref }}
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@3.5.5
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,10 +72,9 @@ jobs:
       run: |
         echo $REF
         echo $EVENT_NAME
-        echo ${{ github.event_name }}
-        echo ${{ github.ref }}
-        echo "{{ github.ref }}"
-        echo ${{ github.event_name == 'push' && github.ref == 'develop' }}
+        echo ${{ github.event_name == 'push' }}
+        echo ${{ github.ref == 'refs/heads/develop' }}
+        echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@3.5.5
       if: ${{ github.event_name == 'push' && github.ref == 'develop' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,9 +79,9 @@ jobs:
         echo ${{ github.ref }}
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@3.5.5
-      if: ${{ github.event_name == 'push' && github.ref == 'develop' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'ref/heads/develop' }}
       with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
           BRANCH: gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,4 +86,3 @@ jobs:
           REF: ${{ github.ref }}
           BRANCH: gh-pages
           FOLDER: docs/build/html
-          GIT_CONFIG_NAME: deltarcm-helper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,11 @@ jobs:
         (cd docs && make docs)
     - name: Debug
       run: |
-        echo REF
-        echo EVENT_NAME
+        echo $REF
+        echo $EVENT_NAME
+        echo ${{ github.event_name }}
+        echo ${{ github.ref }}
+        echo "{{ github.ref }}"
         echo ${{ github.event_name == 'push' && github.ref == 'develop' }}
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@3.5.5


### PR DESCRIPTION
So I suspect that the changes here may lead to correct documentation deployment.
```
echo ${{ github.event_name == 'push' }}
echo ${{ github.ref == 'refs/heads/develop' }}
echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
```
now leads to 
```
false
false
false
```
because this is a PR (which is what it should do), but I think that when the PR is merged, the `event_name` will be `push` and the `ref` will be 'refs/heads/develop', which would lead to the third line being `true`, and so [the line with conditional](https://github.com/amoodie/pyDeltaRCM_WMT/blob/89a823120b62417d97a17bd92244047ff6c1ba8d/.github/workflows/build.yml#L80) will evaluate to true and the docs will deploy. 

Honestly, this might fail too, but I don't really know how else to debug this. I could try pushing a minor doc change directly to develop too...?