### PR TITLE
Options to save xy-components

### DIFF
--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -88,6 +88,10 @@ Output Settings
 
 :attr:`pyDeltaRCM.model.DeltaModel.save_velocity_grids`
 
+:attr:`pyDeltaRCM.model.DeltaModel.save_discharge_components`
+
+:attr:`pyDeltaRCM.model.DeltaModel.save_velocity_components`
+
 :attr:`pyDeltaRCM.model.DeltaModel.save_dt`
 
 :attr:`pyDeltaRCM.model.DeltaModel.checkpoint_dt`

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -112,6 +112,12 @@ save_velocity_grids:
 save_sedflux_grids:
   type: 'bool'
   default: False
+save_discharge_components:
+  type: 'bool'
+  default: False
+save_velocity_components:
+  type: 'bool'
+  default: False
 save_dt:
   type: 'int'
   default: 86400

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -291,7 +291,9 @@ class init_tools(abc.ABC):
         self._save_any_grids = (self._save_eta_grids or
                                 self._save_depth_grids or
                                 self._save_stage_grids or self._save_discharge_grids or
-                                self._save_velocity_grids or self._save_sedflux_grids)
+                                self._save_velocity_grids or self._save_sedflux_grids or
+                                self._save_discharge_components or
+                                self._save_velocity_components)
         self._save_any_figs = (self._save_eta_figs or
                                self._save_depth_figs or
                                self._save_stage_figs or self._save_discharge_figs or
@@ -501,6 +503,20 @@ class init_tools(abc.ABC):
                 sedflux = self.output_netcdf.createVariable(
                     'sedflux', 'f4', ('total_time', 'length', 'width'))
                 sedflux.units = 'cubic meters per second'
+            if self.save_discharge_components:
+                discharge_x = self.output_netcdf.createVariable(
+                    'discharge_x', 'f4', ('total_time', 'length', 'width'))
+                discharge_x.units = 'cubic meters per second'
+                discharge_y = self.output_netcdf.createVariable(
+                    'discharge_y', 'f4', ('total_time', 'length', 'width'))
+                discharge_y.units = 'cubic meters per second'
+            if self.save_velocity_components:
+                velocity_x = self.output_netcdf.createVariable(
+                    'velocity_x', 'f4', ('total_time', 'length', 'width'))
+                velocity_x.units = 'meters per second'
+                velocity_y = self.output_netcdf.createVariable(
+                    'velocity_y', 'f4', ('total_time', 'length', 'width'))
+                velocity_y.units = 'meters per second'
 
             # set up metadata group and populate variables
             def _create_meta_variable(varname, varvalue, varunits,

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -309,6 +309,14 @@ class iteration_tools(abc.ABC):
             if self._save_sedflux_grids:
                 self.save_grids('sedflux', self.qs, save_idx)
 
+            if self._save_discharge_components:
+                self.save_grids('discharge_x', self.qx, save_idx)
+                self.save_grids('discharge_y', self.qy, save_idx)
+
+            if self._save_velocity_components:
+                self.save_grids('velocity_x', self.ux, save_idx)
+                self.save_grids('velocity_y', self.uy, save_idx)
+
         # ------------------ metadata ------------------
         if self._save_metadata:
             self.output_netcdf['meta']['H_SL'][save_idx] = self._H_SL

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -702,6 +702,28 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._save_sedflux_grids = save_sedflux_grids
 
     @property
+    def save_discharge_components(self):
+        """
+        save_discharge_components controls saving of x-y discharge components.
+        """
+        return self._save_discharge_components
+
+    @save_discharge_components.setter
+    def save_discharge_components(self, save_discharge_components):
+        self._save_discharge_components = save_discharge_components
+
+    @property
+    def save_velocity_components(self):
+        """
+        save_velocity_components controls saving of x-y velocity components.
+        """
+        return self._save_velocity_components
+
+    @save_velocity_components.setter
+    def save_velocity_components(self, save_velocity_components):
+        self._save_velocity_components = save_velocity_components
+
+    @property
     def save_dt(self):
         """
         save_dt defines the saving interval in seconds.

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -484,6 +484,22 @@ def test_save_velocity_grids(tmp_path):
     assert _delta._save_any_figs is False
 
 
+def test_save_discharge_components(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'save_discharge_components': True})
+    _delta = DeltaModel(input_file=p)
+    assert _delta._save_any_grids is True
+    assert _delta._save_any_figs is False
+    assert _delta._save_discharge_components is True
+
+def test_save_velocity_components(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'save_velocity_components': True})
+    _delta = DeltaModel(input_file=p)
+    assert _delta._save_any_grids is True
+    assert _delta._save_any_figs is False
+    assert _delta._save_velocity_components is True
+
 def test_save_eta_figs(tmp_path):
     p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                  {'save_eta_figs': True})


### PR DESCRIPTION
This would go after #106 

Pretty straightforward, adds the options to save the x-y components of water velocity and discharge as new yaml parameters `save_discharge_components` and `save_velocity_components`

- [x] Before marking this as "ready" I just want to do a real test run with it to make sure I didn't miss something when adding these new yaml parameters.

Edit: Did a longer run (5,000 timesteps) and it looks like the components work as expected. Differences between true "velocity" and "discharge" grids and re-creations from their components are on the order of 10^-6 or 10^-7 so likely due to truncation in the saved component grids.

Velocity components and the combined velocity grid:
![image](https://user-images.githubusercontent.com/1770513/99580651-535eda80-29a5-11eb-90b6-33db5b9777e7.png)

Recreated velocity grid from components, saved velocity grid, and difference:
![image](https://user-images.githubusercontent.com/1770513/99580735-6f627c00-29a5-11eb-9b84-47323dce8729.png)
