### PR TITLE
Fix time step names

### DIFF
--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -34,7 +34,7 @@ We can visualize the delta bed elevation, though it's not very exciting after on
     >>> import matplotlib.pyplot as plt
 
     >>> fig, ax = plt.subplots()
-    >>> ax.imshow(delta.bed_elevation, vmax=-4)
+    >>> ax.imshow(delta.bed_elevation, vmax=-3)
     >>> plt.show()
 
 .. plot:: 10min/model_run_visual.py

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -16,18 +16,18 @@ First, we instantiate the main :obj:`~pyDeltaRCM.deltaRCM_driver.pyDeltaRCM` mod
 
 Next, since this is just a simple demo, we will run for a few short timesteps.
 The delta model is run forward with a call to the :meth:`~pyDeltaRCM.DeltaModel.update()` method of the delta model.
-So we loop the update function, and then finalize the model:
+So we loop the `update` function, and then finalize the model:
 
 .. doctest::
 
-    >>> for _ in range(0, 2):
+    >>> for _ in range(0, 5):
     ...     delta.update()
 
     >>> delta.finalize()
 
-That's it! You ran the pyDeltaRCM model for two timesteps. 
+That's it! You ran the pyDeltaRCM model for five timesteps. 
 
-We can visualize the delta bed elevation, though it's not very exciting after only two timestep...
+We can visualize the delta bed elevation, though it's not very exciting after only five timesteps...
 
 .. code::
 

--- a/docs/source/pyplots/10min/model_run_visual.py
+++ b/docs/source/pyplots/10min/model_run_visual.py
@@ -5,12 +5,12 @@ import pyDeltaRCM
 
 delta = pyDeltaRCM.DeltaModel()
 
-for _t in range(0, 2):
+for _t in range(0, 5):
     delta.update()
 
 delta.finalize()
 
 
 fig, ax = plt.subplots()
-ax.imshow(delta.bed_elevation, vmax=-4)
+ax.imshow(delta.bed_elevation, vmax=-3)
 plt.show()

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -99,7 +99,7 @@ save_velocity_grids:
   default: False
 save_dt:
   type: 'int'
-  default: 50
+  default: 86400
 save_strata:
   type: 'bool'
   default: True

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -60,10 +60,10 @@ toggle_subsidence:
   default: False
 sigma_max:
   type: ['float', 'int']
-  default: 0.000825
+  default: 2e-9
 start_subsidence:
   type: ['float', 'int']
-  default: 2.5
+  default: 216000
 save_eta_figs:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -389,7 +389,7 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
         fig, ax = plt.subplots()
         pc = ax.pcolor(_data)
         fig.colorbar(pc)
-        ax.set_title(var + ' --- ' + 'time = ' + str(timestep))
+        ax.set_title(var + ' --- ' + 'time = ' + str(round(timestep, 2)))
         ax.axis('equal')
 
         return fig

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -124,7 +124,7 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
         """
         timestep = self._time
 
-        if self.save_strata and (timestep % self.save_dt == 0):
+        if self.save_strata and self._save_time_since_last > self.save_dt:
 
             timestep = int(timestep)
 
@@ -314,10 +314,6 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
             self.strata_eta = self.strata_eta[:, :self.strata_counter]
 
             shape = self.strata_eta.shape
-            if shape[0] < 1:
-                raise RuntimeError('Stratigraphy are empty! '
-                                   'Are you sure you ran the model at least '
-                                   'one timestep with `update()`?')
 
             total_strata_age = self.output_netcdf.createDimension(
                 'total_strata_age',

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -125,8 +125,7 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
 
         if self.save_strata:
 
-            timestep = int(self.time)
-            if self.strata_eta.shape[1] <= timestep:
+            if self.strata_counter >= self.strata_eta.shape[1]:
                 self.expand_stratigraphy()
 
             _msg = 'Storing stratigraphy data'
@@ -171,7 +170,7 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
                                     shape=(self.L * self.W, 1))
             self.strata_eta[:, self.strata_counter] = eta_sparse
 
-            if self.toggle_subsidence and self.start_subsidence <= timestep:
+            if self.toggle_subsidence and (self.time >= self.start_subsidence):
 
                 sigma_change = (self.strata_eta[:, :self.strata_counter]
                                 - self.sigma.flatten()[:, np.newaxis])
@@ -338,7 +337,7 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
             strata_age = self.output_netcdf.createVariable('strata_age',
                                                            np.int32,
                                                            ('total_strata_age'))
-            strata_age.units = 'timesteps'
+            strata_age.units = 'seconds'
             self.output_netcdf.variables['strata_age'][
                 :] = list(range(shape[1] - 1, -1, -1))
 

--- a/pyDeltaRCM/deltaRCM_tools.py
+++ b/pyDeltaRCM/deltaRCM_tools.py
@@ -184,7 +184,13 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
         """Apply subsidence pattern.
 
         Apply subsidence to domain if toggle_subsidence is True, and
-        start_subsidence is =< timestep.
+        :obj:`~pyDeltaRCM.DeltaModel.time` is ``>=``
+        ::obj:`~pyDeltaRCM.DeltaModel.start_subsidence`. Note, that the
+        :configuration of the :obj:`~pyDeltaRCM.DeltaModel.update()` method
+        :determines that the subsidence may be applied before the model time
+        :is incremented, such that subsidence will begin on the step
+        :*following* the time step that brings the model to ``time ==
+        :start_subsidence``.
 
         Parameters
         ----------
@@ -195,7 +201,7 @@ class Tools(sed_tools, water_tools, init_tools, debug_tools, object):
         """
         if self.toggle_subsidence:
 
-            if self.start_subsidence <= self._time:
+            if self.time >= self.start_subsidence:
 
                 _msg = 'Applying subsidence'
                 self.logger.info(_msg)

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -232,7 +232,7 @@ class init_tools(object):
         self.itmax = 2 * (self.L + self.W)  # max number of jumps for parcel
         self.size_indices = int(self.itmax / 2)  # initial width of self.indices
 
-        self.dt = self.dVs / self.Qs0  # time step size
+        self._dt = self.dVs / self.Qs0  # time step size
 
         self.omega_flow_iter = 2. / self.itermax
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -338,7 +338,7 @@ class init_tools(object):
 
             self.strata_counter = 0
 
-            self.n_steps = 5 * self.save_dt
+            self.n_steps = int(max(1, 5 * int(self.save_dt / self.dt)))
 
             self.strata_sand_frac = lil_matrix((self.L * self.W, self.n_steps),
                                                dtype=np.float32)
@@ -398,7 +398,7 @@ class init_tools(object):
                                                      ('total_time',))
             x.units = 'meters'
             y.units = 'meters'
-            time.units = 'timesteps'
+            time.units = 'seconds'
 
             x[:] = self.x
             y[:] = self.y

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -156,20 +156,16 @@ class DeltaModel(Tools):
         """
         return self._dt
 
-    @dt.setter
-    def dt(self, new_dt):
-        if new_dt * self.init_Np_sed < 100:
-            warnings.warn(UserWarning('Using a very small timestep, '
+    @time_step.setter
+    def time_step(self, new_time_step):
+        if new_time_step * self.init_Np_sed < 100:
+            warnings.warn(UserWarning('Using a very small time step, '
                                       'Delta might evolve very slowly.'))
 
         if self.toggle_subsidence:
-            self.sigma = self.subsidence_mask * self.sigma_max * new_dt
+            self.sigma = self.subsidence_mask * self.sigma_max * new_time_step
 
-        self._dt = new_dt
-
-    @time_step.setter
-    def time_step(self, new_time_step):
-        self.dt = new_time_step
+        self._dt = new_time_step
 
     @property
     def time_iter(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -159,9 +159,6 @@ class DeltaModel(Tools):
             warnings.warn(UserWarning('Using a very small timestep, '
                                       'Delta might evolve very slowly.'))
 
-        # self.Np_sed = int(new_dt * self.init_Np_sed)
-        # self.Np_water = int(new_dt * self.init_Np_water)
-
         if self.toggle_subsidence:
             self.sigma = self.subsidence_mask * self.sigma_max * new_dt
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -48,7 +48,7 @@ class DeltaModel(Tools):
         """
         self._time = 0.
         self._time_iter = int(0)
-        self._save_time_since_last = 0.
+        self._save_time_since_last = float("inf")  # force save on t==0
         self._save_iter = int(0)
 
         self.input_file = input_file
@@ -91,19 +91,18 @@ class DeltaModel(Tools):
         -------
 
         """
-        self.run_one_timestep()
-        self.apply_subsidence()
-        self.finalize_timestep()
-
-        self._time += self.dt
-        self._save_time_since_last += self.dt
-
         if self._save_time_since_last >= self.save_dt:
             self.record_stratigraphy()
             self.output_data()
             self._save_iter += int(1)
             self._save_time_since_last = 0
 
+        self.run_one_timestep()
+        self.apply_subsidence()
+        self.finalize_timestep()
+
+        self._time += self.dt
+        self._save_time_since_last += self.dt
         self._time_iter += int(1)
 
     def finalize(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -98,8 +98,11 @@ class DeltaModel(Tools):
         self._time += self.dt
         self._save_time_since_last += self.dt
 
-        self.record_stratigraphy()
-        self.output_data()
+        if self._save_time_since_last >= self.save_dt:
+            self.record_stratigraphy()
+            self.output_data()
+            self._save_iter += int(1)
+            self._save_time_since_last = 0
 
         self._time_iter += int(1)
 
@@ -172,7 +175,7 @@ class DeltaModel(Tools):
     def time_iter(self):
         """Number of time iterations.
 
-        The number of times the `:obj:`update` method has been called.
+        The number of times the :obj:`update` method has been called.
         """
         return self._time_iter
 
@@ -180,7 +183,7 @@ class DeltaModel(Tools):
     def save_time_since_last(self):
         """Time since data last output.
 
-        The number of times the `:obj:`update` method has been called.
+        The number of times the :obj:`update` method has been called.
         """
         return self._save_time_since_last
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -167,6 +167,10 @@ class DeltaModel(Tools):
 
         self._dt = new_dt
 
+    @time_step.setter
+    def time_step(self, new_time_step):
+        self.dt = new_time_step
+
     @property
     def time_iter(self):
         """Number of time iterations.

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -47,7 +47,9 @@ class DeltaModel(Tools):
 
         """
         self._time = 0.
-        self._time_step = 1.
+        self._time_iter = int(0)
+        self._save_time_since_last = 0.
+        self._save_iter = int(0)
 
         self.input_file = input_file
         _src_dir = os.path.realpath(os.path.dirname(__file__))
@@ -90,15 +92,16 @@ class DeltaModel(Tools):
 
         """
         self.run_one_timestep()
-
         self.apply_subsidence()
-
         self.finalize_timestep()
-        self.record_stratigraphy()
 
+        self._time += self.dt
+        self._save_time_since_last += self.dt
+
+        self.record_stratigraphy()
         self.output_data()
 
-        self._time += self.time_step
+        self._time_iter += int(1)
 
     def finalize(self):
         """Finalize the model run.
@@ -128,7 +131,13 @@ class DeltaModel(Tools):
         self._is_finalized = True
 
     @property
-    def time_step(self):
+    def time(self):
+        """Elapsed model time in seconds.
+        """
+        return self._time
+
+    @property
+    def dt(self):
         """The time step.
 
         Raises
@@ -136,21 +145,48 @@ class DeltaModel(Tools):
         UserWarning
             If a very small timestep is configured.
         """
-        return self._time_step
+        return self._dt
 
-    @time_step.setter
-    def time_step(self, new_dt):
+    @property
+    def time_step(self):
+        """Alias for `dt`.
+        """
+        return self._dt
+
+    @dt.setter
+    def dt(self, new_dt):
         if new_dt * self.init_Np_sed < 100:
             warnings.warn(UserWarning('Using a very small timestep, '
                                       'Delta might evolve very slowly.'))
 
-        self.Np_sed = int(new_dt * self.init_Np_sed)
-        self.Np_water = int(new_dt * self.init_Np_water)
+        # self.Np_sed = int(new_dt * self.init_Np_sed)
+        # self.Np_water = int(new_dt * self.init_Np_water)
 
         if self.toggle_subsidence:
             self.sigma = self.subsidence_mask * self.sigma_max * new_dt
 
-        self._time_step = new_dt
+        self._dt = new_dt
+
+    @property
+    def time_iter(self):
+        """Number of time iterations.
+
+        The number of times the `:obj:`update` method has been called.
+        """
+        return self._time_iter
+
+    @property
+    def save_time_since_last(self):
+        """Time since data last output.
+
+        The number of times the `:obj:`update` method has been called.
+        """
+        return self._save_time_since_last
+
+    @property
+    def save_iter(self):
+        """Number of times data has been saved."""
+        return self._save_iter
 
     @property
     def channel_flow_velocity(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -119,6 +119,12 @@ class DeltaModel(Tools):
 
         """
         self.logger.info('Finalize model run')
+
+        # get the final timestep recorded, if needed.
+        if self._save_time_since_last >= self.save_dt:
+            self.record_stratigraphy()
+            self.output_data()
+
         self.output_strata()
 
         try:

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -21,8 +21,8 @@ class BasePreprocessor(abc.ABC):
     Defines a prelimiary yaml reading, then handles the YAML "meta" tag
     parsing, model instatiation, and job running.
 
-    Subclasses create the high-level command line API 
-    and the high-level python API. 
+    Subclasses create the high-level command line API
+    and the high-level python API.
 
     .. note::
 
@@ -32,7 +32,7 @@ class BasePreprocessor(abc.ABC):
     """
 
     def extract_yaml_config(self):
-        """Preliminary YAML parsing. 
+        """Preliminary YAML parsing.
 
         Extract ``.yml`` file (``self.input_file``) into a dictionary, if
         provided. This dictionary provides a few keys used throughout the
@@ -208,6 +208,9 @@ class BasePreprocessor(abc.ABC):
             TODO: implement the parallel pool.
 
         """
+        if self._dryrun:
+            return
+
         if len(self.job_list) > 1:
             # set up parallel pool if multiple jobs
             pass
@@ -275,14 +278,14 @@ class PreprocessorCLI(BasePreprocessor):
     defines a method to process the arguments from the command line (using the
     `argparse` package).
 
-    .. note:: 
+    .. note::
 
         You probably do not need to interact with this class directly.
         Instead, you can use the command line API as it is defined HERE XX or
-        the python API :class:`~pyDeltaRCM.preprocessor.Preprocessor`. 
+        the python API :class:`~pyDeltaRCM.preprocessor.Preprocessor`.
 
-        When the class is called from the command line the instantiated object's
-        method :meth:`run_jobs` is called by the
+        When the class is called from the command line the instantiated
+        object's method :meth:`run_jobs` is called by the
         :obj:`~pyDeltaRCM.preprocessor.preprocessor_wrapper` function that the
         CLI (entry point) calls directly.
 
@@ -321,10 +324,15 @@ class PreprocessorCLI(BasePreprocessor):
 
         self.construct_job_list()
 
+        if self.args['dryrun']:
+            self._dryrun = True
+        else:
+            self._dryrun = False
+
     def process_arguments(self):
         """Process the command line arguments.
 
-        .. note:: 
+        .. note::
 
             The command line args are not directly passed to this function in
             any way.
@@ -355,9 +363,10 @@ class Preprocessor(BasePreprocessor):
 
     This is the python high-level API class that is callable from a python
     script. For complete documentation on the API configurations, see
-    XXXXXXXXXXXXXX. 
+    XXXXXXXXXXXXXX.
 
-    The class gives a way to configure and run multiple jobs from a python script.
+    The class gives a way to configure and run multiple jobs from a python
+    script.
 
     Examples
     --------
@@ -396,6 +405,7 @@ class Preprocessor(BasePreprocessor):
 
         """
         super().__init__()
+        self._dryrun = False
 
         if not input_file and not timesteps:
             raise ValueError('Cannot use Preprocessor with no arguments.')

--- a/tests/test_deltaRCM_tools.py
+++ b/tests/test_deltaRCM_tools.py
@@ -104,26 +104,27 @@ def test_expand_stratigraphy(tmp_path):
     assert _delta.dt == 300
     assert _delta.n_steps == 10
     assert _delta.strata_counter == 0
-    for _t in range(20):
+    assert _delta.strata_eta[:, _delta.strata_counter].getnnz() == 0
+    for _t in range(19):
         assert _delta.strata_eta[:, _delta.strata_counter].getnnz() == 0
         _delta.update()
+        assert _delta.time == _delta.dt * (_t + 1)
         assert _delta.strata_eta.shape[1] == 10
-        assert (_delta.time // _delta.save_dt) + ((_delta.time % _delta.dt) / _delta.dt) == _delta.strata_counter
-    assert _delta.time == 20 * 300
+    assert _delta.time == 19 * 300
     assert _delta.strata_counter == 10  # stored 10 but invalid index next store
     assert _delta.strata_eta.shape[1] == 10
     # nothing occurs on next  update, because save_dt = 2 * dt
     _delta.update()
-    assert _delta.time == 21 * 300
+    assert _delta.time == 20 * 300
     assert _delta.strata_counter == 10
     assert _delta.strata_eta.shape[1] == 10
     # expansion occurs when model tries to save strata after next update
     _delta.update()
-    assert _delta.time == 22 * 300
+    assert _delta.time == 21 * 300
     assert _delta.strata_counter == 11
     assert _delta.strata_eta.shape[1] == 20
     # run to bring to even 100 steps, check status again
-    for _t in range(78):
+    for _t in range(79):
         _delta.update()
     assert _delta.time == 100 * 300
     assert _delta.strata_counter == 50

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -522,6 +522,30 @@ def test_save_figs_sequential(tmp_path):
     assert _delta._save_figs_sequential is False
 
 
+def test_toggle_subsidence(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'toggle_subsidence': True})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.toggle_subsidence is True
+
+
+def test_start_subsidence(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'start_subsidence': 12345})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.start_subsidence == 12345
+
+
+def test_sigma_max(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'toggle_subsidence': True,
+                                  'sigma_max': 1e-9})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.sigma_max == 1e-9
+    assert np.any(_delta.sigma > 0)
+    assert np.all(_delta.sigma <= (1e-9 * _delta.dt))
+
+
 # test definition of the model domain
 
 def test_x(test_DeltaModel):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -261,12 +261,12 @@ def test_version_call():
 from pyDeltaRCM import preprocessor
 
 
-def test_python_highlevelapi_call_without_args():
+def test_py_hlvl_wo_args():
     with pytest.raises(ValueError):
         pp = preprocessor.Preprocessor()
 
 
-def test_python_highlevelapi_call_without_timesteps(tmp_path):
+def test_py_hlvl_wo_timesteps(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)
     utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
@@ -275,7 +275,7 @@ def test_python_highlevelapi_call_without_timesteps(tmp_path):
         pp = preprocessor.Preprocessor(p)
 
 
-def test_python_highlevelapi_call_with_timesteps_yaml_init_types(tmp_path):
+def test_py_hlvl_tsteps_yml_init_types(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)
     utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
@@ -289,7 +289,7 @@ def test_python_highlevelapi_call_with_timesteps_yaml_init_types(tmp_path):
     assert pp.job_list[0]._is_completed is False
 
 
-def test_python_highlevelapi_call_with_timesteps_yaml_runjobs(tmp_path):
+def test_py_hlvl_tsteps_yml_runjobs_sngle(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)
     utilities.write_parameter_to_file(f, 'Length', 10.0)
@@ -300,6 +300,7 @@ def test_python_highlevelapi_call_with_timesteps_yaml_runjobs(tmp_path):
     utilities.write_parameter_to_file(f, 'Np_water', 10)
     utilities.write_parameter_to_file(f, 'Np_sed', 10)
     utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
     utilities.write_parameter_to_file(f, 'timesteps', 2)
     f.close()
     pp = preprocessor.Preprocessor(p)
@@ -309,7 +310,7 @@ def test_python_highlevelapi_call_with_timesteps_yaml_runjobs(tmp_path):
     assert pp.job_list[0]._is_completed is True
 
 
-def test_python_highlevelapi_call_with_args(tmp_path):
+def test_py_hlvl_args(tmp_path):
     """
     test calling the python hook command line feature with a config file.
     """

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -134,13 +134,14 @@ def test_no_outputs_save_dt_notreached(tmp_path):
     utilities.write_parameter_to_file(f, 'save_dt', 43200)
     f.close()
     delta = DeltaModel(input_file=p)
+    with pytest.raises(RuntimeError, match=r'Model has no computed strat.*'):
+        delta.finalize()
     for _ in range(2):
         delta.update()
     assert delta.dt == 20000.0
-    assert delta.strata_counter == 0
+    assert delta.strata_counter == 1  # one saved, t==0
     assert delta.time < delta.save_dt
-    with pytest.raises(RuntimeError, match=r'Model has no computed strat.*'):
-        delta.finalize()
+    delta.finalize()
 
 
 def test_no_outputs_save_strata_false(tmp_path):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -545,7 +545,6 @@ def test_python_highlevelapi_matrix_expansion_scientificnotation(tmp_path):
     f.close()
     pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
     SLR_list = [j.deltamodel.SLR for j in pp.job_list]
-    print("SLR_LIST:", SLR_list)
     assert sum([j == 4e-5 for j in SLR_list]) == 3
     assert sum([j == 0.000001 for j in SLR_list]) == 3
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -134,8 +134,6 @@ def test_no_outputs_save_dt_notreached(tmp_path):
     utilities.write_parameter_to_file(f, 'save_dt', 43200)
     f.close()
     delta = DeltaModel(input_file=p)
-    with pytest.raises(RuntimeError, match=r'Model has no computed strat.*'):
-        delta.finalize()
     for _ in range(2):
         delta.update()
     assert delta.dt == 20000.0
@@ -215,9 +213,11 @@ def test_entry_point_python_main_call(tmp_path):
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
     exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+    exp_path_png2 = os.path.join(tmp_path / 'test', 'eta_00002.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png)
-    assert not os.path.isfile(exp_path_png1)
+    assert os.path.isfile(exp_path_png1)
+    assert not os.path.isfile(exp_path_png2)
 
 
 def test_entry_point_python_main_call_dryrun(tmp_path):
@@ -380,7 +380,8 @@ def test_py_hlvl_args(tmp_path):
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
     exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
     exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
-    exp_path_png3 = os.path.join(tmp_path / 'test', 'eta_00002.png')
+    exp_path_png2 = os.path.join(tmp_path / 'test', 'eta_00002.png')
+    exp_path_png3 = os.path.join(tmp_path / 'test', 'eta_00003.png')
     assert os.path.isfile(exp_path_nc)
     assert os.path.isfile(exp_path_png)
     assert os.path.isfile(exp_path_png1)
@@ -478,7 +479,7 @@ def test_python_highlevelapi_matrix_expansion_one_list_timesteps_config(tmp_path
     ds = netCDF4.Dataset(exp_path_nc0, "r", format="NETCDF4")
     assert ds.variables['strata_sand_frac'].shape[1:] == (10, 10)
     assert ds.variables['strata_sand_frac'].shape[1:] == (10, 10)
-    assert ds.variables['strata_age'].shape == (3,)
+    assert ds.variables['strata_age'].shape == (4,)
 
 
 def test_python_highlevelapi_matrix_expansion_two_lists(tmp_path):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -34,11 +34,16 @@ def test_update_saving_intervals(test_DeltaModel):
     test_DeltaModel.update()
     assert test_DeltaModel.time_iter == int(1)
     assert test_DeltaModel.time == test_DeltaModel.dt
-    assert test_DeltaModel.strata_counter == 0
+    assert test_DeltaModel.strata_counter == 1
     test_DeltaModel.update()
     assert test_DeltaModel.time_iter == int(2)
     assert test_DeltaModel.time == 2 * test_DeltaModel.dt
     assert test_DeltaModel.strata_counter == 1
+    assert test_DeltaModel._is_finalized is False
+    test_DeltaModel.update()
+    assert test_DeltaModel.time_iter == int(3)
+    assert test_DeltaModel.time == 3 * test_DeltaModel.dt
+    assert test_DeltaModel.strata_counter == 2
     assert test_DeltaModel._is_finalized is False
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,13 +15,13 @@ def test_init(test_DeltaModel):
     """
     test the deltaRCM_driver init (happened when delta.initialize was run)
     """
-    assert test_DeltaModel._time == 0.
+    assert test_DeltaModel.time_iter == 0.
     assert test_DeltaModel._is_finalized == False
 
 
 def test_update(test_DeltaModel):
     test_DeltaModel.update()
-    assert test_DeltaModel._time == 1.0
+    assert test_DeltaModel.time_iter == 1.0
     assert test_DeltaModel._is_finalized == False
 
 
@@ -35,7 +35,7 @@ def test_multifinalization_error(test_DeltaModel):
     err_delta = test_DeltaModel
     err_delta.update()
     # test will fail if any assertion is wrong
-    assert err_delta._time == 1.0 
+    assert err_delta.time_iter == 1.0 
     assert err_delta._is_finalized == False
     err_delta.finalize()
     assert err_delta._is_finalized == True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,37 +16,60 @@ def test_init(test_DeltaModel):
     test the deltaRCM_driver init (happened when delta.initialize was run)
     """
     assert test_DeltaModel.time_iter == 0.
-    assert test_DeltaModel._is_finalized == False
+    assert test_DeltaModel._is_finalized is False
 
 
 def test_update(test_DeltaModel):
     test_DeltaModel.update()
-    assert test_DeltaModel.time_iter == 1.0
-    assert test_DeltaModel._is_finalized == False
+    assert test_DeltaModel.time_iter == int(1)
+    assert test_DeltaModel.time == test_DeltaModel.dt
+    test_DeltaModel.update()
+    assert test_DeltaModel.time_iter == int(2)
+    assert test_DeltaModel.time == 2 * test_DeltaModel.dt
+    assert test_DeltaModel._is_finalized is False
+
+
+def test_update_saving_intervals(test_DeltaModel):
+    assert test_DeltaModel.strata_counter == 0
+    test_DeltaModel.update()
+    assert test_DeltaModel.time_iter == int(1)
+    assert test_DeltaModel.time == test_DeltaModel.dt
+    assert test_DeltaModel.strata_counter == 0
+    test_DeltaModel.update()
+    assert test_DeltaModel.time_iter == int(2)
+    assert test_DeltaModel.time == 2 * test_DeltaModel.dt
+    assert test_DeltaModel.strata_counter == 1
+    assert test_DeltaModel._is_finalized is False
 
 
 def test_finalize(test_DeltaModel):
-    test_DeltaModel.update()
+    for _ in range(2):
+        test_DeltaModel.update()
     test_DeltaModel.finalize()
-    assert test_DeltaModel._is_finalized == True
+    assert test_DeltaModel._is_finalized is True
+
+
+def test_output_strata_error_if_no_updates(test_DeltaModel):
+    with pytest.raises(RuntimeError, match=r'Model has no computed strat.*'):
+        test_DeltaModel.output_strata()
 
 
 def test_multifinalization_error(test_DeltaModel):
     err_delta = test_DeltaModel
+    assert err_delta.dt == 300.0
+    err_delta.save_dt = 300.0
     err_delta.update()
     # test will fail if any assertion is wrong
-    assert err_delta.time_iter == 1.0 
-    assert err_delta._is_finalized == False
+    assert err_delta.time_iter == 1.0
+    assert err_delta._is_finalized is False
     err_delta.finalize()
-    assert err_delta._is_finalized == True
+    assert err_delta._is_finalized is True
     # next line should throw RuntimeError
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match=r'Cannot update model,.*'):
         err_delta.update()
 
 
 def test_initial_values(test_DeltaModel):
-
-    # delta = DeltaModel(input_file=os.path.join(os.getcwd(), 'tests', 'test.yaml'))
     assert np.all(test_DeltaModel.sea_surface_elevation == 0)
     assert test_DeltaModel.water_depth[0, 2] == 0
     assert test_DeltaModel.water_depth[0, 3] == 1
@@ -93,7 +116,7 @@ def test_setting_getting_channel_width(test_DeltaModel):
     test_DeltaModel.channel_flow_depth = 2
     assert test_DeltaModel.channel_flow_depth == 2
 
-    
+
 def test_setting_getting_channel_width(test_DeltaModel):
     assert test_DeltaModel.influx_sediment_concentration == 0.1
     test_DeltaModel.influx_sediment_concentration = 2

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -70,7 +70,7 @@ def test_DeltaModel(tmp_path):
     write_parameter_to_file(f, 'save_depth_grids', False)
     write_parameter_to_file(f, 'save_discharge_grids', False)
     write_parameter_to_file(f, 'save_velocity_grids', False)
-    write_parameter_to_file(f, 'save_dt', 50)
+    write_parameter_to_file(f, 'save_dt', 500)
     write_parameter_to_file(f, 'save_strata', True)
     f.close()
     _delta = DeltaModel(input_file=p)


### PR DESCRIPTION
**UPDATED v2:** 

This PR is an attempt at reconciling some of the timestepping and actual time behavior in the model.

Herein, I do the conversion of `time` to true elapsed time in seconds, and use `dt` as the main "timestep" variable, with `time_step` as an alias, for backwards compatibility. Additionally, I have added separate counters for model timestep iteration and saving intervals (`time_iter`, `save_time_since_last`, `save_iter`). There are lots of new tests to accompany these changes.

# saving intervals

This is one point of "I'm not sure what the best choice is," but I have made a choice that I think makes enough sense to move forward with it. I have set it up so that saving occurs whenever `save_time_since_last >= save_dt`, and reset `save_time_since_last` each time saving occurs. This works mostly as expected when boundary conditions are unchanged (so as to render `dt` fixed). 

One change is that the saving now occurs at the beginning of the `update()` routine. This was necessary because I find it helpful to have a true `t==0` snapshot of the model domain in the output netCDF file. In the previous setup, the first saved interval was often not early enough, and created difficulty in computing stratigraphy in DeltaMetrics. I have achieved this by setting the `save_time_since_last` to `Inf` at the initialization, such that the `t==0` snapshot is always saved.

Additioanlly, saving now occurs at the end of the run, in `finalize()` **IF** the run is due for a save. This is unchanged functionality from before. Before, saving was at the end of `update()`, so the final state would be saved if the model was due for a save, but now, the save needs to be checked one final time in `finalize()`.

Notably, saving may not occur exactly at the user specified frequency. For example, if `save_dt = 1000` and `dt=300`, saving will occur on `_time_iter` equal to `[0, 4, 8, 12, ...]`, or when time is `[0, 1200, 2400, 3600, ...]`, which means that frames are saved after `1200` seconds, rather than 1000. I think this is okay, since the intervals are regular.

# updating model operations loops

After this PR we need to implement routines in the `model` and `preprocessor` to accept as config inputs *either* the number of timesteps to run *or* the elapsed real time to complete. I have opened another issue (#84) with detailed thoughts on how I expect to implement this.

When you approve of the changes, I will open issues to these points above, and then merge.