### PR TITLE
fix water and sediment routing onto land parcels

### DIFF
--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -125,7 +125,7 @@ def get_weight_at_cell(ind, weight_sfc, weight_int, depth_nbrs, ct_nbrs,
 
     weight = gamma * weight_sfc + (1 - gamma) * weight_int
     weight = depth_nbrs ** theta * weight
-    weight[depth_nbrs <= dry_depth] = 0
+    weight[drywall] = np.nan
 
     nanWeight = np.isnan(weight)
 


### PR DESCRIPTION
Main change is to change the replacement of "dry" cells to `weight == 0` into a `weight == np.nan`. 

This makes it so that sediment and water parcels are not routed onto land at any time.

**This change breaks the consistency tests.**

## bug source

The problem was that when a parcel landed up against the model "land" cells when the water surface was otherwise flat, the weights were determined to be zero everywhere, and so the returned probabilities from [`get_weight_at_cell()`](https://github.com/DeltaRCM/pyDeltaRCM/blob/2d5fd66dd07c952f323d682c2c2714af8b201434/pyDeltaRCM/shared_tools.py#L208) were all equal to 1/9. This is despite the fact that the probabilities should be `[0, 0, 0, 1/6, 1/6, 1/6, 1/6, 1/6, 1/6]`. This discrepency allowed the parcel to walk off into the "land" cells, and then sometimes eventually to out-of-bounds and raising and `IndexError` (see #75). 

The fix is to just not let sediment get onto the land at all. The [problematic line was](https://github.com/DeltaRCM/pyDeltaRCM/blob/2d5fd66dd07c952f323d682c2c2714af8b201434/pyDeltaRCM/shared_tools.py#L198):
```
weight[depth_nbrs <= dry_depth] = 0
```
which would replace the "land" cells (three `nan`s across the top) with `0`s, because the depth of the land cells was 0.
My fix was to change the index here to use the `drywall` index created above, which should capture *both* dry cells and "land" cells, and to make the new values `nan`s rather than `0`s, because this makes the returned probabilities `==0` for these `nan` cells. 

## a different potential fix
It may be worth noting at this time that the "original" pyDeltaRCM code [gave a very small chance of routing *sediment* onto dry parcels, and zero chance of routing them onto land](https://github.com/DeltaRCM/pyDeltaRCM/blob/2b1e9c68cfc7abe165e17ff09a44a46e8b9a3f16/pyDeltaRCM/deltaRCM_tools.py#L273):
```
weight[depth_ind <= self.dry_depth] = 0.0001
weight[cell_type_ind == -2] = np.nan
```
The *water* routing is a little more complicated, but I believe it [prevented parcels from entering dry cells or land cells whatsoever](https://github.com/DeltaRCM/pyDeltaRCM/blob/2b1e9c68cfc7abe165e17ff09a44a46e8b9a3f16/pyDeltaRCM/deltaRCM_tools.py#L733-L746). 
```
weight_sfc[(depth_ind <= self.dry_depth) | (ct_ind == -2)] = 0
weight_int[(depth_ind <= self.dry_depth) | (ct_ind == -2)] = 0

    ...        

self.weight = self.gamma * weight_sfc + (1 - self.gamma) * weight_int
self.weight = depth_ind ** self.theta_water * self.weight      
self.weight[depth_ind <= self.dry_depth] = np.nan
```

so, an alternative fix, to bring this back in line with the older codes, could be to pass another argument, which is `dry_depth_weight`, which would be `nan` or `0` for water, but `0.0001` for sediment.

thoughts?