### PR TITLE
add controls for angular bounds of subsiding region

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,10 +38,14 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.graphviz',
               'sphinx.ext.imgmath',
               'sphinx.ext.githubpages',
-              'matplotlib.sphinxext.plot_directive']
+              'matplotlib.sphinxext.plot_directive',
+              'sphinx.ext.todo']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+
+# toggle todo items
+todo_include_todos = True
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/guides/subsidenceguide.rst
+++ b/docs/source/guides/subsidenceguide.rst
@@ -1,0 +1,57 @@
+=======================
+Working with subsidence
+=======================
+
+What is subsidence anyway? Subsidence is basically the downward vertical
+movement of the ground. There are many direct and indirect causes of subsidence,
+check out the `Wikipedia page <https://en.wikipedia.org/wiki/Subsidence>`_
+to get an overview.
+
+Turning on Subsidence in pyDeltaRCM
+===================================
+
+To configure a pyDeltaRCM model with subsidence, the yaml parameter,
+``toggle_subsidence`` must be set to ``True``.
+
+Configuring Lateral Extents of Subsidence
+=========================================
+
+There are two yaml parameters associated with the lateral extents of the
+subsiding region in pyDeltaRCM: ``theta1`` and ``theta2``. ``theta1`` is
+specified in radians and represents the left boundary of the subsiding region.
+The angle in radians is expressed relative to a datum aligned with the inlet
+channel. ``theta2`` determines the right boundary of the subsiding region.
+
+If, for example we wanted the left half of the domain to subside, we would
+write our yaml file with the following parameters:
+
+.. code:: yaml
+
+    toggle_subsidence: True
+    theta1: -1.5707963267948966
+    theta2: 0
+
+This specifies ``theta1`` as negative 90 degrees, and ``theta2`` as 0 degrees.
+Doing so, will generate a domain that has the a subsiding region as shown in
+yellow in the figure below.
+
+.. plot:: userguide/subsidence_region.py
+
+Configuring When Subsidence Occurs
+==================================
+
+To control when subsidence begins over the course of the model run, there is
+another yaml parameter, ``start_subsidence``. The value assigned to this
+parameter controls the time (in seconds) at which the subsidence will be turned
+"on" in the model.
+
+Configuring The Rate of Subsidence
+==================================
+
+.. todo:: Add documentation here.
+
+
+Advanced Subsidence Configurations
+==================================
+
+.. todo:: Bit about subclassing and custom configurations

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -193,3 +193,6 @@ The ensemble expansion can be applied to configuration files that include a matr
         - 2.0
 
 The above configuration file would produce 6 model runs, 3 with a basin depth (`h0`) of 1.0, and 3 with a basin depth of 2.0.
+
+
+.. include:: subsidenceguide.rst

--- a/docs/source/pyplots/userguide/subsidence_region.py
+++ b/docs/source/pyplots/userguide/subsidence_region.py
@@ -1,0 +1,14 @@
+import matplotlib.pyplot as plt
+from math import pi
+import pyDeltaRCM
+
+delta = pyDeltaRCM.DeltaModel()
+delta.toggle_subsidence = True
+delta.theta1 = -pi/2
+delta.theta2 = 0
+delta.init_subsidence()
+
+
+fig, ax = plt.subplots()
+ax.imshow(delta.subsidence_mask)
+plt.show()

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -58,6 +58,12 @@ Csmooth:
 toggle_subsidence:
   type: 'bool'
   default: False
+theta1:
+  type: ['float', 'int']
+  default: -1.0471975511965976
+theta2:
+  type: ['float', 'int']
+  default: 1.0471975511965976
 sigma_max:
   type: ['float', 'int']
   default: 2e-9

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -534,18 +534,28 @@ class init_tools(abc.ABC):
                 print(_msg)
 
     def init_subsidence(self):
-        """
+        """Initialize subsidence pattern.
+
         Initializes patterns of subsidence if
         toggle_subsidence is True (default False)
 
-        Modify the equations for self.subsidence_mask and self.sigma as desired
+        Uses theta1 and theta2 (defined in yaml) to set the angular bounds for
+        the subsiding region. To create a custom subsidence region, we
+        recommend subclassing the DeltaModel class and defining your own array
+        for self.subsidence_mask (a binary array with 1s in the cells that
+        are subsiding and 0s elswhere), and self.sigma (the subsidence mask
+        multiplied with the vertical rate of subsidence and the timestep size).
+
+        theta1 and theta2 are set in relation to the inlet orientation. The
+        inlet channel is at an angle of 0, if theta1 is -pi/3 radians, this
+        means that the angle to the left of the inlet that will be included
+        in the subsiding region is 30 degrees. theta2 defines the right angular
+        bounds for the subsiding region in a similar fashion.
         """
         if self.toggle_subsidence:
 
             R1 = 0.3 * self.L
             R2 = 1. * self.L  # radial limits (fractions of L)
-            theta1 = -pi / 3
-            theta2 = pi / 3.   # angular limits
 
             Rloc = np.sqrt((self.y - self.L0)**2 + (self.x - self.W / 2.)**2)
 
@@ -554,7 +564,8 @@ class init_tools(abc.ABC):
                 (self.x[self.y > self.L0 - 1] - self.W / 2.)
                 / (self.y[self.y > self.L0 - 1] - self.L0 + 1))
             self.subsidence_mask = ((R1 <= Rloc) & (Rloc <= R2) &
-                                    (theta1 <= thetaloc) & (thetaloc <= theta2))
+                                    (self.theta1 <= thetaloc) &
+                                    (thetaloc <= self.theta2))
             self.subsidence_mask[:self.L0, :] = False
 
             self.sigma = self.subsidence_mask * self.sigma_max * self.dt

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -540,6 +540,22 @@ def test_toggle_subsidence(tmp_path):
     assert _delta.toggle_subsidence is True
 
 
+def test_theta1(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'toggle_subsidence': True,
+                                  'theta1': -1.0})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.theta1 == -1
+
+
+def test_theta2(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'toggle_subsidence': True,
+                                  'theta2': 2.0})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.theta2 == 2.0
+
+
 def test_start_subsidence(tmp_path):
     p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                  {'start_subsidence': 12345})

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -823,3 +823,23 @@ def test_Preprocessor_toplevelimport():
 
     assert 'Preprocessor' in dir(pyDeltaRCM)
     assert pyDeltaRCM.Preprocessor is pyDeltaRCM.preprocessor.Preprocessor
+
+
+def test_subsidence_bounds(tmp_path):
+    """Test subsidence bounds."""
+
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'Length', 600.)
+    utilities.write_parameter_to_file(f, 'Width', 600.)
+    utilities.write_parameter_to_file(f, 'dx', 5)
+    utilities.write_parameter_to_file(f, 'toggle_subsidence', True)
+    utilities.write_parameter_to_file(f, 'theta1', -np.pi/2)
+    utilities.write_parameter_to_file(f, 'theta1', 0)
+    f.close()
+    delta = DeltaModel(input_file=p)
+    # assert subsidence mask is binary
+    assert np.all(delta.subsidence_mask == delta.subsidence_mask.astype(bool))
+    # check specific regions
+    assert np.all(delta.subsidence_mask[75:, 60:] == 1)
+    assert np.all(delta.subsidence_mask[:, :55] == 0)


### PR DESCRIPTION
Closes #94.

This adds two parameters to the yaml: `theta1` and `theta2` which set the bounds for the subsiding region. 

Default behavior is unchanged from how it was previously. This just adds a bit of flexibility, for complex situations subclassing should be encouraged/used. Added a few tests to check the yaml behavior and to check that we could control the subsiding region.