### PR TITLE
Stepiter yaml + docs fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         echo ${{ github.ref == 'refs/heads/develop' }}
         echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@3.5.5
+      uses: JamesIves/github-pages-deploy-action@3.7.1
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
       with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -129,3 +129,5 @@ Reduced-Complexity Routing Parameters
 :attr:`pyDeltaRCM.model.DeltaModel.coeff_U_ero_sand`
 
 :attr:`pyDeltaRCM.model.DeltaModel.alpha`
+
+:attr:`pyDeltaRCM.model.DeltaModel.stepmax`

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -169,3 +169,6 @@ coeff_U_ero_sand:
 alpha:
   type: ['float', 'int']
   default: 0.1
+stepmax:
+  type: ['float', 'int', 'None']
+  default: null

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -275,7 +275,7 @@ class init_tools(abc.ABC):
         # max number of jumps for parcel
         if self.stepmax is None:
             self.stepmax = 2 * (self.L + self.W)
-        elif type(self.stepmax) == float:
+        else:
             self.stepmax = int(self.stepmax)
 
         # initial width of self.free_surf_walk_indices

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -272,7 +272,12 @@ class init_tools(abc.ABC):
         self.Qs0 = self.Qw0 * self.C0  # sediment total input discharge
         self.Vp_sed = self.dVs / self._Np_sed   # volume of each sediment parcel
 
-        self.stepmax = 2 * (self.L + self.W)  # max number of jumps for parcel
+        # max number of jumps for parcel
+        if self.stepmax is None:
+            self.stepmax = 2 * (self.L + self.W)
+        elif type(self.stepmax) == float:
+            self.stepmax = int(self.stepmax)
+
         # initial width of self.free_surf_walk_indices
         self.size_indices = int(self.stepmax / 2)
 
@@ -290,18 +295,21 @@ class init_tools(abc.ABC):
 
         self._save_any_grids = (self._save_eta_grids or
                                 self._save_depth_grids or
-                                self._save_stage_grids or self._save_discharge_grids or
-                                self._save_velocity_grids or self._save_sedflux_grids or
+                                self._save_stage_grids or
+                                self._save_discharge_grids or
+                                self._save_velocity_grids or
+                                self._save_sedflux_grids or
                                 self._save_discharge_components or
                                 self._save_velocity_components)
         self._save_any_figs = (self._save_eta_figs or
                                self._save_depth_figs or
-                               self._save_stage_figs or self._save_discharge_figs or
-                               self._save_velocity_figs or self._save_sedflux_figs)
+                               self._save_stage_figs or
+                               self._save_discharge_figs or
+                               self._save_velocity_figs or
+                               self._save_sedflux_figs)
         if self._save_any_grids:  # always save metadata if saving grids
             self._save_metadata = True
         self._is_finalized = False
-
 
     def create_domain(self):
         """
@@ -332,7 +340,8 @@ class init_tools(abc.ABC):
         self.Vp_dep_mud = np.zeros((self.L, self.W))
         self.free_surf_flag = np.zeros((self._Np_water,), dtype=np.int64)
         self.looped = np.zeros((self._Np_water,), dtype=np.int64)
-        self.free_surf_walk_indices = np.zeros((self._Np_water, self.size_indices),
+        self.free_surf_walk_indices = np.zeros((self._Np_water,
+                                                self.size_indices),
                                                dtype=np.int64)
         self.sfc_visit = np.zeros_like(self.depth)
         self.sfc_sum = np.zeros_like(self.depth)

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -958,6 +958,33 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._alpha = alpha
 
     @property
+    def stepmax(self):
+        """
+        stepmax is the maximum number of jumps a parcel can make.
+
+        stepmax is the maximum number of jumps a parcel (water or sediment)
+        can make. If the parcel reaches the oceanic boundary before stepmax is
+        reached, then this condition is not invoked. However if the parcel
+        does not reach the oceaninc bounary but does reach "stepmax" jumps,
+        then the parcel will just stop moving and disappear.
+
+        If stepmax is not specified in the yaml, the default value assigned
+        is 2 times the perimeter of the domain (2 * (self.L + self.W)).
+
+        .. note::
+           If stepmax is set too low and many parcels reach the stepmax
+           condition during routing, then there may be a considerable
+           amount of sediment 'missing' from the system as any sediment in
+           a parcel that hits the stepmax threshold disappears from the
+           simulation.
+        """
+        return self._stepmax
+
+    @stepmax.setter
+    def stepmax(self, stepmax):
+        self._stepmax = stepmax
+
+    @property
     def time(self):
         """Elapsed model time in seconds.
         """

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -424,6 +424,27 @@ def test_alpha(tmp_path):
     assert _delta.alpha == 0.25
 
 
+def test_stepmax_default(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'alpha': 0.25})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.stepmax == 2 * (_delta.L + _delta.W)
+
+
+def test_stepmax_integer(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'stepmax': 10})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.stepmax == 10
+
+
+def test_stepmax_float(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'stepmax': 11.0})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.stepmax == 11
+
+
 def test_diffusion_multiplier(tmp_path):
     p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                  {'u0': 0.8,


### PR DESCRIPTION
Hello. 

This PR makes `stepiter` a configurable yaml parameter, consistent with our efforts to make the model as configurable as possible. If unspecified the default is still `2 * (L + W)` or the number of cells along the perimeter of the domain.

Maybe more importantly, I think the docs action broke because there were some Actions security vulnerabilities that GitHub has recently fixed. So I just bumped us up to the most recent version of the docs action and it seems to be working now.