### PR TITLE
Preprocessor fix

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -361,6 +361,7 @@ class PreprocessorCLI(BasePreprocessor):
             self.input_file = self.args['config']
             self.extract_yaml_config()
         else:
+            self.verbose = 0  # no verbosity by defauly
             self.input_file = None
             self.user_dict = {}
             self._has_matrix = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+
+import pytest
+import utilities
+import os
+
+
+def test_cli_notimestep(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    result = os.system("pyDeltaRCM --config " + str(p))
+    # if the result is 256 this is an error code
+    assert result == 256
+
+
+def test_cli_noconfig():
+    result = os.system("pyDeltaRCM --timesteps 1")
+    assert result == 0
+
+
+def test_cli_noargs():
+    result = os.system("pyDeltaRCM")
+    # returns an error code
+    assert result == 256

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 import pytest
 import utilities
 import os
+import platform
 
 
 def test_cli_notimestep(tmp_path):
@@ -9,8 +10,11 @@ def test_cli_notimestep(tmp_path):
     p, f = utilities.create_temporary_file(tmp_path, file_name)
     utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
     result = os.system("pyDeltaRCM --config " + str(p))
-    # if the result is 256 this is an error code
-    assert result == 256
+    # if the result is 256 or 1 this is an error code
+    if platform.system() == 'Windows':
+        assert result == 1
+    else:
+        assert result == 256
 
 
 def test_cli_noconfig():
@@ -21,4 +25,7 @@ def test_cli_noconfig():
 def test_cli_noargs():
     result = os.system("pyDeltaRCM")
     # returns an error code
-    assert result == 256
+    if platform.system() == 'Windows':
+        assert result == 1
+    else:
+        assert result == 256


### PR DESCRIPTION
This closes #91 by simply defining the verbosity for the CLI preprocessor if no 'config' file is given. This is a super minor PR so there is no rush to review or merge this.

Several awkward things about this PR relate to the unit tests though.

- To test the problem that prompted this fix, we cannot modify the config file to set a temporary output directory - so this is the one unit test that actually creates an output folder, log file, and output file. I don't see an obvious way around this problem.

- For the CLI testing in general I opted to use `os.system` to simulate putting text in the command prompt from Python. I think there are some pytest plugins that might help address this, but after looking at one of them ([here](https://github.com/painless-software/python-cli-test-helpers)) I wasn't sure how much use these types of tools actually get. So instead, we just test the "system" outputs after running something with `os.system` so this is a 0 when the command runs successfully and 256 (or 1 for Windows) when there is an error.