### PR TITLE
FIX: add buffer syncing for output netcdf file on each save

### DIFF
--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -316,6 +316,10 @@ class iteration_tools(abc.ABC):
             self.output_netcdf['meta']['C0_percent'][save_idx] = self.H_SL
             self.output_netcdf['meta']['u0'][save_idx] = self.H_SL
 
+        # -------------------- sync --------------------
+        if (self._save_metadata or self._save_any_grids):
+            self.output_netcdf.sync()
+
     def output_checkpoint(self):
         """Save checkpoint.
 

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -430,7 +430,7 @@ def test_save_one_fig_one_grid(tmp_path):
         _delta.update()
     nc_size_middle = os.path.getsize(exp_path_nc)
     assert _delta.time_iter == 2.0
-    assert nc_size_middle == nc_size_before
+    assert nc_size_middle > nc_size_before
 
     # now finalize, and then file size should increase
     _delta.finalize()


### PR DESCRIPTION
Add buffer syncing for output netcdf file on each save, this prevents a memory overload at the end of a run, if trying to save a large netcdf file.

Ask me how I know we need this...