### PR TITLE
add another branch to if statement to ensure never divide by zero.

### DIFF
--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -194,10 +194,12 @@ def get_weight_at_cell(ind, stage_nbrs, depth_nbrs, ct_nbrs, stage, qx, qy,
         weight = weight / np.nansum(weight)
         weight[nanWeight] = 0
     elif np.any(~nanWeight):
+        # if there are any value that are non-nan
         weight[~nanWeight] = 1 / len(weight[~nanWeight])
         weight[nanWeight] = 0
     else:
-        weight[~nanWeight] = 1 / len(weight)
+        # if the whole array is nan
+        weight[~nanWeight] = 1 / (len(weight)-1)
         weight[4] = 0
 
     return weight

--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -187,14 +187,19 @@ def get_weight_at_cell(ind, stage_nbrs, depth_nbrs, ct_nbrs, stage, qx, qy,
     weight = depth_nbrs ** theta * weight
     weight[depth_nbrs <= dry_depth] = 0
 
-    nanWeight = np.isnan(weight)
+    nanWeight = np.isnan(weight)  # which weights are nan
 
     if np.any(weight[~nanWeight] != 0):
+        # if any non-nan value is non-zero
         weight = weight / np.nansum(weight)
         weight[nanWeight] = 0
-    else:
+    elif np.any(~nanWeight):
         weight[~nanWeight] = 1 / len(weight[~nanWeight])
         weight[nanWeight] = 0
+    else:
+        weight[~nanWeight] = 1 / len(weight)
+        weight[4] = 0
+
     return weight
 
 


### PR DESCRIPTION
this relates to #71. I'm not sure if this is the correct fix though.

The bug/error in #71 arises because an array called `weight` is all `np.nan` within the `shared_tools.get_weight_at_cell` function ([here is the exact line that causes the error](https://github.com/DeltaRCM/pyDeltaRCM_WMT/blob/7270b70b7fd2fc3ab89e5a8713ed478979da30ea/pyDeltaRCM/shared_tools.py#L196)). AFAIK this function is supposed to determine the weighting array for a given cell for the water routing random choice algorithm. The original code is below.

```python
nanWeight = np.isnan(weight)

if np.any(weight[~nanWeight] != 0):
    weight = weight / np.nansum(weight)
    weight[nanWeight] = 0
else:
    weight[~nanWeight] = 1 / len(weight[~nanWeight])
    weight[nanWeight] = 0
```

So, when `weight` was all nans, then the length of the non-nan slice was zero, and the divide by zero error occurs.

My fix was to add another branch to the `if` statement, so that there is a safe choice for when the weighting array evaluates to all `np.nan`. This choice is to just weight all eight neighbors as 1/8 and the weight of center cell is 0.

```python    
    nanWeight = np.isnan(weight)  # which weights are nan

    if np.any(weight[~nanWeight] != 0):
        # if any non-nan value is non-zero
        weight = weight / np.nansum(weight)
        weight[nanWeight] = 0
    elif np.any(~nanWeight):
        weight[~nanWeight] = 1 / len(weight[~nanWeight])
        weight[nanWeight] = 0
    else:
        weight[~nanWeight] = 1 / len(weight)
        weight[4] = 0
```

I'd really like @ericbarefoot to take a look at this, since he did the refactoring to jit this function. I also think both he and @elbeejay have a much deeper understanding of the water routing algorithm and so could say whether my "safe" choice is really a good choice.

Importantly, I do not understand _why_ the weight array becomes entirely `np.nan`, so this is more of a band-aid than effective surgery. If either of you thinks you understand the root cause of the weight array being nans, this may be a better fix that what I have proposed here.