### PR TITLE
Fix div-zero error

### DIFF
--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -193,7 +193,7 @@ def get_weight_at_cell(ind, stage_nbrs, depth_nbrs, ct_nbrs, stage, qx, qy,
         weight = weight / np.nansum(weight)
         weight[nanWeight] = 0
     else:
-        weight[~nanWeight] = 1 / len(weight[~nanWeight])
+        weight[~nanWeight] = 1 / np.maximum(1, len(weight[~nanWeight]))
         weight[nanWeight] = 0
     return weight
 


### PR DESCRIPTION
Should close #71. 

### Short Explanation

In the case of an (x, y) location in which all adjacent cells and the cell itself have a weight value of `nan`, then even though the [line](https://github.com/DeltaRCM/pyDeltaRCM/blob/dea1069cd70aa994c749d6a86f9533749e39e919/pyDeltaRCM/shared_tools.py#L196) in `shared_tools.get_weight_at_cell` is not assigning values to any indices, it is still being executed and trying to divide by 0 (as `len(weight[~nanWeight]) == 0`). So the proposed fix is to use `np.maximum()` to ensure that the value there is always 1 or greater. An alternative solution is extending the [if-else statement](https://github.com/DeltaRCM/pyDeltaRCM/blob/dea1069cd70aa994c749d6a86f9533749e39e919/pyDeltaRCM/shared_tools.py#L192) but I figured `np.maximum` was going to be cheaper computationally than another clause (to split the case of having a 0 and the case of all nans).


### Longer Explanation

Using the config described in #71, the error is a bit cryptic as the division by zero is not actually happening within `water_tools` but rather within a jitted function in `shared_tools`. The error is also a bit puzzling as it occurs on one of the 'land' cell indices (2, 142) but wasn't thrown for the previous index (2, 141) which is also a 'land' cell. To better understand this, some of the variable values that are fed to `shared_tools.get_weight_at_cell` are provided below for both index (2, 141) and (2, 142).

For index (2, 141):
```
stage_nbrs = array([[0.1152    , 0.12517995, 0.12517995],
       [0.1152    , 0.12517995, 0.12517995],
       [0.1152    , 0.12517995, 0.12517995]], dtype=float32)

depth_nbrs = array([[0.09119999, 0.10117994, 0.10117994],
       [0.0952    , 0.10517995, 0.10517995],
       [0.0992    , 0.10917994, 0.10917994]], dtype=float32)

ct_nbrs = array([[-2, -2, -2],
       [-2, -2, -2],
       [-2, -2, -2]])

self.stage[i,j] = 0.12517995

self.qx[i,j] = 0.0

self.qy[i,j] = 0.0
```

For index (2, 142)
```
stage_nbrs = array([[0.12517995, 0.12517995, 0.12517995],
       [0.12517995, 0.12517995, 0.12517995],
       [0.12517995, 0.12517995, 0.12026037]], dtype=float32)

depth_nbrs = array([[0.10117994, 0.10117994, 0.10117994],
       [0.10517995, 0.10517995, 0.10517995],
       [0.10917994, 0.10917994, 0.10426037]], dtype=float32)

ct_nbrs = array([[-2, -2, -2],
       [-2, -2, -2],
       [-2, -2, -2]])

self.stage[i,j] = 0.12517995

self.qx[i,j] = 0.0

self.qy[i,j] = 0.0
```

The significant difference boils down to the values in `depth_nbrs` which are acquired from the padded depth array in `water_tools.get_water_weight_array()`. Some of these values for index (2, 141) are actually below the `dry_depth` threshold of 0.1 while for index (2, 142), all `depth_nbrs` values are above 0.1. This ultimately leads to a difference within the `shared_tools.get_weight_at_cell()` function (after [this line](https://github.com/DeltaRCM/pyDeltaRCM/blob/dea1069cd70aa994c749d6a86f9533749e39e919/pyDeltaRCM/shared_tools.py#L188) is executed):

For index (2, 141):
```
weight[depth_nbrs <= dry_depth] = 0
array([ 0., nan, nan,  0., nan, nan,  0., nan, nan])
```

For index (2, 142):
```
weight[depth_nbrs <= dry_depth] = 0
array([nan, nan, nan, nan, nan, nan, nan, nan, nan])
```

Then when the final weight setting is being done in the if-else statement there is a division by zero issue for index (2, 142) that is not present for index (2, 141) because the weight array contains some 0 values. As we can see in the example above, this difference in 0 v `np.nan` values is stemming from the `depth_nbrs` v `dry_depth` relationship.

So while this small bugfix should alleviate the bug pointed out in #71, there is the question of whether this is the best way to handle the `np.nan` v 0 value in the weighting. There are likely other alternative formulations to get around this issue besides the one proposed here, and the alternative mentioned above involving the addition of another clause to the [if-else statement](https://github.com/DeltaRCM/pyDeltaRCM/blob/dea1069cd70aa994c749d6a86f9533749e39e919/pyDeltaRCM/shared_tools.py#L192), so of course I'm open to other solutions.