### PR TITLE
Fix index error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,8 @@
 # This workflow installs and tests pyDeltaRCM on mulitple python versions and operating systems.
 
-name: actions
+name: build
 
-on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,11 @@ jobs:
     - name: Build and test documentation
       run: |
         (cd docs && make docs)
+    - name: Upload log file
+      uses: actions/upload-artifact@v2
+      with:
+        name: log-file
+        path: docs/deltaRCM_Output/*.log
     - name: Debug
       run: |
         echo $REF

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -185,11 +185,12 @@ class init_tools(object):
         self.U_ero_sand = self.coeff_U_ero_sand * self.u0
         self.U_ero_mud = self.coeff_U_ero_mud * self.u0
 
-        self.L0 = max(1, int(round(self.L0_meters / self.dx)))
-        self.N0 = max(3, int(round(self.N0_meters / self.dx)))
-
         self.L = int(round(self.Length / self.dx))        # num cells in x
         self.W = int(round(self.Width / self.dx))         # num cells in y
+
+        # inlet length and width
+        self.L0 = max(1, min(int(round(self.L0_meters / self.dx)), self.W // 4))
+        self.N0 = max(3, min(int(round(self.N0_meters / self.dx)), self.L // 4))
 
         self.set_constants()
 
@@ -206,10 +207,9 @@ class init_tools(object):
         self.V0 = self.h0 * (self.dx**2)    # (m^3) reference volume (volume to
 
         # fill cell to characteristic depth)
-
         self.Qw0 = self.u0 * self.h0 * self.N0 * self.dx    # const discharge
-        # at inlet
 
+        # at inlet
         self.qw0 = self.u0 * self.h0                # water unit input discharge
         self.Qp_water = self.Qw0 / self.Np_water    # volume each water parcel
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -201,6 +201,8 @@ class init_tools(object):
         # (m) critial depth to switch to "dry" node
         self.dry_depth = min(0.1, 0.1 * self.h0)
         self.CTR = floor(self.W / 2.) - 1
+        if self.CTR <= 1:
+            self.CTR = floor(self.W / 2.)
 
         self.gamma = self.g * self.S0 * self.dx / (self.u0**2)
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -25,6 +25,7 @@ class DeltaModel(Tools):
     finalized (:meth:`finalize`), such that files and data are appropriately
     closed and written to disk.
     """
+
     def __init__(self, input_file=None):
         """Creates an instance of the pyDeltaRCM model.
 

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -73,14 +73,8 @@ class water_tools(object):
             self.update_Q(dist, current_inds, next_index, astep, jstep, istep)
 
             current_inds, self.looped, self.free_surf_flag = shared_tools.check_for_loops(
-                self.indices,
-                next_index,
-                _iter,
-                self.L0,
-                self.looped,
-                self.eta.shape,
-                self.CTR,
-                self.free_surf_flag)
+                self.indices, next_index, _iter, self.L0, self.looped, self.eta.shape,
+                self.CTR, self.free_surf_flag)
 
             current_inds = self.check_for_boundary(current_inds)
 

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -78,8 +78,8 @@ def test_limit_inds_error_inlet_size_fixed_bug_example_1(tmp_path):
     outside the domain. This produced an IndexError.
 
     We now limit the size of the inlet to 1/4 of the domain edge length in
-    both directions (length and width). This fixed this case example, and it
-    is now here as a consistency check, and to make sure the bug is not
+    both directions (length and width). This change fixed this case example,
+    and it is now here as a consistency check, and to make sure the bug is not
     recreated by mistake.
     """
     file_name = 'user_parameters.yaml'
@@ -114,8 +114,8 @@ def test_limit_inds_error_inlet_size_fixed_bug_example_2(tmp_path):
     outside the domain. This produced an IndexError.
 
     We now limit the size of the inlet to 1/4 of the domain edge length in
-    both directions (length and width). This fixed this case example, and it
-    is now here as a consistency check, and to make sure the bug is not
+    both directions (length and width). This change fixed this case example,
+    and it is now here as a consistency check, and to make sure the bug is not
     recreated by mistake.
     """
     file_name = 'user_parameters.yaml'
@@ -139,3 +139,40 @@ def test_limit_inds_error_inlet_size_fixed_bug_example_2(tmp_path):
 
     _exp = np.array([-4.9960604, -5.7494435, -7.1670866, -6.7887363, -6.3081055])
     assert np.all(delta.eta[:5, 30] == pytest.approx(_exp))
+
+
+def test_limit_inds_error_fixed_bug_example_3(tmp_path):
+    """IndexError due to inlet width resolving to an edge cell.
+
+    If the domain was made small and long (20x10), then the configuration that
+    determined the center cell to hinge the inlet location on, would resolve
+    to place the inlet at an edge cell. This led to some index error at the
+    end of the water iteration and an IndexError.
+
+    We now recalcualte the value of the self.CTR parameter if the cell is
+    chosen as ind = 0 or 1. This is really only relevant to the testing suite,
+    where domains are very small. This change fixed this case example, and it
+    is now here as a consistency check, and to make sure the bug is not
+    recreated by mistake.
+    """
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'seed', 42)
+    utilities.write_parameter_to_file(f, 'Length', 20.)
+    utilities.write_parameter_to_file(f, 'Width', 10.)
+    utilities.write_parameter_to_file(f, 'dx', 2)
+    utilities.write_parameter_to_file(f, 'verbose', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 20)
+    utilities.write_parameter_to_file(f, 'Np_sed', 20)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.65)
+    f.close()
+    delta = DeltaModel(input_file=p)
+
+    for _ in range(0, 2):
+        delta.update()
+
+    # slice is: test_DeltaModel.eta[:5, 2]
+    print(delta.eta[:5, 2])
+
+    _exp = np.array([-5., -4.41237, -4.965255, -5., -5.])
+    assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -54,9 +54,9 @@ def test_long_multi_validation(tmp_path):
         delta.update()
 
     # slice is: test_DeltaModel.eta[:5, 62]
-    # print(delta.eta[:5, 62])
+    print(delta.eta[:5, 62])
 
-    _exp1 = np.array([-4.971009,  -3.722004,  -4.973,     -3.7240038, -3.7250037])
+    _exp1 = np.array([-4.9709888, -4.972, -3.722989, -7.786886, -3.7249935])
     assert np.all(delta.eta[:5, 62] == pytest.approx(_exp1))
 
     for _ in range(0, 10):
@@ -65,5 +65,77 @@ def test_long_multi_validation(tmp_path):
     # slice is: test_DeltaModel.eta[:5, 4]
     print(delta.eta[:5, 62])
 
-    _exp2 = np.array([-4.971052,  -2.0813923, -2.0824013, -4.6614914, -1.5570664])
+    _exp2 = np.array([-4.9710174, -1.5536911, -3.268889, -3.2696986, -2.0843806])
     assert np.all(delta.eta[:5, 62] == pytest.approx(_exp2))
+
+
+def test_limit_inds_error_inlet_size_fixed_bug_example_1(tmp_path):
+    """IndexError due to inlet size being too large by default. 
+
+    If the domain was made small (30x60), but the `N0_meters` and `L0_meters`
+    parameters were not adjusted, the model domain was filled with landscape
+    above sea level and water routing failed due to trying to access a cell
+    outside the domain. This produced an IndexError.
+
+    We now limit the size of the inlet to 1/4 of the domain edge length in
+    both directions (length and width). This fixed this case example, and it
+    is now here as a consistency check, and to make sure the bug is not
+    recreated by mistake.
+    """
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'seed', 42)
+    utilities.write_parameter_to_file(f, 'Length', 30.)
+    utilities.write_parameter_to_file(f, 'Width', 60.)
+    utilities.write_parameter_to_file(f, 'dx', 1)
+    utilities.write_parameter_to_file(f, 'verbose', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 20)
+    utilities.write_parameter_to_file(f, 'Np_sed', 20)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.65)
+    f.close()
+    delta = DeltaModel(input_file=p)
+
+    for _ in range(0, 2):
+        delta.update()
+
+    # slice is: test_DeltaModel.eta[:5, 30]
+    print(delta.eta[:5, 30])
+
+    _exp = np.array([-4.9969087, -5.0120177, -5.0507884, -5.142324, -5.1529646])
+    assert np.all(delta.eta[:5, 30] == pytest.approx(_exp))
+
+
+def test_limit_inds_error_inlet_size_fixed_bug_example_2(tmp_path):
+    """IndexError due to inlet size being too large by default. 
+
+    If the domain was made small (30x60), but the `N0_meters` and `L0_meters`
+    parameters were not adjusted, the model domain was filled with landscape
+    above sea level and water routing failed due to trying to access a cell
+    outside the domain. This produced an IndexError.
+
+    We now limit the size of the inlet to 1/4 of the domain edge length in
+    both directions (length and width). This fixed this case example, and it
+    is now here as a consistency check, and to make sure the bug is not
+    recreated by mistake.
+    """
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'seed', 43)
+    utilities.write_parameter_to_file(f, 'Length', 30.)
+    utilities.write_parameter_to_file(f, 'Width', 60.)
+    utilities.write_parameter_to_file(f, 'dx', 1)
+    utilities.write_parameter_to_file(f, 'verbose', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 20)
+    utilities.write_parameter_to_file(f, 'Np_sed', 20)
+    utilities.write_parameter_to_file(f, 'f_bedload', 0.15)
+    f.close()
+    delta = DeltaModel(input_file=p)
+
+    for _ in range(0, 7):
+        delta.update()
+
+    # slice is: test_DeltaModel.eta[:5, 30]
+    print(delta.eta[:5, 30])
+
+    _exp = np.array([-4.9960604, -5.7494435, -7.1670866, -6.7887363, -6.3081055])
+    assert np.all(delta.eta[:5, 30] == pytest.approx(_exp))

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -10,6 +10,35 @@ from pyDeltaRCM.model import DeltaModel
 from pyDeltaRCM import init_tools
 
 from utilities import test_DeltaModel
+import utilities
+
+
+def test_inlet_size_specified(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 4000.)
+    utilities.write_parameter_to_file(f, 'Width', 8000.)
+    utilities.write_parameter_to_file(f, 'dx', 20)
+    utilities.write_parameter_to_file(f, 'N0_meters', 150)
+    utilities.write_parameter_to_file(f, 'L0_meters', 200)
+    f.close()
+    delta = DeltaModel(input_file=p)
+    assert delta.N0 == 8
+    assert delta.L0 == 10
+
+
+def test_inlet_size_set_to_one_fourth_domain(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 4000.)
+    utilities.write_parameter_to_file(f, 'Width', 8000.)
+    utilities.write_parameter_to_file(f, 'dx', 20)
+    utilities.write_parameter_to_file(f, 'N0_meters', 5500)
+    utilities.write_parameter_to_file(f, 'L0_meters', 3300)
+    f.close()
+    delta = DeltaModel(input_file=p)
+    assert delta.N0 == 50
+    assert delta.L0 == 100
 
 
 # tests for attrs set during yaml parsing

--- a/tests/test_shared_tools.py
+++ b/tests/test_shared_tools.py
@@ -226,36 +226,3 @@ def test_version_is_valid():
     assert type(v) is str
     dots = [i for i, c in enumerate(v) if c == '.']
     assert len(dots) == 2
-
-
-@pytest.mark.xfail(raises=IndexError, strict=True)
-def test_limit_inds_error_fixed_bug_example_3(tmp_path):
-    # IndexError on corner.
-
-    # This test throws an error by trying to index cell 1800 of a 30x60 array.
-    # This exceeds the limit of the array. I suspect this is a bug with the
-    # unravel in shared_tools.
-
-    # The xfail should be removed when the bug is fixed.
-
-    file_name = 'user_parameters.yaml'
-    p, f = utilities.create_temporary_file(tmp_path, file_name)
-    utilities.write_parameter_to_file(f, 'seed', 42)
-    utilities.write_parameter_to_file(f, 'Length', 20.)
-    utilities.write_parameter_to_file(f, 'Width', 10.)
-    utilities.write_parameter_to_file(f, 'dx', 2)
-    utilities.write_parameter_to_file(f, 'verbose', 1)
-    utilities.write_parameter_to_file(f, 'Np_water', 20)
-    utilities.write_parameter_to_file(f, 'Np_sed', 20)
-    utilities.write_parameter_to_file(f, 'f_bedload', 0.65)
-    f.close()
-    delta = DeltaModel(input_file=p)
-
-    for _ in range(0, 2):
-        delta.update()
-
-    # slice is: test_DeltaModel.eta[:5, 4]
-    print(delta.eta[:5, 2])
-
-    _exp = np.array([1.7, 0.83358884, -0.9256229,  -1., -1.])
-    assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))

--- a/tests/test_shared_tools.py
+++ b/tests/test_shared_tools.py
@@ -229,71 +229,7 @@ def test_version_is_valid():
 
 
 @pytest.mark.xfail(raises=IndexError, strict=True)
-def test_limit_inds_error(tmp_path):
-    """IndexError on corner.
-
-    This test throws an error by trying to index cell 1800 of a 30x60 array.
-    This exceeds the limit of the array. I suspect this is a bug with the
-    unravel in shared_tools.
-
-    The xfail should be removed when the bug is fixed.
-    """
-
-    file_name = 'user_parameters.yaml'
-    p, f = utilities.create_temporary_file(tmp_path, file_name)
-    utilities.write_parameter_to_file(f, 'seed', 42)
-    utilities.write_parameter_to_file(f, 'Length', 30.)
-    utilities.write_parameter_to_file(f, 'Width', 60.)
-    utilities.write_parameter_to_file(f, 'dx', 1)
-    utilities.write_parameter_to_file(f, 'verbose', 1)
-    utilities.write_parameter_to_file(f, 'Np_water', 20)
-    utilities.write_parameter_to_file(f, 'Np_sed', 20)
-    utilities.write_parameter_to_file(f, 'f_bedload', 0.65)
-    f.close()
-    delta = DeltaModel(input_file=p)
-
-    for _ in range(0, 2):
-        delta.update()
-
-    # slice is: test_DeltaModel.eta[:5, 4]
-    print(delta.eta[:5, 2])
-
-    _exp = np.array([1.7, 0.83358884, -0.9256229,  -1., -1.])
-    assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))    
-
-
-"""
-This test cannot be enabled because it causes a segfault. For some reason,
-this configuration results in an index error (like the below test) if you run
-the config as a normal model run, but produces a segfault inside the test.
-
-@pytest.mark.xfail(raises=IndexError, strict=True)
-def test_limits_inds_error_segfault_error(tmp_path):
-    file_name = 'user_parameters.yaml'
-    p, f = utilities.create_temporary_file(tmp_path, file_name)
-    utilities.write_parameter_to_file(f, 'seed', 43)
-    utilities.write_parameter_to_file(f, 'Length', 30.)
-    utilities.write_parameter_to_file(f, 'Width', 60.)
-    utilities.write_parameter_to_file(f, 'dx', 1)
-    utilities.write_parameter_to_file(f, 'verbose', 1)
-    utilities.write_parameter_to_file(f, 'Np_water', 20)
-    utilities.write_parameter_to_file(f, 'Np_sed', 20)
-    utilities.write_parameter_to_file(f, 'f_bedload', 0.65)
-    f.close()
-    delta = DeltaModel(input_file=p)
-
-    for _ in range(0, 2):
-        delta.update()
-
-    # slice is: test_DeltaModel.eta[:5, 4]
-    print(delta.eta[:5, 2])
-
-    _exp = np.array([1.7, 0.83358884, -0.9256229,  -1., -1.])
-    assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))    
-
-
-@pytest.mark.xfail(raises=IndexError, strict=True)
-def test_limit_inds_error(tmp_path):
+def test_limit_inds_error_fixed_bug_example_3(tmp_path):
     # IndexError on corner.
 
     # This test throws an error by trying to index cell 1800 of a 30x60 array.
@@ -322,6 +258,4 @@ def test_limit_inds_error(tmp_path):
     print(delta.eta[:5, 2])
 
     _exp = np.array([1.7, 0.83358884, -0.9256229,  -1., -1.])
-    assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))    
-
-"""
+    assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))


### PR DESCRIPTION
closes #53. This may not clear up all of the `IndexError`s we have, but it does fix the ones we've identified so far.

I have set a new default behavior, which limits the width and length of the inlet channel to 1/4 of the domain width and length. This limit happens silently, so if the configuration specifies a value larger than 1/4 of the domain, the value is limited without alerting the user. This could be changed to warn the user, if we feel it's necessary.

I have also added a change to prevent the inlet from being up against the model domain edge. This was the cause of one of the other index errors. This relates to `self.CTR`.

I've relocated the previously failing tests to the `test_consistent.py` test suite to prevent regressing on these bug fixes.

Finally, I added a step to the documentation building that uploads the log as an artifact so that we can determine the cause of the doc build failing. 