### PR TITLE
Time additions to preprocessor

### DIFF
--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -34,6 +34,9 @@ There is a "high-level" model API, which takes as argument a YAML configuration 
 The "low-level" API consists of creating a model instance from a YAML configuration file and manually handling the timestepping, or optionally, augmenting operations of the model to implement new features.
 
 
+
+.. _high_level_api: 
+
 High-level model API
 ====================
 
@@ -91,11 +94,12 @@ Model simulation duration in the high-level API
 -----------------------------------------------
 
 The duration of a model run configured with the high-level API can be set up with a number of different configuration parameters.
-For more information on "time" in the model, see the complete description at :doc:`../info/modeltime`.
 
-In the high-level API, you can specify the duration to run the model by two mechanisms: 1) the number of timesteps to run the model, or 2) the duration of time to run the model.
+.. note:: see the complete description of "time" in the model: :doc:`../info/modeltime`.
 
-The former case is straightforward, insofar that the model determines the timestep duration and the high-level API simply iterates the model for the specified number of timestep iterations.
+Using the high-level API, you can specify the duration to run the model by two mechanisms: 1) the number of timesteps to run the model, or 2) the duration of time to run the model.
+
+The former case is straightforward, insofar that the model determines the timestep duration and the high-level API simply iterates for the specified number of timestep iterations.
 To specify the number of timesteps to run the model, use the argument ``--timesteps`` at the command line (or ``timesteps:`` in the configuration YAML file).
 
 .. code:: bash
@@ -103,6 +107,10 @@ To specify the number of timesteps to run the model, use the argument ``--timest
     pyDeltaRCM --config model_configuration.yml --timesteps 5000
 
 The second case is more complicated, because the time specification is converted to model time according to a set of additional parameters.
+In this case, the model run end condition is that the elapsed model time is *equal to or greater than* the specified input time. 
+Importantly, this means that the duration of the model run is unlikely to exactly match the input condition, because the model timestep is unlikely to be a factor of the specified time.
+Again, refer to the complete description of model time :doc:`../info/modeltime` for more information.
+
 To specify the duration of time to run the model in *seconds*, simply use the argument ``--time`` at the command line (or ``time:`` in the configuration YAML file).
 It is also possible to specify the input run duration in units of years with the similarly named argument ``--time_years`` (``time_years:``).
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -37,7 +37,7 @@ The "low-level" API consists of creating a model instance from a YAML configurat
 High-level model API
 ====================
 
-The high-level API is accessed via either a shell prompt or python script, and is invoked directly if a YAML configuration file includes the ``timesteps`` variable.
+The high-level API is accessed via either a shell prompt or python script, and handles setting up the model configuration and running the model a specified duration.
 
 For the following high-level API demonstrations, consider a YAML input file named ``model_configuration.yml`` which looks like:
 
@@ -64,7 +64,7 @@ or equivalently:
 
     python -m pyDeltaRCM --config model_configuration.yml
 
-These invokations will run the pyDeltaRCM :obj:`preprocessor <pyDeltaRCM.preprocessor.PreprocessorCLI>` with the parameters specified in the ``model_configuration.yml`` file.
+These invocations will run the pyDeltaRCM :obj:`preprocessor <pyDeltaRCM.preprocessor.PreprocessorCLI>` with the parameters specified in the ``model_configuration.yml`` file.
 If the YAML configuration indicates multiple jobs (:ref:`via matrix expansion or ensemble specification <configuring_multiple_jobs>`), the jobs will each be run automatically by calling :obj:`~pyDeltaRCM.DeltaModel.update` on the model 500 times.
 
 
@@ -85,6 +85,15 @@ Jobs are then run with:
 .. code::
 
     >>> pp.run_jobs()
+
+Model simulation duration in the high-level API
+-----------------------------------------------
+
+The duration of a model run configured with the high-level API can be set up with a number of different configuration parameters.
+For more information on "time" in the model, see the complete description at :doc:`../info/modeltime`.
+
+FINISH THIS
+
 
 
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -124,7 +124,8 @@ See :doc:`../info/modeltime` for complete information on the scaling between mod
 Low-level model API
 ===================
 
-iinteract with the model by creating your own script, and manipulating model outputs at the desired level. The simplest case is to do
+Interact with the model by creating your own script, and manipulating model outputs at the desired level.
+The simplest case to use the low-level API is to do
 
 .. code::
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -96,15 +96,15 @@ For more information on "time" in the model, see the complete description at :do
 In the high-level API, you can specify the duration to run the model by two mechanisms: 1) the number of timesteps to run the model, or 2) the duration of time to run the model.
 
 The former case is straightforward, insofar that the model determines the timestep duration and the high-level API simply iterates the model for the specified number of timestep iterations.
-To specify the number of timesteps to run the model, use the argument `--timesteps` at the command line (or `timesteps:` in the configuration YAML file).
+To specify the number of timesteps to run the model, use the argument ``--timesteps`` at the command line (or ``timesteps:`` in the configuration YAML file).
 
 .. code:: bash
     
     pyDeltaRCM --config model_configuration.yml --timesteps 5000
 
 The second case is more complicated, because the time specification is converted to model time according to a set of additional parameters.
-To specify the duration of time to run the model in *seconds*, simply use the argument `--time` at the command line (or `time:` in the configuration YAML file).
-It is also possible to specify the input run duration in units of years with the similarly named argument `--time_years` (`time_years:`).
+To specify the duration of time to run the model in *seconds*, simply use the argument ``--time`` at the command line (or ``time:`` in the configuration YAML file).
+It is also possible to specify the input run duration in units of years with the similarly named argument ``--time_years`` (``time_years:``).
 
 .. code:: bash
     
@@ -112,10 +112,13 @@ It is also possible to specify the input run duration in units of years with the
     pyDeltaRCM --config model_configuration.yml --time_years 1
 
 would each run a simulation for :math:`(86400 * 365.25)` seconds, or 1 year.
-Do not specify both time arguments, or specify time arguments with the timesteps argument.
-In the case of multiple argument specification, precedence is given in the order `timesteps` > `time` > `time_years`.
 
-When specifying the time to run the simulation, an additional parameter determining the intermittency factor (:math:`I_f`) may be specified `--If` at the command line (or `If:` in the YAML configuration file).
+.. important::
+
+    Do not specify both time arguments, or specify time arguments with the timesteps argument.
+    In the case of multiple argument specification, precedence is given in the order `timesteps` > `time` > `time_years`.
+
+When specifying the time to run the simulation, an additional parameter determining the intermittency factor (:math:`I_f`) may be specified ``--If`` at the command line (or ``If:`` in the YAML configuration file).
 This argument will scale the specified time-to-model-time, such that the *scaled time* is equal to the input argument time.
 Specifying the :math:`I_f`  value is essential when using the model duration run specifications.
 See :doc:`../info/modeltime` for complete information on the scaling between model time and elapsed simulation time.

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -86,15 +86,39 @@ Jobs are then run with:
 
     >>> pp.run_jobs()
 
+
 Model simulation duration in the high-level API
 -----------------------------------------------
 
 The duration of a model run configured with the high-level API can be set up with a number of different configuration parameters.
 For more information on "time" in the model, see the complete description at :doc:`../info/modeltime`.
 
-FINISH THIS
+In the high-level API, you can specify the duration to run the model by two mechanisms: 1) the number of timesteps to run the model, or 2) the duration of time to run the model.
 
+The former case is straightforward, insofar that the model determines the timestep duration and the high-level API simply iterates the model for the specified number of timestep iterations.
+To specify the number of timesteps to run the model, use the argument `--timesteps` at the command line (or `timesteps:` in the configuration YAML file).
 
+.. code:: bash
+    
+    pyDeltaRCM --config model_configuration.yml --timesteps 5000
+
+The second case is more complicated, because the time specification is converted to model time according to a set of additional parameters.
+To specify the duration of time to run the model in *seconds*, simply use the argument `--time` at the command line (or `time:` in the configuration YAML file).
+It is also possible to specify the input run duration in units of years with the similarly named argument `--time_years` (`time_years:`).
+
+.. code:: bash
+    
+    pyDeltaRCM --config model_configuration.yml --time 31557600
+    pyDeltaRCM --config model_configuration.yml --time_years 1
+
+would each run a simulation for :math:`(86400 * 365.25)` seconds, or 1 year.
+Do not specify both time arguments, or specify time arguments with the timesteps argument.
+In the case of multiple argument specification, precedence is given in the order `timesteps` > `time` > `time_years`.
+
+When specifying the time to run the simulation, an additional parameter determining the intermittency factor (:math:`I_f`) may be specified `--If` at the command line (or `If:` in the YAML configuration file).
+This argument will scale the specified time-to-model-time, such that the *scaled time* is equal to the input argument time.
+Specifying the :math:`I_f`  value is essential when using the model duration run specifications.
+See :doc:`../info/modeltime` for complete information on the scaling between model time and elapsed simulation time.
 
 
 Low-level model API

--- a/docs/source/info/modeltime.rst
+++ b/docs/source/info/modeltime.rst
@@ -2,8 +2,57 @@
 Time in pyDeltaRCM
 ******************
 
-Information on how "time" is handled in the model and how it may be translated
-to analogous "simulated time".
+Time in the pyDeltaRCM model is simulated in units of seconds.
+The duration of a timestep is determined during initialization to maintain numerical stability; the calculation is based on model domain and configuration parameters.
+The model is then iterated timestep by timestep, until and end-run condition is reached (see :doc:`../guides/userguide` for more information).
 
-.. note::
-   Incomplete.
+Over the duration of the model, the water discharge (and thus sediment discharge) are assumed to be at bankfull.
+This assumption is based on the concept of geomorphic work [WM60]_ and the strongly nonlinear relationship between water discharge and sediment transport.
+To summarize the basis of this assumption, a very small proportion of sediment is in motion when discharge is at or near a low-flow "base flow" condition, relative to the amount of sediment in motion during flood conditions.
+So while flooding only occurs for a small fraction of total time, most of the time-integrated sediment transport occurs during this fraction of time, and the remainder of time is deemed negligible in comparison.
+
+For example, in the contrived river-delta hydrograph shown below, the discharge fluctuates around a base-flow condition for most of the year, with the exception of a 50 day period when a flood event occurs (from "start event" to "end event").
+For 25 days of the flood event, the discharge is high enough to exceed the bankfull discharge ("flooding duration").
+
+.. plot:: modeltime/one_year_plot.py
+
+A numerical model could simulate every day of this hydrograph, but this would require substantial computing power.
+To accelerate the computation time of models, we assume that the only important period of time is when the river is at-or-above bankfull discharge, and we collapse the hydrograph to a single value: the bankfull discharge.
+The choice of bankfull discharge for the single-value discharge assumption is a matter of convenience, in that this is readily estimated from field data or measurements.
+
+The duration of time represented by the single-value discharge assumption is also  determined by the hydrograph.
+We arrive at the so-called *intermittency factor* (:math:`I_f`) by finding the fraction of unit-time per unit-time when the river is in flood.
+For this example, the intermittency factor scales between days and years as 
+
+.. math::
+
+    \frac{25~\textrm{days}}{365.25~\textrm{days}} \approx 0.07 \equiv I_f
+
+The intermittency factor thus gives a relationship to scale pyDeltaRCM model time (which is always computed in units of seconds elapsed) from seconds to years.
+For example, for a model run that has elapsed :math:`4.32 \times 10^8` seconds and an assumed intermittency factor of 0.07:
+
+.. math::
+
+    \frac{\textrm{seconds~elapsed}}{I_f} = \frac{4.32 \times 10^8~\textrm{seconds}}{0.07} = 6.17 \times 10^9~\textrm{seconds} \approx 196~\textrm{years}
+
+.. note:: A convenience function is supplied with the low-level API for these time conversions: :obj:`~pyDeltaRCM.shared_tools.scale_model_time`.
+
+Applying the intermittency assumption to a four year model simulation reveals the computational advantage of this approach.
+A simulation of every day in the simulation duration would require 1460 days of simulated time (:math:`1.26 \times 10^8` seconds).
+
+.. plot:: modeltime/four_year_plot.py
+
+In contrast, by condensing the simulated time down to a bankfull discharge only, the intermittency assumption allows us to simulate the same "four year" period in just under 59 days of simulated time (:math:`5.08 \times 10^6` seconds).
+
+
+See also
+--------
+
+* :obj:`~pyDeltaRCM.preprocessor.scale_relative_sea_level_rise_rate`
+* :obj:`~pyDeltaRCM.shared_tools.scale_model_time`
+
+
+References
+----------
+
+.. [WM60] Wolman, M. G., & Miller, J. P. (1960). Magnitude and frequency of forces in geomorphic processes. The Journal of Geology, 68(1), 54–74. https://doi.org/10.1086/626637

--- a/docs/source/info/modeltime.rst
+++ b/docs/source/info/modeltime.rst
@@ -3,8 +3,14 @@ Time in pyDeltaRCM
 ******************
 
 Time in the pyDeltaRCM model is simulated in units of seconds.
-The duration of a timestep is determined during initialization to maintain numerical stability; the calculation is based on model domain and configuration parameters.
-The model is then iterated timestep by timestep, until and end-run condition is reached (see :doc:`../guides/userguide` for more information).
+The duration of a timestep is determined during model initialization to maintain numerical stability; the calculation is based on model domain and configuration parameters.
+The model is then iterated timestep by timestep, until an end-run condition is reached 
+
+.. note:: 
+    
+    If you are using the :ref:`high-level API <high_level_api>`, the model run end condition is that the elapsed model time is *equal to or greater than* the specified input time. As a result, the model run duration is unlikely to exactly match the input time specification, because the model timestep is unlikely to be a factor of the specified time. 
+
+    Please keep this in mind when evaluating model results, and especially when comparing  between different model runs.
 
 Over the duration of the model, the water discharge (and thus sediment discharge) are assumed to be at bankfull.
 This assumption is based on the concept of geomorphic work [WM60]_ and the strongly nonlinear relationship between water discharge and sediment transport.

--- a/docs/source/pyplots/modeltime/_base.py
+++ b/docs/source/pyplots/modeltime/_base.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+time = np.arange(365)
+hydrograph = np.ones((len(time),)) + \
+    (np.random.uniform(size=(len(time),)) / 10)
+hydrograph[100:150] = 2 + np.sin(np.arange(15, 65) / 15)
+flood = hydrograph >= 2.5

--- a/docs/source/pyplots/modeltime/four_year_condensed_plot.py
+++ b/docs/source/pyplots/modeltime/four_year_condensed_plot.py
@@ -1,0 +1,29 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+import _base
+
+
+fig, ax = plt.subplots(figsize=(8, 2))
+plt.subplots_adjust(top=0.7)
+
+nflood = np.sum(_base.flood)
+day = 0
+for i in range(4):
+    ax.axvline(x=day, color='k', ls='-')
+    ax.fill_between(day + np.arange(nflood + 1), np.zeros((nflood + 1,)),
+                    4 * np.ones((nflood + 1,)),
+                    alpha=0.4, edgecolor='none')
+    ax.plot(day + np.arange(nflood + 1), 2.5 * np.ones((nflood + 1),))
+    day += nflood
+
+ax.axvline(x=day, color='k', ls='-')
+ax.set_ylim(0.9, 3.1)
+ax.set_xlim(0 - 10, 365 * 4 + 10)
+ax.set_yticks([])
+ax.set_xlabel(r'time $\rightarrow$')
+ax.set_yticks([1.05, 2.5])
+ax.set_yticklabels(['base flow', 'bankfull flow'])
+
+plt.show()

--- a/docs/source/pyplots/modeltime/four_year_plot.py
+++ b/docs/source/pyplots/modeltime/four_year_plot.py
@@ -1,0 +1,49 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+import _base
+
+
+fig, ax = plt.subplots(2, 1, figsize=(8, 4), sharex=True)
+# plt.subplots_adjust(top=0.7)
+
+
+day = 0
+for i in range(4):
+    ax[0].axvline(x=day, color='k', ls='-')
+    ax[0].fill_between(day + np.arange(365), np.zeros((len(_base.time),)),
+                    4 * np.ones((len(_base.time),)),
+                    where=_base.flood, alpha=0.4, edgecolor='none')
+    ax[0].plot(day + np.arange(365), _base.hydrograph)
+    ax[0].text(day + 220, 2.6, 'year ' + str(i))
+    day += 365
+
+ax[0].axvline(x=day, color='k', ls='-')
+ax[0].set_ylim(0.9, 3.1)
+ax[0].set_xlim(0 - 10, day + 10)
+ax[0].set_xlabel(r'time $\rightarrow$')
+ax[0].set_yticks([1.05, 2.5])
+ax[0].set_yticklabels(['base flow', 'bankfull flow'])
+
+
+nflood = np.sum(_base.flood)
+day = 0
+for i in range(4):
+    ax[1].axvline(x=day, color='k', ls='-')
+    ax[1].fill_between(day + np.arange(nflood + 1), np.zeros((nflood + 1,)),
+                    4 * np.ones((nflood + 1,)),
+                    alpha=0.4, edgecolor='none')
+    ax[1].plot(day + np.arange(nflood + 1), 2.5 * np.ones((nflood + 1),))
+    day += nflood
+
+ax[1].axvline(x=day, color='k', ls='-')
+ax[1].set_ylim(0.9, 3.1)
+ax[1].set_xlim(0 - 10, 365 * 4 + 10)
+ax[1].set_yticks([])
+ax[1].set_xlabel(r'time $\rightarrow$')
+ax[1].set_yticks([1.05, 2.5])
+ax[1].set_yticklabels(['base flow', 'bankfull flow'])
+
+
+plt.show()

--- a/docs/source/pyplots/modeltime/one_year_plot.py
+++ b/docs/source/pyplots/modeltime/one_year_plot.py
@@ -1,0 +1,28 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import _base
+
+fig, ax = plt.subplots()
+plt.subplots_adjust(left=0.2)
+ax.plot(_base.time, _base.hydrograph)
+ax.axhline(y=2.5, color='k', ls='--')
+ax.fill_between(np.arange(365), 2.5 * np.ones((len(_base.time),)),
+                _base.hydrograph, where=_base.flood, alpha=0.4)
+ax.set_yticks([1.05, 2.5])
+ax.set_yticklabels(['base flow', 'bankfull flow'])
+ax.set_xlabel('calendar day')
+ax.set_ylim(0.9, 3.1)
+
+bbox = dict(boxstyle="round", fc="0.8")
+_cs0 = "angle,angleA=-10,angleB=-60,rad=10"
+ax.annotate('start event', xy=(95, 1.1), xytext=(0, 1.4),
+            bbox=bbox, arrowprops=dict(arrowstyle="->", connectionstyle=_cs0))
+_cs1 = "angle,angleA=10,angleB=60,rad=10"
+ax.annotate('end event', xy=(150, 1.1), xytext=(170, 1.4),
+            bbox=bbox, arrowprops=dict(arrowstyle="->", connectionstyle=_cs1))
+_cs2 = "angle,angleA=-10,angleB=60,rad=10"
+ax.annotate('flooding duration', xy=(110, 2.7), xytext=(150, 2.7),
+            bbox=bbox, arrowprops=dict(arrowstyle="->", connectionstyle=_cs2))
+
+plt.show()

--- a/docs/source/reference/preprocessor/index.rst
+++ b/docs/source/reference/preprocessor/index.rst
@@ -20,9 +20,9 @@ Preprocessor classes and API
     Preprocessor
     BasePreprocessor
 
-
 Preprocessor function and utilities
 -----------------------------------
 
 .. autofunction:: preprocessor_wrapper
 .. autofunction:: write_yaml_config_to_file
+.. autofunction:: scale_relative_sea_level_rise_rate

--- a/docs/source/reference/shared_tools/index.rst
+++ b/docs/source/reference/shared_tools/index.rst
@@ -24,3 +24,10 @@ Shared functions
 .. autofunction:: get_weight_sfc_int
 .. autofunction:: get_weight_at_cell
 .. autofunction:: _get_version
+
+
+Time scaling functions
+----------------------
+
+.. autofunction:: scale_model_time
+.. autofunction:: _scale_factor

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -400,6 +400,24 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._SLR = SLR
 
     @property
+    def If(self):
+        """
+        Intermittency factor converting model time to real-world time.
+
+        .. important::
+
+            This parameter has no effect on model operations. It is used in
+            determining model run duration.
+        """
+        return self._If
+
+    @If.setter
+    def If(self, If):
+        if (If <= 0) or (If > 1):
+            raise ValueError('If must in interval (0, 1].')
+        self._If = If
+
+    @property
     def Np_sed(self):
         """
         Np_sed is the number of sediment parcels simulated.

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -414,7 +414,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @If.setter
     def If(self, If):
         if (If <= 0) or (If > 1):
-            raise ValueError('If must in interval (0, 1].')
+            raise ValueError('If must be in interval (0, 1].')
         self._If = If
 
     @property

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -525,6 +525,52 @@ def write_yaml_config_to_file(_config, _path):
     f.close()
 
 
+def scale_relative_sea_level_rise_rate(mmyr, If=1):
+    """Scale a relative sea level rise rate to model time.
+
+    This function scales any relative sea level rise rate (RSLR) (e.g., sea
+    level rise, subsidence) to a rate appropriate for the model time. This is
+    helpful, because most discussion of RSLR uses units of mm/yr, but the
+    model (and model configuration) require units of m/s. Additionally, the
+    model framework needs to assume an "intermittency factor" to convert from
+    real-world time to model time.
+
+    Relative sea level rise (subsidence and/or sea level rise) are scaled from
+    real world dimensions of mm/yr to model input as:
+
+    .. math::
+
+        \widehat{RSLR} = (RSLR / 1000) \cdot \dfrac{1}{I_f \cdot 365.25 \cdot 86400}
+
+    This conversion makes it such that when one real-world year has elapsed
+    (:math:`I_f \cdot 365.25 \cdot 86400` seconds in model time), the relative
+    sea level has changed by the number of millimeters specified in the input
+    :obj:`mmyr`.
+
+    .. note::
+
+        Users should use this function to determine the value to specify in
+        an input YAML configuration file; no scaling is performed
+        internally.
+
+    Parameters
+    ----------
+    mmyr : :obj:`float`
+        Millimeters per year, relative sea level rise rate.
+
+    If : :obj:`float`, optional
+        Intermittency factor, fraction of time represented by morphodynamic
+        activity. Should be in interval (0, 1). Defaults to 1 if not provided,
+        i.e., no scaling is performed.
+
+    Returns
+    -------
+    scaled : :obj:`float`
+        Scaled relative sea level rise rate, in meters per second.
+    """
+    return (mmyr / 1000) * (1 / (shared_tools._scale_factor(If)))
+
+
 if __name__ == '__main__':
 
     preprocessor_wrapper()

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -31,7 +31,7 @@ class BasePreprocessor(abc.ABC):
 
     """
 
-    def extract_yaml_config(self):
+    def preliminary_yaml_parsing(self):
         """Preliminary YAML parsing.
 
         Extract ``.yml`` file (``self.input_file``) into a dictionary, if
@@ -47,48 +47,34 @@ class BasePreprocessor(abc.ABC):
         """
         # open the file, an error will be thrown if invalid yaml?
         user_file = open(self.input_file, mode='r')
-        self.user_dict = yaml.load(user_file, Loader=yaml.FullLoader)
+        self.yaml_dict = yaml.load(user_file, Loader=yaml.FullLoader)
         user_file.close()
 
-        if 'ensemble' in self.user_dict.keys():
+        if 'ensemble' in self.yaml_dict.keys():
             self._has_ensemble = True
-            self.expand_ensemble()
+            self.expand_yaml_ensemble()
 
-        if 'matrix' in self.user_dict.keys():
+        if 'matrix' in self.yaml_dict.keys():
             self._has_matrix = True
         else:
             self._has_matrix = False
 
-        if 'verbose' in self.user_dict.keys():
-            self.verbose = self.user_dict['verbose']
+        if 'verbose' in self.yaml_dict.keys():
+            self.verbose = self.yaml_dict['verbose']
         else:
             self.verbose = 0
 
-    def expand_ensemble(self):
-        """Create ensemble random seeds and put into matrix.
+        return self.yaml_dict
 
-        Seed the yaml configuration based on the number of ensembles specified.
-        If matrix exists add seeds there, if not, create matrix and add seeds.
+    def _create_matrix(self):
+        """Create a matrix if not already in the yaml.
+
+        Note that this is only needed for ensemble expansion.
         """
-        if self._has_ensemble:
-            # ensemble must be integer - check if valid
-            _ensemble = self.user_dict.pop('ensemble')
-            if not isinstance(_ensemble, int):
-                raise TypeError('Invalid ensemble type, must be an integer.')
-
-            # if matrix does not exist, then it must be created
-            if 'matrix' not in self.user_dict.keys():
-                self.create_matrix()
-
-            # then the seed values must be added to the matrix
-            self.seed_matrix(_ensemble)
-
-    def create_matrix(self):
-        """Create a matrix if not already in the yaml."""
         _matrix = dict()
-        self.user_dict['matrix'] = _matrix
+        self.yaml_dict['matrix'] = _matrix
 
-    def seed_matrix(self, n_ensembles):
+    def _seed_matrix(self, n_ensembles):
         """Generate random integers to be used as seeds for ensemble runs.
 
         Parameters
@@ -97,7 +83,7 @@ class BasePreprocessor(abc.ABC):
             Number of ensembles which is the number of seeds to generate.
 
         """
-        _matrix = self.user_dict.pop('matrix')
+        _matrix = self.yaml_dict.pop('matrix')
         if not isinstance(_matrix, dict):
             raise ValueError(
                 'Invalid matrix specification, was not evaluated to "dict".')
@@ -113,7 +99,7 @@ class BasePreprocessor(abc.ABC):
 
         # add list of random seeds to the matrix
         _matrix['seed'] = seed_list
-        self.user_dict['matrix'] = _matrix
+        self.yaml_dict['matrix'] = _matrix
 
     def write_yaml_config(self, i, ith_config, ith_dir, ith_id):
         """Write full config to file in output folder.
@@ -130,21 +116,40 @@ class BasePreprocessor(abc.ABC):
         write_yaml_config_to_file(ith_config, ith_p)
         return ith_p
 
+    def expand_yaml_ensemble(self):
+        """Create ensemble random seeds and put into matrix.
+
+        Seed the yaml configuration based on the number of ensembles specified.
+        If matrix exists add seeds there, if not, create matrix and add seeds.
+        """
+        if self._has_ensemble:
+            # ensemble must be integer - check if valid
+            _ensemble = self.yaml_dict.pop('ensemble')
+            if not isinstance(_ensemble, int):
+                raise TypeError('Invalid ensemble type, must be an integer.')
+
+            # if matrix does not exist, then it must be created
+            if 'matrix' not in self.yaml_dict.keys():
+                self._create_matrix()
+
+            # then the seed values must be added to the matrix
+            self._seed_matrix(_ensemble)
+
     def expand_yaml_matrix(self):
         """Expand YAML matrix, if given.
 
-        Compute the matrix expansion.
+        Compute the matrix expansion of parameters listed in `matrix` key.
 
         """
         if self._has_matrix:
             # extract and remove 'matrix' from config
-            _matrix = self.user_dict.pop('matrix')
+            _matrix = self.yaml_dict.pop('matrix')
 
             # check validity of matrix specs
             if not isinstance(_matrix, dict):
                 raise ValueError(
                     'Invalid matrix specification, was not evaluated to "dict".')
-            if 'out_dir' not in self.user_dict.keys():
+            if 'out_dir' not in self.yaml_dict.keys():
                 raise ValueError(
                     'You must specify "out_dir" in YAML to use matrix expansion.')
             if 'out_dir' in _matrix.keys():
@@ -162,7 +167,7 @@ class BasePreprocessor(abc.ABC):
                 if ':' in k:
                     raise ValueError(
                         'Colon operator found in matrix expansion key.')
-                if k in self.user_dict.keys():
+                if k in self.yaml_dict.keys():
                     raise ValueError(
                         'You cannot specify the same key in the matrix '
                         'configuration and fixed configuration. '
@@ -175,7 +180,7 @@ class BasePreprocessor(abc.ABC):
             pts = [len(l) for l in lil]
             jobs = np.prod(pts)
             _combs = list(itertools.product(*lil))  # actual matrix expansion
-            _fixed_config = self.user_dict.copy()  # fixed config dict to expand on
+            _fixed_config = self.yaml_dict.copy()  # fixed config dict to expand on
 
             if self.verbose > 0:
                 print(('Matrix expansion:\n' +
@@ -183,7 +188,7 @@ class BasePreprocessor(abc.ABC):
                        '  jobs {_jobs}').format(_dims=dims, _jobs=jobs))
 
             # create directory at root
-            jobs_root = self.user_dict['out_dir']  # checked above for exist
+            jobs_root = self.yaml_dict['out_dir']  # checked above for exist
             p = Path(jobs_root)
             try:
                 p.mkdir()
@@ -203,27 +208,6 @@ class BasePreprocessor(abc.ABC):
                 ith_p = self.write_yaml_config(i, _ith_config, ith_dir, ith_id)
                 self.file_list.append(ith_p)
 
-    def extract_timesteps(self):
-        """Pull timestep from arg and YAML.
-
-        Extract the `timesteps` parameter from the arguments line and YAML
-        configuration. The arguments line may come from either the command
-        line as ``--timesteps=N`` or in the python API as ``timesteps=N``,
-        where ``N`` is the number of timesteps.
-
-        """
-        if hasattr(self, 'arg_timesteps'):
-            # overrides everything else
-            self.timesteps = self.arg_timesteps
-
-        if not hasattr(self, 'timesteps'):
-            if 'timesteps' in self.user_dict.keys():
-                self.timesteps = self.user_dict['timesteps']
-            else:
-                raise ValueError('You must specify timesteps in either the '
-                                 'YAML configuration file or via the --timesteps '
-                                 'CLI flag, in order to use the high-level API.')
-
     def construct_job_list(self):
         """Construct the job list.
 
@@ -238,8 +222,8 @@ class BasePreprocessor(abc.ABC):
             for i in range(len(self.file_list)):
                 try:
                     self.job_list.append(self._Job(self.file_list[i],
-                                                   yaml_timesteps=self.yaml_timesteps,
-                                                   arg_timesteps=self.arg_timesteps))
+                                                   cli_dict=self.cli_dict,
+                                                   yaml_dict=self.yaml_dict))
                 except TypeError as e:
                     raise TypeError(
                         'During job instantiation, one of the model '
@@ -253,8 +237,8 @@ class BasePreprocessor(abc.ABC):
         else:
             # there's only one job so append directly.
             self.job_list.append(self._Job(self.input_file,
-                                           yaml_timesteps=self.yaml_timesteps,
-                                           arg_timesteps=self.arg_timesteps))
+                                           cli_dict=self.cli_dict,
+                                           yaml_dict=self.yaml_dict))
 
     def run_jobs(self):
         """Run the set of jobs.
@@ -280,34 +264,41 @@ class BasePreprocessor(abc.ABC):
             job.finalize_model()
 
     class _Job(object):
+        """Class for individual jobs to run.
 
-        def __init__(self, input_file, yaml_timesteps, arg_timesteps):
+        This class handles setting options for its own run time duration.
+
+        You probably don't need to interact with this class directly.
+        """
+
+        def __init__(self, input_file, cli_dict, yaml_dict):
             """Initialize a job.
 
-            All arguments are required, but either the ``yaml_timesteps`` or
-            ``arg_timesteps`` can be `None`.
-
-            The ``input_file`` argument is passed to the DeltaModel for
+            The `input_file` argument is passed to the DeltaModel for
             instantiation.
 
-            The ``timesteps`` value is selected from either of the timestep
-            input arguments, *but the YAML input will override an argument
-            values.
+            The various model run duration parameters are passed from the
+            `cli_dict` and `yaml_dict` arguments, and are processed into a
+            single value for the run time. Precedence is given to values specified in the 
             """
             self.deltamodel = DeltaModel(input_file=input_file)
 
-            # determine the timestep from the two arguments given. Either the
-            # yaml file or the arguments should include the timesteps
-            # argument.
-            if yaml_timesteps:
-                _timesteps = yaml_timesteps
-            elif arg_timesteps:
-                _timesteps = arg_timesteps
+            self.timesteps = ('timesteps', cli_dict, yaml_dict)
+            self.time = ('time', cli_dict, yaml_dict)
+            self.time_years = ('time_years', cli_dict, yaml_dict)
+            self.If = ('If', cli_dict, yaml_dict)
+
+            # determine job end time, *in model time*
+            if not (self.timesteps is None):
+                self._job_end_time = (self.timesteps * self.deltamodel._dt)
+            elif not (self.time is None):
+                self._job_end_time = (self.time) * self.If
+            elif not (self.time_years is None):
+                self._job_end_time = (self.time_years) * self.If * 86400 * 365.25
             else:
-                raise ValueError('You must specify timesteps in either the '
-                                 'YAML configuration file or via the timesteps '
-                                 'argument, in order to use the high-level API.')
-            self.timesteps = _timesteps
+                raise ValueError(
+                    'You must specify a run duration configuration in either '
+                    'the input YAML file or via input arguments.')
 
             self._is_completed = False
 
@@ -317,13 +308,77 @@ class BasePreprocessor(abc.ABC):
             Iterate the timestep ``update`` routine for the specified number of
             iterations.
             """
-            for _ in range(self.timesteps):
+            while self.deltamodel._time < self._job_end_time:
                 self.deltamodel.update()
 
         def finalize_model(self):
             """Finalize the job."""
             self.deltamodel.finalize()
             self._is_completed = True
+
+        def _optional_input(self, argument, cli_dict=None, yaml_dict=None,
+                            default=None):
+            """
+            Processor function to be used on all the optional choices,
+            for determining the hierachy of options and setting a single
+            value.
+
+            Hierarchy is to use CLI/preprocessor options first, then yaml.
+
+            Both inputs should be `dict`!
+
+            If default is not `None`, this value is used if no parameter
+            specified in the cli or yaml.
+            """
+            if argument in cli_dict.keys() and not (cli_dict[argument] is None):
+                return float(cli_dict[argument])
+            elif argument in yaml_dict.keys():
+                return float(yaml_dict[argument])
+            elif not (default is None):
+                return default
+            else:
+                return None
+
+        @property
+        def timesteps(self):
+            return self._timesteps
+
+        @timesteps.setter
+        def timesteps(self, arg_tuple):
+            _timesteps = self._optional_input(
+                arg_tuple[0], cli_dict=arg_tuple[1], yaml_dict=arg_tuple[2])
+            self._timesteps = _timesteps
+
+        @property
+        def time(self):
+            return self._time
+
+        @time.setter
+        def time(self, arg_tuple):
+            _time = self._optional_input(
+                arg_tuple[0], cli_dict=arg_tuple[1], yaml_dict=arg_tuple[2])
+            self._time = _time
+
+        @property
+        def time_years(self):
+            return self._time_years
+
+        @time_years.setter
+        def time_years(self, arg_tuple):
+            _time_years = self._optional_input(
+                arg_tuple[0], cli_dict=arg_tuple[1], yaml_dict=arg_tuple[2])
+            self._time_years = _time_years
+
+        @property
+        def If(self):
+            return self._If
+
+        @If.setter
+        def If(self, arg_tuple):
+            _If = self._optional_input(
+                arg_tuple[0], cli_dict=arg_tuple[1], yaml_dict=arg_tuple[2],
+                default=1)
+            self._If = _If
 
 
 class PreprocessorCLI(BasePreprocessor):
@@ -357,30 +412,18 @@ class PreprocessorCLI(BasePreprocessor):
 
         self.process_arguments()
 
-        if self.args['config']:
-            self.input_file = self.args['config']
-            self.extract_yaml_config()
+        if self.cli_dict['config']:
+            self.input_file = self.cli_dict['config']
+            self.preliminary_yaml_parsing()
         else:
             self.verbose = 0  # no verbosity by defauly
             self.input_file = None
-            self.user_dict = {}
+            self.yaml_dict = {}
             self._has_matrix = False
-
-        if self.args['timesteps']:
-            self.arg_timesteps = int(self.args['timesteps'])
-        else:
-            self.arg_timesteps = None
-
-        if 'timesteps' in self.user_dict.keys():
-            self.yaml_timesteps = self.user_dict['timesteps']
-        else:
-            self.yaml_timesteps = None
-
-        self.extract_timesteps()
 
         self.construct_job_list()
 
-        if self.args['dryrun']:
+        if self.cli_dict['dryrun']:
             self._dryrun = True
         else:
             self._dryrun = False
@@ -397,21 +440,41 @@ class PreprocessorCLI(BasePreprocessor):
         parser = argparse.ArgumentParser(
             description='Arguments for running pyDeltaRCM from command line')
 
-        parser.add_argument('--config',
-                            help='Path to a config file that you would like to use.')
-        parser.add_argument('--timesteps',
-                            help='Number of timesteps to run model defined '
-                                 'in config file. Optional, and if provided, '
-                                 'will override any value in the config file.')
-        parser.add_argument('--dryrun', action='store_true',
-                            help='Boolean indicating whether to execute '
-                                 ' timestepping or only set up the run.')
-        parser.add_argument('--version', action='version',
-                            version=_ver, help='Print pyDeltaRCM version.')
+        parser.add_argument(
+            '--config', help='Path to a config file that you would like '
+            'to use.')
+        parser.add_argument(
+            '--timesteps', help='Number of timesteps to run model. Optional, '
+            'and if provided, will override any value in the config file. '
+            'Is overrided by "time" options.')
+        parser.add_argument(
+            '--time', help='Time to run the model until, in seconds.'
+            'Time is scaled due to intermittency, which is set to 1 by '
+            'default (i.e., no scaling). See options "If" or "time_years" '
+            'for other specification options. Optional, '
+            'and if provided, will override any value in the config file.')
+        parser.add_argument(
+            '--time_years', help='Time to run the model until, in years.'
+            'Time is scaled due to intermittency, which is set to 1 by '
+            'default (i.e., no scaling). See options "If" or "time" '
+            'for other specification options. Optional, '
+            'and if provided, will override any value in the config file.')
+        parser.add_argument(
+            '--If', help='Assumed intermittency factor for converting model '
+            'time to real-world time. This is a value in (0, 1] representing '
+            'the fraction of days per year that the delta is flooding. '
+            'Optional, default value is 1.')
+        parser.add_argument(
+            '--dryrun', action='store_true',
+            help='Boolean indicating whether to execute timestepping or only '
+            'set up the run.')
+        parser.add_argument(
+            '--version', action='version',
+            version=_ver, help='Print pyDeltaRCM version.')
 
         args = parser.parse_args()
 
-        self.args = vars(args)
+        self.cli_dict = vars(args)
 
 
 class Preprocessor(BasePreprocessor):
@@ -437,7 +500,7 @@ class Preprocessor(BasePreprocessor):
 
     """
 
-    def __init__(self, input_file=None, timesteps=None):
+    def __init__(self, input_file=None, **kwargs):
         """Initialize the python preprocessor.
 
         The initialization includes the entire configuration of the job list
@@ -463,28 +526,18 @@ class Preprocessor(BasePreprocessor):
         super().__init__()
         self._dryrun = False
 
-        if not input_file and not timesteps:
+        if not input_file and len(kwargs.keys()) == 0:
             raise ValueError('Cannot use Preprocessor with no arguments.')
 
         if input_file:
             self.input_file = input_file
-            self.extract_yaml_config()
+            self.preliminary_yaml_parsing()
         else:
             self.input_file = None
-            self.user_dict = {}
+            self.yaml_dict = {}
             self._has_matrix = False
 
-        if timesteps:
-            self.arg_timesteps = int(timesteps)
-        else:
-            self.arg_timesteps = None
-
-        if 'timesteps' in self.user_dict.keys():
-            self.yaml_timesteps = self.user_dict['timesteps']
-        else:
-            self.yaml_timesteps = None
-
-        self.extract_timesteps()
+        self.cli_dict = kwargs
 
         self.construct_job_list()
 

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -279,7 +279,8 @@ class BasePreprocessor(abc.ABC):
 
             The various model run duration parameters are passed from the
             `cli_dict` and `yaml_dict` arguments, and are processed into a
-            single value for the run time. Precedence is given to values specified in the 
+            single value for the run time. Precedence is given to values
+            specified in the command line interface.
             """
             self.deltamodel = DeltaModel(input_file=input_file)
 
@@ -621,7 +622,8 @@ def scale_relative_sea_level_rise_rate(mmyr, If=1):
     scaled : :obj:`float`
         Scaled relative sea level rise rate, in meters per second.
     """
-    return (mmyr / 1000) * (1 / (shared_tools._scale_factor(If)))
+    return (mmyr / 1000) * (1 / (shared_tools._scale_factor(
+        If, units='years')))
 
 
 if __name__ == '__main__':

--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -155,9 +155,9 @@ def scale_model_time(time, If=1, units='seconds'):
     implicitly assumes that the delta is *always* receiving a large volume of
     sediment and water at the inlet. This is unrealistic, given that rivers
     flood only during a small portion of the year, and this is when
-    morphodynamic activity is largest. See :doc:`modeltime` for a complete
-    description of this assumption, and how to work with the assumption in
-    configuring the model.
+    morphodynamic activity is largest. See :doc:`../../info/modeltime` for a
+    complete description of this assumption, and how to work with the
+    assumption in configuring the model.
 
     Using this assumption, it is possible to scale up model time to "real"
     time, by assuming an *intermittency factor*. This intermittency factor is
@@ -170,7 +170,8 @@ def scale_model_time(time, If=1, units='seconds'):
     where :math:`t` is the model time (:obj:`~pyDeltaRCM.DeltaModel.time`),
     :math:`t_r` is the "real" scaled time, :math:`I_f` is the
     intermittency factor, and :math:`S_f` is the scale factor to convert base
-    units of seconds to units specified as an input argument.
+    units of seconds to units specified as an input argument. Note that this
+    function uses :obj:`_scale_factor` internally for this conversion.
 
     Parameters
     ----------
@@ -179,7 +180,7 @@ def scale_model_time(time, If=1, units='seconds'):
 
     If : :obj:`float`, optional
         Intermittency factor, fraction of time represented by morphodynamic
-        activity. Should be in interval (0, 1). Defaults to 1 if not provided,
+        activity. Should be in interval (0, 1]. Defaults to 1 if not provided,
         i.e., no scaling is performed.
 
     units : :obj:`str`, optional
@@ -208,8 +209,19 @@ def scale_model_time(time, If=1, units='seconds'):
 def _scale_factor(If, units):
     """Scaling factor between model time and "real" time.
 
-    The scaling factor relates the model time to a real worl time, by assuming
-    an intermittency factor.
+    The scaling factor relates the model time to a real worl time, by the
+    assumed intermittency factor and the user-specified units for output.
+
+    Parameters
+    ----------
+    If : :obj:`float`
+        Intermittency factor, fraction of time represented by morphodynamic
+        activity. **Must** be in interval (0, 1].
+
+    units : :obj:`str`
+        The units to convert the scaled time to. Must be a string in
+        `['seconds', 'days', 'years']`.
+
     """
     sec_in_day = 86400
     day_in_yr = 365.25

--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -147,7 +147,7 @@ def _get_version():
     return _version.__version__()
 
 
-def scale_model_time(time, If=1):
+def scale_model_time(time, If=1, units='seconds'):
     """Scale the model time to "real" time.
 
     Model time is executed as assumed flooding conditions, and executed at the
@@ -155,20 +155,22 @@ def scale_model_time(time, If=1):
     implicitly assumes that the delta is *always* receiving a large volume of
     sediment and water at the inlet. This is unrealistic, given that rivers
     flood only during a small portion of the year, and this is when
-    morphodynamic activity is largest.
+    morphodynamic activity is largest. See :doc:`modeltime` for a complete
+    description of this assumption, and how to work with the assumption in
+    configuring the model.
 
-    Despite this assumption, it is possible to scale up model time to "real"
+    Using this assumption, it is possible to scale up model time to "real"
     time, by assuming an *intermittency factor*. This intermittency factor is
-    the fraction of time, scaled to 1 year, when the delta system is assumed
-    to be flooding.
+    the fraction of unit-time that a river is assumed to be flooding.
 
     .. math::
 
-        t_r = \dfrac{t}{I_f \cdot 365.25 \cdot 86400}
+        t_r = \dfrac{t}{I_f \cdot S_f}
 
     where :math:`t` is the model time (:obj:`~pyDeltaRCM.DeltaModel.time`),
-    :math:`t_r` is the "real" scaled time, and :math:`I_f` is the
-    intermittency factor.
+    :math:`t_r` is the "real" scaled time, :math:`I_f` is the
+    intermittency factor, and :math:`S_f` is the scale factor to convert base
+    units of seconds to units specified as an input argument.
 
     Parameters
     ----------
@@ -180,27 +182,43 @@ def scale_model_time(time, If=1):
         activity. Should be in interval (0, 1). Defaults to 1 if not provided,
         i.e., no scaling is performed.
 
+    units : :obj:`str`, optional
+        The units to convert the scaled time to. Default is to return the
+        scaled time in seconds (`seconds`), but optionally supply argument
+        `days` or `years` for unit conversion.
+
     Returns
     -------
     scaled : :obj:`float`
-        Scaled time, in years, assuming the intermittency factor :obj:`If`.
+        Scaled time, in :obj:`units`, assuming the intermittency factor
+        :obj:`If`.
 
     Raises
     ------
     ValueError
-        if the value for intermittency is not ``0 <= If <= 1``.
+        if the value for intermittency is not ``0 < If <= 1``.
     """
-    if (If < 0) or (If > 1):
+    if (If <= 0) or (If > 1):
         raise ValueError(
-            'Intermittency `If` is not 0 <= If <= 1: %s' % str(If))
+            'Intermittency `If` is not 0 < If <= 1: %s' % str(If))
 
-    return time / _scale_factor(If)
+    return time / _scale_factor(If, units)
 
 
-def _scale_factor(If):
+def _scale_factor(If, units):
     """Scaling factor between model time and "real" time.
 
     The scaling factor relates the model time to a real worl time, by assuming
     an intermittency factor.
     """
-    return (If * 365.25 * 86400)
+    sec_in_day = 86400
+    day_in_yr = 365.25
+    if units == 'seconds':
+        S_f = 1
+    elif units == 'days':
+        S_f = sec_in_day
+    elif units == 'years':
+        S_f = sec_in_day * day_in_yr
+    else:
+        raise ValueError('Bad value for `units`: %s' % str(units))
+    return (If * S_f)

--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -145,3 +145,62 @@ def _get_version():
     """
     from . import _version
     return _version.__version__()
+
+
+def scale_model_time(time, If=1):
+    """Scale the model time to "real" time.
+
+    Model time is executed as assumed flooding conditions, and executed at the
+    per-second level, with a multi-second timestep. This model design
+    implicitly assumes that the delta is *always* receiving a large volume of
+    sediment and water at the inlet. This is unrealistic, given that rivers
+    flood only during a small portion of the year, and this is when
+    morphodynamic activity is largest.
+
+    Despite this assumption, it is possible to scale up model time to "real"
+    time, by assuming an *intermittency factor*. This intermittency factor is
+    the fraction of time, scaled to 1 year, when the delta system is assumed
+    to be flooding.
+
+    .. math::
+
+        t_r = \dfrac{t}{I_f \cdot 365.25 \cdot 86400}
+
+    where :math:`t` is the model time (:obj:`~pyDeltaRCM.DeltaModel.time`),
+    :math:`t_r` is the "real" scaled time, and :math:`I_f` is the
+    intermittency factor.
+
+    Parameters
+    ----------
+    time : :obj:`float`
+        The model time, in seconds.
+
+    If : :obj:`float`, optional
+        Intermittency factor, fraction of time represented by morphodynamic
+        activity. Should be in interval (0, 1). Defaults to 1 if not provided,
+        i.e., no scaling is performed.
+
+    Returns
+    -------
+    scaled : :obj:`float`
+        Scaled time, in years, assuming the intermittency factor :obj:`If`.
+
+    Raises
+    ------
+    ValueError
+        if the value for intermittency is not ``0 <= If <= 1``.
+    """
+    if (If < 0) or (If > 1):
+        raise ValueError(
+            'Intermittency `If` is not 0 <= If <= 1: %s' % str(If))
+
+    return time / _scale_factor(If)
+
+
+def _scale_factor(If):
+    """Scaling factor between model time and "real" time.
+
+    The scaling factor relates the model time to a real worl time, by assuming
+    an intermittency factor.
+    """
+    return (If * 365.25 * 86400)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -277,6 +277,62 @@ def test_error_if_no_timesteps(tmp_path):
                                  '--config', str(p)])
 
 
+def test_entry_point_timesteps(tmp_path):
+    """
+    test calling the command line feature with a config file.
+    """
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'save_eta_figs', True)
+    f.close()
+    subprocess.check_output(['pyDeltaRCM',
+                             '--config', str(p), '--timesteps', '2'])
+    exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
+    exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+    assert os.path.isfile(exp_path_nc)
+    assert os.path.isfile(exp_path_png0)
+    assert os.path.isfile(exp_path_png1)
+
+
+def test_entry_point_time(tmp_path):
+    """
+    test calling the command line feature with a config file.
+    """
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'save_eta_figs', True)
+    f.close()
+    subprocess.check_output(['pyDeltaRCM',
+                             '--config', str(p), '--time', '1000'])
+    exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
+    exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
+    exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+    assert os.path.isfile(exp_path_nc)
+    assert os.path.isfile(exp_path_png0)
+    assert os.path.isfile(exp_path_png1)
+
+
 import pyDeltaRCM as _pyimportedalias
 
 
@@ -344,6 +400,96 @@ def test_py_hlvl_tsteps_yml_runjobs_sngle(tmp_path):
     assert pp.job_list[0]._is_completed is False
     pp.run_jobs()
     assert pp.job_list[0]._is_completed is True
+
+
+def test_py_hlvl_time_yml_runjobs_sngle(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time', 1000)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    assert len(pp.job_list) == 1
+    assert pp.job_list[0]._is_completed is False
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 1200
+
+
+def test_py_hlvl_time_If_yml_runjobs_sngle(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time', 10000)
+    utilities.write_parameter_to_file(f, 'If', 0.1)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    assert len(pp.job_list) == 1
+    assert pp.job_list[0]._is_completed is False
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 1200
+
+
+def test_py_hlvl_timeyears_yml_runjobs_sngle(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time_years', 3.16880878140e-05)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    assert len(pp.job_list) == 1
+    assert pp.job_list[0]._is_completed is False
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 1200
+
+
+def test_py_hlvl_timeyears_If_yml_runjobs_sngle(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time_years', 0.00031688087814)
+    utilities.write_parameter_to_file(f, 'If', 0.1)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    assert len(pp.job_list) == 1
+    assert pp.job_list[0]._is_completed is False
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 1200
 
 
 def test_py_hlvl_args(tmp_path):
@@ -549,6 +695,30 @@ def test_python_highlevelapi_matrix_expansion_scientificnotation(tmp_path):
     SLR_list = [j.deltamodel.SLR for j in pp.job_list]
     assert sum([j == 4e-5 for j in SLR_list]) == 3
     assert sum([j == 0.000001 for j in SLR_list]) == 3
+
+
+def test_python_highlevelapi_matrix_expansion_one_list_time_config(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'time', 1000)
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_matrix_to_file(f,
+                                   ['f_bedload'],
+                                   [[0.2, 0.6]])
+    f.close()
+    pp = preprocessor.Preprocessor(input_file=p)
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 1200.0
+    assert pp.job_list[1].deltamodel.time == 1200.0
 
 
 def test_python_highlevelapi_matrix_needs_out_dir(tmp_path):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -447,6 +447,72 @@ def test_py_hlvl_time_If_yml_runjobs_sngle(tmp_path):
     assert pp.job_list[0].deltamodel.time == 1200
 
 
+def test_py_hlvl_timeargs_precedence_tstepsovertime(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time', 10000)
+    utilities.write_parameter_to_file(f, 'timesteps', 2)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 600
+    assert pp.job_list[0].deltamodel.time_iter == 2
+
+
+def test_py_hlvl_timeargs_precedence_tstepsovertimeyears(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time_years', 10000)
+    utilities.write_parameter_to_file(f, 'timesteps', 2)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 600
+    assert pp.job_list[0].deltamodel.time_iter == 2
+
+
+def test_py_hlvl_timeargs_precedence_timeovertimeyears(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time', 900)
+    utilities.write_parameter_to_file(f, 'time_years', 10000)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    pp.run_jobs()
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 900
+    assert pp.job_list[0].deltamodel.time_iter == 3
+
+
 def test_py_hlvl_timeyears_yml_runjobs_sngle(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -513,6 +513,30 @@ def test_py_hlvl_timeargs_precedence_timeovertimeyears(tmp_path):
     assert pp.job_list[0].deltamodel.time_iter == 3
 
 
+def test_py_hlvl_time_timestep_mismatch_endtime_check(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+    utilities.write_parameter_to_file(f, 'save_dt', 300)
+    utilities.write_parameter_to_file(f, 'time', 1000)
+    f.close()
+    pp = preprocessor.Preprocessor(p)
+    pp.run_jobs()
+    # timestep will have been 300, so should have run 4 iterations, and time
+    # will equal 1200. I.e., more than specified, this is the expected
+    # behavior
+    assert pp.job_list[0]._is_completed is True
+    assert pp.job_list[0].deltamodel.time == 1200
+    assert pp.job_list[0].deltamodel.time_iter == 4
+
+
 def test_py_hlvl_timeyears_yml_runjobs_sngle(tmp_path):
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1157,3 +1157,14 @@ def test_negative_Csmooth(tmp_path):
     f.close()
     with pytest.raises(ValueError):
         delta = DeltaModel(input_file=p)
+
+
+class TestScaleRelativeSeaLeveLRiseRate():
+
+    def test_scale_If_1(self):
+        scaled = preprocessor.scale_relative_sea_level_rise_rate(5, If=1)
+        assert scaled == 5 / 1000 / 365.25 / 86400
+
+    def test_scale_If_0p1(self):
+        scaled = preprocessor.scale_relative_sea_level_rise_rate(5, If=0.1)
+        assert scaled == 5 / 1000 / 365.25 / 86400 * 10

--- a/tests/test_shared_tools.py
+++ b/tests/test_shared_tools.py
@@ -168,3 +168,48 @@ def test_version_is_valid():
     assert type(v) is str
     dots = [i for i, c in enumerate(v) if c == '.']
     assert len(dots) == 2
+
+
+class TestScaleModelTime():
+
+    def test_defaults(self):
+        scaled = shared_tools.scale_model_time(86400)
+        assert scaled == 86400
+
+    def test_If(self):
+        scaled = shared_tools.scale_model_time(86400, 0.1)
+        assert scaled == 86400 / 0.1
+        scaled = shared_tools.scale_model_time(86400, 0.5)
+        assert scaled == 86400 / 0.5
+        scaled = shared_tools.scale_model_time(86400, 0.9)
+        assert scaled == 86400 / 0.9
+        scaled = shared_tools.scale_model_time(86400, 1)
+        assert scaled == 86400
+        scaled = shared_tools.scale_model_time(86400, 1e-15)
+        assert scaled == 86400 / 1e-15
+        with pytest.raises(ValueError, match='Intermittency `If` .*'):
+            scaled = shared_tools.scale_model_time(86400, 0)
+        with pytest.raises(ValueError, match='Intermittency `If` .*'):
+            scaled = shared_tools.scale_model_time(86400, 1.01)
+
+    def test_units(self):
+        scaled = shared_tools.scale_model_time(86400, units='seconds')
+        assert scaled == 86400
+        scaled = shared_tools.scale_model_time(86400, units='days')
+        assert scaled == 1
+        scaled = shared_tools.scale_model_time(86400, units='years')
+        assert scaled == (1 / 365.25)
+        with pytest.raises(ValueError):
+            scaled = shared_tools.scale_model_time(86400, units='badstr')
+
+    def test_combinations(self):
+        scaled = shared_tools.scale_model_time(86400, If=0.1, units='days')
+        assert scaled == 10
+        scaled = shared_tools.scale_model_time(2 * 86400, If=0.1, units='days')
+        assert scaled == 20
+        scaled = shared_tools.scale_model_time(
+            365.25 * 86400, If=1, units='years')
+        assert scaled == 1
+        scaled = shared_tools.scale_model_time(
+            365.25 * 86400, If=0.1, units='years')
+        assert scaled == 10


### PR DESCRIPTION
Adding "time" options to model preprocessor (i.e., rather than `--timesteps`, running `--time`, etc).

Add a few helper functions to convert between mode ltime and real-world time.

## todo

- [x] detailed documentation page (and link to it throughout) describing the intermittency factor in detail, and how the model uses this concept to scale time.
- [ ] ~create the `DeltaModel` api for timestepping for durations, rather than just number of timesteps~
- [x] create preprocessor API for working with time and timesteps and intermittency