### PR TITLE
Rework output netcdf file

### DIFF
--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -79,6 +79,9 @@ save_discharge_figs:
 save_velocity_figs:
   type: 'bool'
   default: False
+save_sedflux_figs:
+  type: 'bool'
+  default: True
 save_figs_sequential:
   type: 'bool'
   default: True
@@ -95,6 +98,9 @@ save_discharge_grids:
   type: 'bool'
   default: False
 save_velocity_grids:
+  type: 'bool'
+  default: False
+save_sedflux_grids:
   type: 'bool'
   default: False
 save_dt:

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -81,10 +81,13 @@ save_velocity_figs:
   default: False
 save_sedflux_figs:
   type: 'bool'
-  default: True
+  default: False
 save_figs_sequential:
   type: 'bool'
   default: True
+save_metadata:
+  type: 'bool'
+  default: False
 save_eta_grids:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -513,7 +513,7 @@ class init_tools(abc.ABC):
                 _v[:] = varvalue
 
             if self.save_metadata:
-                meta = self.output_netcdf.createGroup('meta')
+                self.output_netcdf.createGroup('meta')
                 # fixed metadata
                 _create_meta_variable('L0', self.L0, 'cells')
                 _create_meta_variable('N0', self.N0, 'cells')

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -512,22 +512,23 @@ class init_tools(abc.ABC):
                 _v.units = varunits
                 _v[:] = varvalue
 
-            meta = self.output_netcdf.createGroup('meta')
-            # fixed metadata
-            _create_meta_variable('L0', self.L0, 'cells')
-            _create_meta_variable('N0', self.N0, 'cells')
-            _create_meta_variable('CTR', self.CTR, 'cells')
-            _create_meta_variable('dx', self.dx, 'meters')
-            _create_meta_variable('h0', self.h0, 'meters')
-            # time-varying metadata
-            _create_meta_variable('H_SL', None, 'meters',
-                                  vardims=('total_time'))
-            _create_meta_variable('f_bedload', None, 'fraction',
-                                  vardims=('total_time'))
-            _create_meta_variable('C0_percent', None, 'percent',
-                                  vardims=('total_time'))
-            _create_meta_variable('u0', None, 'meters per second',
-                                  vardims=('total_time'))
+            if self.save_metadata:
+                meta = self.output_netcdf.createGroup('meta')
+                # fixed metadata
+                _create_meta_variable('L0', self.L0, 'cells')
+                _create_meta_variable('N0', self.N0, 'cells')
+                _create_meta_variable('CTR', self.CTR, 'cells')
+                _create_meta_variable('dx', self.dx, 'meters')
+                _create_meta_variable('h0', self.h0, 'meters')
+                # time-varying metadata
+                _create_meta_variable('H_SL', None, 'meters',
+                                      vardims=('total_time'))
+                _create_meta_variable('f_bedload', None, 'fraction',
+                                      vardims=('total_time'))
+                _create_meta_variable('C0_percent', None, 'percent',
+                                      vardims=('total_time'))
+                _create_meta_variable('u0', None, 'meters per second',
+                                      vardims=('total_time'))
 
             _msg = 'Output netCDF file created'
             self.logger.info(_msg)

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -36,6 +36,7 @@ class init_tools(abc.ABC):
 
     def init_logger(self):
         """Initialize a logger.
+
         The logger is initialized regardless of the value of ``self.verbose``.
         The level of information printed to the log depends on the verbosity
         setting.
@@ -114,16 +115,46 @@ class init_tools(abc.ABC):
             else:
                 input_file_vars[k] = default_dict[k]['default']
 
-        # now make each one an attribute of the model object.
-        for k, v in list(input_file_vars.items()):
+        # save the input file as a hidden attr and grab needed value
+        self._input_file_vars = input_file_vars
+        self.out_dir = self._input_file_vars['out_dir']
+        self.verbose = self._input_file_vars['verbose']
+
+    def process_input_to_model(self):
+        """Process input file to model variables.
+
+        Loop through the items specified in the model configuration and apply
+        them to the model (i.e., ``self``). Additionally, write the input
+        values specified into the log file.
+
+        .. note::
+
+            If ``self.resume_checkpoint == True``, then the input values are
+            *not* written to the log.
+        """
+        _msg = 'Setting up model configuration'
+        self.logger.info(_msg)
+        if self.verbose >= 2:
+            print(_msg)
+
+        # process the input file to attributes of the model
+        for k, v in list(self._input_file_vars.items()):
             setattr(self, k, v)
 
-        # if checkpoint_dt is the default value, None, then set it to save_dt
+        # if checkpoint_dt is the default value (None), then set it to save_dt
         if self.checkpoint_dt is None:
             self.checkpoint_dt = self.save_dt
 
+        # handle a not implemented setup
         if self.save_checkpoint and self.toggle_subsidence:
             raise NotImplementedError('Cannot handle checkpointing with subsidence.')
+
+        # write the input file values to the log
+        if not self.resume_checkpoint:
+            for k, v in list(self._input_file_vars.items()):
+                _msg = 'Configuration variable `{var}`: {val}'.format(
+                    var=k, val=v)
+                self.logger.info(_msg)
 
     def determine_random_seed(self):
         """Set the random seed if given.
@@ -151,34 +182,23 @@ class init_tools(abc.ABC):
         self.logger.info('Setting model constants')
 
         self.g = 9.81   # (gravitation const.)
-
         sqrt2 = np.sqrt(2)
+        sqrt05 = np.sqrt(0.5)
+
         self.distances = np.array([[sqrt2, 1, sqrt2],
                                    [1, 1, 1],
                                    [sqrt2, 1, sqrt2]]).astype(np.float32)
-
-        sqrt05 = np.sqrt(0.5)
         self.ivec = np.array([[-sqrt05, 0, sqrt05],
                               [-1, 0, 1],
                               [-sqrt05, 0, sqrt05]]).astype(np.float32)
-
-        self.iwalk = shared_tools.get_iwalk()
-
         self.jvec = np.array([[-sqrt05, -1, -sqrt05],
                               [0, 0, 0],
                               [sqrt05, 1, sqrt05]]).astype(np.float32)
-
+        self.iwalk = shared_tools.get_iwalk()
         self.jwalk = shared_tools.get_jwalk()
-        # self.dxn_iwalk = [1, 1, 0, -1, -1, -1, 0, 1]
-        # self.dxn_jwalk = [0, 1, 1, 1, 0, -1, -1, -1]
-        # self.dxn_dist = \
-        #     [sqrt(self.dxn_iwalk[i]**2 + self.dxn_jwalk[i]**2)
-        #      for i in range(8)]
-
         self.dxn_iwalk = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
         self.dxn_jwalk = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
         self.dxn_dist = np.sqrt(self.dxn_iwalk**2 + self.dxn_jwalk**2)
-
         self.walk_flat = np.array([1, -self.W + 1, -self.W, -self.W - 1,
                                    -1, self.W - 1, self.W, self.W + 1])
         self.distances_flat = self.distances.flatten()
@@ -268,6 +288,7 @@ class init_tools(abc.ABC):
         self.diffusion_multiplier = (self.dt / self.N_crossdiff * self.alpha
                                      * 0.5 / self.dx**2)
 
+        self._save_metadata = self.save_metadata
         self._save_any_grids = (self.save_eta_grids or self.save_depth_grids or
                                 self.save_stage_grids or self.save_discharge_grids or
                                 self.save_velocity_grids or self.save_sedflux_grids)
@@ -398,7 +419,7 @@ class init_tools(abc.ABC):
             self.strata_eta = lil_matrix((self.L * self.W, self.n_steps),
                                          dtype=np.float32)
 
-    def init_output_grids(self):
+    def init_output_file(self):
         """Creates a netCDF file to store output grids.
 
         Fills with default variables.
@@ -406,7 +427,8 @@ class init_tools(abc.ABC):
         .. warning:: Overwrites an existing netcdf file with the same name.
 
         """
-        if (self.save_eta_grids or
+        if (self.save_metadata or
+                self.save_eta_grids or
                 self.save_depth_grids or
                 self.save_stage_grids or
                 self.save_discharge_grids or
@@ -483,16 +505,34 @@ class init_tools(abc.ABC):
                 sedflux.units = 'cubic meters per second'
 
             # set up metadata group and populate variables
+            def _create_meta_variable(varname, varvalue, varunits,
+                                      vartype='f4', vardims=()):
+                _v = self.output_netcdf.createVariable(
+                    'meta/'+varname, vartype, vardims)
+                _v.units = varunits
+                _v[:] = varvalue
+
             meta = self.output_netcdf.createGroup('meta')
-            L0 = self.output_netcdf.createVariable('meta/L0', 'f4', ())
-            L0[:] = 100000
+            # fixed metadata
+            _create_meta_variable('L0', self.L0, 'cells')
+            _create_meta_variable('N0', self.N0, 'cells')
+            _create_meta_variable('CTR', self.CTR, 'cells')
+            _create_meta_variable('dx', self.dx, 'meters')
+            _create_meta_variable('h0', self.h0, 'meters')
+            # time-varying metadata
+            _create_meta_variable('H_SL', None, 'meters',
+                                  vardims=('total_time'))
+            _create_meta_variable('f_bedload', None, 'fraction',
+                                  vardims=('total_time'))
+            _create_meta_variable('C0_percent', None, 'percent',
+                                  vardims=('total_time'))
+            _create_meta_variable('u0', None, 'meters per second',
+                                  vardims=('total_time'))
 
             _msg = 'Output netCDF file created'
             self.logger.info(_msg)
             if self.verbose >= 2:
                 print(_msg)
-
-            # breakpoint()
 
     def init_subsidence(self):
         """

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -288,7 +288,6 @@ class init_tools(abc.ABC):
         self.diffusion_multiplier = (self.dt / self.N_crossdiff * self.alpha
                                      * 0.5 / self.dx**2)
 
-        self._save_metadata = self.save_metadata
         self._save_any_grids = (self.save_eta_grids or self.save_depth_grids or
                                 self.save_stage_grids or self.save_discharge_grids or
                                 self.save_velocity_grids or self.save_sedflux_grids)
@@ -296,6 +295,9 @@ class init_tools(abc.ABC):
                                self.save_stage_figs or self.save_discharge_figs or
                                self.save_velocity_figs or self.save_sedflux_figs)
         self._save_figs_sequential = self.save_figs_sequential  # copy as private
+        self._save_metadata = self.save_metadata
+        if self._save_any_grids:  # always save metadata if saving grids
+            self._save_metadata = True
         self._is_finalized = False
 
         self._save_checkpoint = self.save_checkpoint  # copy as private
@@ -427,13 +429,8 @@ class init_tools(abc.ABC):
         .. warning:: Overwrites an existing netcdf file with the same name.
 
         """
-        if (self.save_metadata or
-                self.save_eta_grids or
-                self.save_depth_grids or
-                self.save_stage_grids or
-                self.save_discharge_grids or
-                self.save_velocity_grids or
-                self.save_sedflux_grids or
+        if (self._save_metadata or
+                self._save_any_grids or
                 self.save_strata):
 
             _msg = 'Generating netCDF file for output grids'
@@ -512,23 +509,22 @@ class init_tools(abc.ABC):
                 _v.units = varunits
                 _v[:] = varvalue
 
-            if self.save_metadata:
-                self.output_netcdf.createGroup('meta')
-                # fixed metadata
-                _create_meta_variable('L0', self.L0, 'cells')
-                _create_meta_variable('N0', self.N0, 'cells')
-                _create_meta_variable('CTR', self.CTR, 'cells')
-                _create_meta_variable('dx', self.dx, 'meters')
-                _create_meta_variable('h0', self.h0, 'meters')
-                # time-varying metadata
-                _create_meta_variable('H_SL', None, 'meters',
-                                      vardims=('total_time'))
-                _create_meta_variable('f_bedload', None, 'fraction',
-                                      vardims=('total_time'))
-                _create_meta_variable('C0_percent', None, 'percent',
-                                      vardims=('total_time'))
-                _create_meta_variable('u0', None, 'meters per second',
-                                      vardims=('total_time'))
+            self.output_netcdf.createGroup('meta')
+            # fixed metadata
+            _create_meta_variable('L0', self.L0, 'cells')
+            _create_meta_variable('N0', self.N0, 'cells')
+            _create_meta_variable('CTR', self.CTR, 'cells')
+            _create_meta_variable('dx', self.dx, 'meters')
+            _create_meta_variable('h0', self.h0, 'meters')
+            # time-varying metadata
+            _create_meta_variable('H_SL', None, 'meters',
+                                  vardims=('total_time'))
+            _create_meta_variable('f_bedload', None, 'fraction',
+                                  vardims=('total_time'))
+            _create_meta_variable('C0_percent', None, 'percent',
+                                  vardims=('total_time'))
+            _create_meta_variable('u0', None, 'meters per second',
+                                  vardims=('total_time'))
 
             _msg = 'Output netCDF file created'
             self.logger.info(_msg)

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -411,6 +411,7 @@ class init_tools(abc.ABC):
                 self.save_stage_grids or
                 self.save_discharge_grids or
                 self.save_velocity_grids or
+                self.save_sedflux_grids or
                 self.save_strata):
 
             _msg = 'Generating netCDF file for output grids'
@@ -430,7 +431,7 @@ class init_tools(abc.ABC):
                 os.remove(file_path)
 
             self.output_netcdf = Dataset(file_path, 'w',
-                                         format='NETCDF4_CLASSIC')
+                                         format='NETCDF4')
 
             self.output_netcdf.description = 'Output grids from pyDeltaRCM'
             self.output_netcdf.history = ('Created '
@@ -449,40 +450,40 @@ class init_tools(abc.ABC):
                                                      ('total_time',))
             x.units = 'meters'
             y.units = 'meters'
-            time.units = 'seconds'
+            time.units = 'second'
 
             x[:] = self.x
             y[:] = self.y
 
             if self.save_eta_grids:
-                eta = self.output_netcdf.createVariable('eta',
-                                                        'f4',
+                eta = self.output_netcdf.createVariable('eta', 'f4',
                                                         ('total_time', 'length', 'width'))
                 eta.units = 'meters'
 
             if self.save_stage_grids:
-                stage = self.output_netcdf.createVariable('stage',
-                                                          'f4',
+                stage = self.output_netcdf.createVariable('stage', 'f4',
                                                           ('total_time', 'length', 'width'))
                 stage.units = 'meters'
 
             if self.save_depth_grids:
-                depth = self.output_netcdf.createVariable('depth',
-                                                          'f4',
+                depth = self.output_netcdf.createVariable('depth', 'f4',
                                                           ('total_time', 'length', 'width'))
                 depth.units = 'meters'
 
             if self.save_discharge_grids:
-                discharge = self.output_netcdf.createVariable('discharge',
-                                                              'f4',
+                discharge = self.output_netcdf.createVariable('discharge', 'f4',
                                                               ('total_time', 'length', 'width'))
                 discharge.units = 'cubic meters per second'
 
             if self.save_velocity_grids:
-                velocity = self.output_netcdf.createVariable('velocity',
-                                                             'f4',
+                velocity = self.output_netcdf.createVariable('velocity', 'f4',
                                                              ('total_time', 'length', 'width'))
                 velocity.units = 'meters per second'
+
+            if self.save_sedflux_grids:
+                sedflux = self.output_netcdf.createVariable('sedflux', 'f4',
+                                                            ('total_time', 'length', 'width'))
+                sedflux.units = 'cubic meters per second'
 
             _msg = 'Output netCDF file created'
             self.logger.info(_msg)

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -233,6 +233,11 @@ class iteration_tools(abc.ABC):
         -------
 
         """
+        save_idx = self.save_iter
+
+        if (self._save_metadata or self._save_any_grids):
+            self.output_netcdf.variables['time'][save_idx] = self.time
+
         # ------------------ Figures ------------------
         if self._save_any_figs:
 
@@ -280,31 +285,35 @@ class iteration_tools(abc.ABC):
         # ------------------ grids ------------------
         if self._save_any_grids:
 
-            shape = self.output_netcdf.variables['time'].shape
-            self.output_netcdf.variables['time'][shape[0]] = self.time
-
             _msg = 'Saving grids'
             self.logger.info(_msg)
             if self.verbose >= 2:
                 print(_msg)
 
             if self.save_eta_grids:
-                self.save_grids('eta', self.eta, shape[0])
+                self.save_grids('eta', self.eta, save_idx)
 
             if self.save_depth_grids:
-                self.save_grids('depth', self.depth, shape[0])
+                self.save_grids('depth', self.depth, save_idx)
 
             if self.save_stage_grids:
-                self.save_grids('stage', self.stage, shape[0])
+                self.save_grids('stage', self.stage, save_idx)
 
             if self.save_discharge_grids:
-                self.save_grids('discharge', self.qw, shape[0])
+                self.save_grids('discharge', self.qw, save_idx)
 
             if self.save_velocity_grids:
-                self.save_grids('velocity', self.uw, shape[0])
+                self.save_grids('velocity', self.uw, save_idx)
 
             if self.save_sedflux_grids:
-                self.save_grids('sedflux', self.qs, shape[0])
+                self.save_grids('sedflux', self.qs, save_idx)
+
+        # ------------------ metadata ------------------
+        if self._save_metadata:
+            self.output_netcdf['meta']['H_SL'][save_idx] = self.H_SL
+            self.output_netcdf['meta']['f_bedload'][save_idx] = self.H_SL
+            self.output_netcdf['meta']['C0_percent'][save_idx] = self.H_SL
+            self.output_netcdf['meta']['u0'][save_idx] = self.H_SL
 
     def output_checkpoint(self):
         """Save checkpoint.

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -271,6 +271,12 @@ class iteration_tools(abc.ABC):
                                  filename_root='velocity_',
                                  timestep=self.save_iter)
 
+            if self.save_sedflux_figs:
+                _fu = self.make_figure('qs', self.time)
+                self.save_figure(_fu, directory=self.prefix,
+                                 filename_root='sedflux_',
+                                 timestep=self.save_iter)
+
         # ------------------ grids ------------------
         if self._save_any_grids:
 
@@ -296,6 +302,9 @@ class iteration_tools(abc.ABC):
 
             if self.save_velocity_grids:
                 self.save_grids('velocity', self.uw, shape[0])
+
+            if self.save_sedflux_grids:
+                self.save_grids('sedflux', self.qs, shape[0])
 
     def output_checkpoint(self):
         """Save checkpoint.
@@ -368,7 +377,7 @@ class iteration_tools(abc.ABC):
             strata_age = self.output_netcdf.createVariable('strata_age',
                                                            np.int32,
                                                            ('total_strata_age'))
-            strata_age.units = 'seconds'
+            strata_age.units = 'second'
             self.output_netcdf.variables['strata_age'][
                 :] = list(range(shape[1] - 1, -1, -1))
 

--- a/pyDeltaRCM/model (andrew's conflicted copy 2020-11-01).py
+++ b/pyDeltaRCM/model (andrew's conflicted copy 2020-11-01).py
@@ -1,0 +1,328 @@
+#! /usr/bin/env python
+import warnings
+import logging
+import datetime
+import os
+
+from .iteration_tools import iteration_tools
+from .sed_tools import sed_tools
+from .water_tools import water_tools
+from .init_tools import init_tools
+from .debug_tools import debug_tools
+
+
+class DeltaModel(iteration_tools, sed_tools, water_tools,
+                 init_tools, debug_tools, object):
+    """Main model class.
+
+    Instantiating the model class is described in the :meth:`__init__` method
+    below in detail, but generally model instantiation occurs via a model run
+    YAML configuration file. These YAML configuration files define model
+    parameters which are used in the run; read more about creating input YAML
+    configuration files in the :doc:`../../guides/userguide`.
+
+    Once the model has been instantiated, the model is updated via the
+    :meth:`update`. This method coordinates the hydrology, sediment transport,
+    subsidence, and stratigraphic operation that must occur during each
+    timestep. The :meth:`update` should be called iteratively, to "run" the
+    model.
+
+    Finally, after all ``update`` steps are complete, the model should be
+    finalized (:meth:`finalize`), such that files and data are appropriately
+    closed and written to disk.
+    """
+
+    def __init__(self, input_file=None):
+        """Creates an instance of the pyDeltaRCM model.
+
+        This method handles setting up the run, including parsing input files,
+        initializing arrays, and initializing output routines.
+
+        Parameters
+        ----------
+        input_file : `str`, `os.PathLike`, optional
+            User model run configuration file.
+
+        Returns
+        -------
+
+        Notes
+        -----
+        For more information regarding input configuration files, see the
+        :doc:`../../guides/userguide`.
+
+        """
+        self._time = 0.
+        self._time_iter = int(0)
+        self._save_time_since_last = float("inf")  # force save on t==0
+        self._save_iter = int(0)
+        self._save_time_since_checkpoint = 0
+
+        self.input_file = input_file
+        _src_dir = os.path.realpath(os.path.dirname(__file__))
+        self.default_file = os.path.join(_src_dir, 'default.yml')
+        self.import_files()
+
+        self.init_output_infrastructure()
+        self.init_logger()
+
+        self.create_other_variables()
+
+        self.determine_random_seed()
+        self.create_domain()
+
+        self.init_sediment_routers()
+
+        self.init_subsidence()
+
+        # if resume flag set to True, load checkpoint, open netCDF4
+        if self.resume_checkpoint:
+            _msg = 'Loading data from checkpoint and reopening netCDF4 file.'
+            self.logger.info(_msg)
+            self.load_checkpoint()
+
+        else:
+            self.init_stratigraphy()
+            self.init_output_grids()
+
+        self.after_init()
+
+        self.logger.info('Model initialization complete')
+
+    def after_init(self):
+        pass
+
+    def update(self):
+        """Run the model for one full instance
+
+        Calls, in sequence:
+
+            * the routine to run one timestep (i.e., water surface estimation
+              and sediment routing, :meth:`run_one_timestep`)
+            * the basin subsidence update pattern (:meth:`apply_subsidence`)
+            * the timestep finalization routine (:meth:`finalize_timestep`)
+            * straigraphy updating routine (:meth:`record_stratigraphy`)
+
+        If you attempt to override the ``update`` routine, you must implement
+        these operations at a minimum.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+        """
+        if self._save_time_since_last >= self.save_dt:
+            self.record_stratigraphy()
+            self.output_data()
+            self._save_iter += int(1)
+            self._save_time_since_last = 0
+
+        self.run_one_timestep()
+        self.apply_subsidence()
+        self.finalize_timestep()
+
+        self._time += self.dt
+        self._save_time_since_last += self.dt
+        self._save_time_since_checkpoint += self.dt
+        self._time_iter += int(1)
+
+        if self._save_time_since_checkpoint >= self.checkpoint_dt:
+            self.output_checkpoint()
+            self._save_time_since_checkpoint = 0
+
+    def finalize(self):
+        """Finalize the model run.
+
+        Finalization includes saving output stratigraphy, closing relevant
+        files on disk and clearing variables.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+        """
+        self.logger.info('Finalize model run')
+
+        # get the final timestep recorded, if needed.
+        if self._save_time_since_last >= self.save_dt:
+            self.record_stratigraphy()
+            self.output_data()
+
+        if self._save_time_since_checkpoint >= self.checkpoint_dt:
+            self.output_checkpoint()
+
+        self.output_strata()
+
+        try:
+            self.output_netcdf.close()
+            _msg = 'Closed output netcdf file'
+            self.logger.info(_msg)
+            if self.verbose >= 2:
+                print(_msg)
+        except Exception:
+            pass
+
+        self._is_finalized = True
+
+    @property
+    def out_dir(self):
+        """
+        Description of out_dir ... 
+
+        Must be a string.
+        """
+        return self._out_dir
+
+    @out_dir.setter
+    def out_dir(self, out_dir):
+        self._out_dir = out_dir
+
+    @property
+    def time(self):
+        """Elapsed model time in seconds.
+        """
+        return self._time
+
+    @property
+    def dt(self):
+        """The time step.
+
+        Raises
+        ------
+        UserWarning
+            If a very small timestep is configured.
+        """
+        return self._dt
+
+    @property
+    def time_step(self):
+        """Alias for `dt`.
+        """
+        return self._dt
+
+    @time_step.setter
+    def time_step(self, new_time_step):
+        if new_time_step * self.init_Np_sed < 100:
+            warnings.warn(UserWarning('Using a very small time step, '
+                                      'Delta might evolve very slowly.'))
+
+        if self.toggle_subsidence:
+            self.sigma = self.subsidence_mask * self.sigma_max * new_time_step
+
+        self._dt = new_time_step
+
+    @property
+    def time_iter(self):
+        """Number of time iterations.
+
+        The number of times the :obj:`update` method has been called.
+        """
+        return self._time_iter
+
+    @property
+    def save_time_since_last(self):
+        """Time since data last output.
+
+        The number of times the :obj:`update` method has been called.
+        """
+        return self._save_time_since_last
+
+    @property
+    def save_time_since_checkpoint(self):
+        """Time since last data checkpoint was saved."""
+        return self._save_time_since_checkpoint
+
+    @property
+    def save_iter(self):
+        """Number of times data has been saved."""
+        return self._save_iter
+
+    @property
+    def channel_flow_velocity(self):
+        """Get channel flow velocity."""
+        return self.u0
+
+    @channel_flow_velocity.setter
+    def channel_flow_velocity(self, new_u0):
+        self.u0 = new_u0
+        self.create_other_variables()
+        self.init_sediment_routers()
+
+    @property
+    def channel_width(self):
+        """Get channel width."""
+        return self.N0_meters
+
+    @channel_width.setter
+    def channel_width(self, new_N0):
+        self.N0_meters = new_N0
+        self.create_other_variables()
+        self.init_sediment_routers()
+
+    @property
+    def channel_flow_depth(self):
+        """Get channel flow depth."""
+        return self.h0
+
+    @channel_flow_depth.setter
+    def channel_flow_depth(self, new_d):
+        self.h0 = new_d
+        self.create_other_variables()
+        self.init_sediment_routers()
+
+    @property
+    def sea_surface_mean_elevation(self):
+        """Get sea surface mean elevation."""
+        return self.H_SL
+
+    @sea_surface_mean_elevation.setter
+    def sea_surface_mean_elevation(self, new_se):
+        self.H_SL = new_se
+
+    @property
+    def sea_surface_elevation_change(self):
+        """Get rate of change of sea surface elevation, per timestep."""
+        return self.SLR
+
+    @sea_surface_elevation_change.setter
+    def sea_surface_elevation_change(self, new_SLR):
+        self.SLR = new_SLR
+
+    @property
+    def bedload_fraction(self):
+        """Get bedload fraction."""
+        return self.f_bedload
+
+    @bedload_fraction.setter
+    def bedload_fraction(self, new_u0):
+        self.f_bedload = new_u0
+
+    @property
+    def influx_sediment_concentration(self):
+        """Get influx sediment concentration."""
+        return self.C0_percent
+
+    @influx_sediment_concentration.setter
+    def influx_sediment_concentration(self, new_u0):
+        self.C0_percent = new_u0
+        self.create_other_variables()
+        self.init_sediment_routers()
+
+    @property
+    def sea_surface_elevation(self):
+        """Get stage."""
+        return self.stage
+
+    @property
+    def water_depth(self):
+        """Get depth."""
+        return self.depth
+
+    @property
+    def bed_elevation(self):
+        """Get bed elevation."""
+        return self.eta

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -66,13 +66,13 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self.init_output_infrastructure()
         self.init_logger()
 
-        self.create_other_variables()
-
+        self.process_input_to_model()
         self.determine_random_seed()
+
+        self.create_other_variables()
         self.create_domain()
 
         self.init_sediment_routers()
-
         self.init_subsidence()
 
         # if resume flag set to True, load checkpoint, open netCDF4
@@ -83,7 +83,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         else:
             self.init_stratigraphy()
-            self.init_output_grids()
+            self.init_output_file()
 
         self.logger.info('Model initialization complete')
 

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -248,7 +248,8 @@ def test_logger_has_initialization_lines(tmp_path):
         assert 'Generating netCDF file for output grids' in _lines
         assert 'Output netCDF file created' in _lines
         assert 'Model initialization complete' in _lines
-    assert not os.path.isfile(os.path.join(tmp_path, 'out_dir', 'discharge_0.0.png'))
+    assert not os.path.isfile(os.path.join(
+        tmp_path, 'out_dir', 'discharge_0.0.png'))
     assert not os.path.isfile(os.path.join(tmp_path, 'out_dir', 'eta_0.0.png'))
 
 
@@ -429,7 +430,7 @@ def test_save_one_fig_one_grid(tmp_path):
         _delta.update()
     nc_size_middle = os.path.getsize(exp_path_nc)
     assert _delta.time_iter == 2.0
-    assert nc_size_middle == nc_size_before
+    assert nc_size_middle > nc_size_before
 
     # now finalize, and then file size should increase
     _delta.finalize()
@@ -505,6 +506,7 @@ def test_save_all_figures_sequential_false(tmp_path):
     utilities.write_parameter_to_file(f, 'save_velocity_figs', True)
     utilities.write_parameter_to_file(f, 'save_stage_figs', True)
     utilities.write_parameter_to_file(f, 'save_depth_figs', True)
+    utilities.write_parameter_to_file(f, 'save_sedflux_figs', True)
     utilities.write_parameter_to_file(f, 'save_figs_sequential', False)
     utilities.write_parameter_to_file(f, 'save_dt', 1)
     utilities.write_parameter_to_file(f, 'save_strata', False)
@@ -519,10 +521,16 @@ def test_save_all_figures_sequential_false(tmp_path):
     exp_path_png0 = os.path.join(tmp_path / 'out_dir', 'eta_00000.png')
     exp_path_png1 = os.path.join(tmp_path / 'out_dir', 'depth_00000.png')
     exp_path_png0_latest = os.path.join(tmp_path / 'out_dir', 'eta_latest.png')
-    exp_path_png1_latest = os.path.join(tmp_path / 'out_dir', 'depth_latest.png')
-    exp_path_png2_latest = os.path.join(tmp_path / 'out_dir', 'stage_latest.png')
-    exp_path_png3_latest = os.path.join(tmp_path / 'out_dir', 'velocity_latest.png')
-    exp_path_png4_latest = os.path.join(tmp_path / 'out_dir', 'discharge_latest.png')
+    exp_path_png1_latest = os.path.join(
+        tmp_path / 'out_dir', 'depth_latest.png')
+    exp_path_png2_latest = os.path.join(
+        tmp_path / 'out_dir', 'stage_latest.png')
+    exp_path_png3_latest = os.path.join(
+        tmp_path / 'out_dir', 'velocity_latest.png')
+    exp_path_png4_latest = os.path.join(
+        tmp_path / 'out_dir', 'discharge_latest.png')
+    exp_path_png5_latest = os.path.join(
+        tmp_path / 'out_dir', 'sedflux_latest.png')
     assert not os.path.isfile(exp_path_png0)
     assert not os.path.isfile(exp_path_png1)
     assert os.path.isfile(exp_path_png0_latest)
@@ -530,6 +538,7 @@ def test_save_all_figures_sequential_false(tmp_path):
     assert os.path.isfile(exp_path_png2_latest)
     assert os.path.isfile(exp_path_png3_latest)
     assert os.path.isfile(exp_path_png4_latest)
+    assert os.path.isfile(exp_path_png5_latest)
 
 
 def test_save_metadata_no_grids(tmp_path):
@@ -627,6 +636,7 @@ def test_save_eta_grids(tmp_path):
     _arr = ds.variables['eta']
     assert _arr.shape[1] == _delta.eta.shape[0]
     assert _arr.shape[2] == _delta.eta.shape[1]
+    assert not ('meta' in ds.groups)
 
 
 def test_save_depth_grids(tmp_path):
@@ -658,6 +668,7 @@ def test_save_depth_grids(tmp_path):
     _arr = ds.variables['depth']
     assert _arr.shape[1] == _delta.depth.shape[0]
     assert _arr.shape[2] == _delta.depth.shape[1]
+    assert not ('meta' in ds.groups)
 
 
 def test_save_velocity_grids(tmp_path):
@@ -689,6 +700,7 @@ def test_save_velocity_grids(tmp_path):
     _arr = ds.variables['velocity']
     assert _arr.shape[1] == _delta.eta.shape[0]
     assert _arr.shape[2] == _delta.eta.shape[1]
+    assert not ('meta' in ds.groups)
 
 
 def test_save_stage_grids(tmp_path):
@@ -720,6 +732,7 @@ def test_save_stage_grids(tmp_path):
     _arr = ds.variables['stage']
     assert _arr.shape[1] == _delta.eta.shape[0]
     assert _arr.shape[2] == _delta.eta.shape[1]
+    assert not ('meta' in ds.groups)
 
 
 def test_save_discharge_grids(tmp_path):
@@ -782,4 +795,3 @@ def test_save_sedflux_grids(tmp_path):
     _arr = ds.variables['sedflux']
     assert _arr.shape[1] == _delta.eta.shape[0]
     assert _arr.shape[2] == _delta.eta.shape[1]
-

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -429,7 +429,7 @@ def test_save_one_fig_one_grid(tmp_path):
         _delta.update()
     nc_size_middle = os.path.getsize(exp_path_nc)
     assert _delta.time_iter == 2.0
-    assert nc_size_middle == nc_size_before
+    assert nc_size_middle > nc_size_before
 
     # now finalize, and then file size should increase
     _delta.finalize()
@@ -459,6 +459,7 @@ def test_save_all_figures_no_grids(tmp_path):
     utilities.write_parameter_to_file(f, 'save_velocity_figs', True)
     utilities.write_parameter_to_file(f, 'save_stage_figs', True)
     utilities.write_parameter_to_file(f, 'save_depth_figs', True)
+    utilities.write_parameter_to_file(f, 'save_sedflux_figs', True)
     utilities.write_parameter_to_file(f, 'save_dt', 1)
     utilities.write_parameter_to_file(f, 'save_strata', False)
     f.close()
@@ -475,11 +476,13 @@ def test_save_all_figures_no_grids(tmp_path):
     exp_path_png2 = os.path.join(tmp_path / 'out_dir', 'stage_00000.png')
     exp_path_png3 = os.path.join(tmp_path / 'out_dir', 'velocity_00000.png')
     exp_path_png4 = os.path.join(tmp_path / 'out_dir', 'discharge_00000.png')
+    exp_path_png5 = os.path.join(tmp_path / 'out_dir', 'sedflux_00000.png')
     assert os.path.isfile(exp_path_png0)
     assert os.path.isfile(exp_path_png1)
     assert os.path.isfile(exp_path_png2)
     assert os.path.isfile(exp_path_png3)
     assert os.path.isfile(exp_path_png4)
+    assert os.path.isfile(exp_path_png5)
 
 
 def test_save_all_figures_sequential_false(tmp_path):
@@ -682,3 +685,35 @@ def test_save_discharge_grids(tmp_path):
     _arr = ds.variables['discharge']
     assert _arr.shape[1] == _delta.eta.shape[0]
     assert _arr.shape[2] == _delta.eta.shape[1]
+
+
+def test_save_sedflux_grids(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'seed', 0)
+    utilities.write_parameter_to_file(f, 'Length', 10.0)
+    utilities.write_parameter_to_file(f, 'Width', 10.0)
+    utilities.write_parameter_to_file(f, 'dx', 1.0)
+    utilities.write_parameter_to_file(f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(f, 'itermax', 1)
+    utilities.write_parameter_to_file(f, 'Np_water', 10)
+    utilities.write_parameter_to_file(f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(f, 'save_sedflux_grids', True)
+    utilities.write_parameter_to_file(f, 'save_dt', 1)
+    f.close()
+
+    _delta = DeltaModel(input_file=p)
+    exp_path_nc = os.path.join(tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    for _ in range(0, 2):
+        _delta.update()
+    assert _delta.time_iter == 2.0
+    _delta.finalize()
+
+    ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")
+    _arr = ds.variables['sedflux']
+    assert _arr.shape[1] == _delta.eta.shape[0]
+    assert _arr.shape[2] == _delta.eta.shape[1]
+


### PR DESCRIPTION
This PR adds a number of outputs to the netCDF file under a `group` named `meta`. The variables added are:
```
L0
N0
CTR
dx
h0
H_SL
f_bedload
C0_percent
u0
```

A new configuration variable needs to be specified to output these metadata variables `save_metadata`, similar to the `save_eta_grids` style names. No output file will be created if these values are not declared.

------------

Separately, support has been added to save the sediment flux grid into the netcdf file with `save_sedflux_grid` (also added the `save_sedflux_figs` support). Closes #99 

-----------------

I will begin work on a separate PR to try and streamline the checkpointing netcdf opening/closing stuffs.