### PR TITLE
Bedrock

### DIFF
--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -62,6 +62,12 @@ Model Domain Parameters
 
 :attr:`pyDeltaRCM.model.DeltaModel.start_subsidence`
 
+:attr:`pyDeltaRCM.model.DeltaModel.bedrock`
+
+:attr:`pyDeltaRCM.model.DeltaModel.bedrock_depth`
+
+:attr:`pyDeltaRCM.model.DeltaModel.lithification`
+
 
 Output Settings
 ===============

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -76,6 +76,9 @@ bedrock:
 bedrock_depth:
   type: ['float', 'int']
   default: -5
+lithification:
+  type: 'bool'
+  default: False
 save_eta_figs:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -70,6 +70,12 @@ sigma_max:
 start_subsidence:
   type: ['float', 'int']
   default: 216000
+bedrock:
+  type: 'bool'
+  default: False
+bedrock_depth:
+  type: ['float', 'int']
+  default: -5
 save_eta_figs:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -74,8 +74,8 @@ bedrock:
   type: 'bool'
   default: False
 bedrock_depth:
-  type: ['float', 'int']
-  default: -5
+  type: ['float', 'int', 'None']
+  default: null
 lithification:
   type: 'bool'
   default: False

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -407,7 +407,8 @@ class init_tools(abc.ABC):
                                        self.iwalk_flat, self.jwalk_flat,
                                        self.distances_flat, self.dry_depth, self.gamma,
                                        self._lambda, self._beta,  self.stepmax,
-                                       self.theta_mud)
+                                       self.theta_mud, self._bedrock,
+                                       self._bedrock_depth)
         # initialize the SandRouter object
         self._sr = sed_tools.SandRouter(self._dt, self._dx, self.Vp_sed,
                                         self.u_max, self.qs0, self._u0, self.U_ero_sand,
@@ -416,7 +417,8 @@ class init_tools(abc.ABC):
                                         self.iwalk_flat, self.jwalk_flat,
                                         self.distances_flat, self.dry_depth, self.gamma,
                                         self._beta, self.stepmax,
-                                        self.theta_sand)
+                                        self.theta_sand, self._bedrock,
+                                        self._bedrock_depth)
 
     def init_stratigraphy(self):
         """Creates sparse array to store stratigraphy data."""

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -84,7 +84,8 @@ class iteration_tools(abc.ABC):
         self.depth[0, self.inlet] = self._h0
 
         self.H_SL = self._H_SL + self._SLR * self._dt
-        self._bedrock_depth = self._bedrock_depth + self._SLR * self._dt
+        if self._lithification is True:
+            self._bedrock_depth = self._bedrock_depth + self._SLR * self._dt
 
     def expand_stratigraphy(self):
         """Expand stratigraphy array sizes.

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -66,7 +66,8 @@ class iteration_tools(abc.ABC):
         Clean up after sediment routing. This includes a correction for
         flooded cells that are not "wet" (via :meth:`flooding_correction`).
 
-        Update sea level if baselevel changes between timesteps.
+        Update sea level if baselevel changes between timesteps, also update
+        the bedrock depth if lithification is turned on.
 
         Parameters
         ----------
@@ -83,6 +84,7 @@ class iteration_tools(abc.ABC):
         self.depth[0, self.inlet] = self._h0
 
         self.H_SL = self._H_SL + self._SLR * self._dt
+        self._bedrock_depth = self._bedrock_depth + self._SLR * self._dt
 
     def expand_stratigraphy(self):
         """Expand stratigraphy array sizes.

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -84,7 +84,7 @@ class iteration_tools(abc.ABC):
         self.depth[0, self.inlet] = self._h0
 
         self.H_SL = self._H_SL + self._SLR * self._dt
-        if self._lithification is True:
+        if (self._lithification is True) and (self._bedrock is True):
             self._bedrock_depth = self._bedrock_depth + self._SLR * self._dt
 
     def expand_stratigraphy(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -548,6 +548,28 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._start_subsidence = start_subsidence
 
     @property
+    def bedrock(self):
+        """
+        defines whether or not bedrock exists.
+        """
+        return self._bedrock
+
+    @bedrock.setter
+    def bedrock(self, bedrock):
+        self._bedrock = bedrock
+
+    @property
+    def bedrock_depth(self):
+        """
+        sets the depth of bedrock
+        """
+        return self._bedrock_depth
+
+    @bedrock_depth.setter
+    def bedrock_depth(self, bedrock_depth):
+        self._bedrock_depth = float(bedrock_depth)
+
+    @property
     def save_eta_figs(self):
         """
         save_eta_figs controls whether or not figures of topography are saved.

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -554,8 +554,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         Default is False, meaning that there is no bedrock (or basement) to the
         basin and erosion can continue unbounded. If set to True, then the
-        value of `bedrock_depth` defines the basement (or bedrock) depth below
-        which no erosion will be allowed to occur.
+        value of :attr:`bedrock_depth` defines the basement (or bedrock) depth
+        below which no erosion will be allowed to occur.
         """
         return self._bedrock
 
@@ -568,9 +568,9 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         """
         Set depth of bedrock.
 
-        If default value of `None` is used and `bedrock` is set to True, then
-        the bedrock depth will be set as 2x the characteristic water depth,
-        `h0`.
+        If default value of `None` is used and :attr:`bedrock` is set to True,
+        then the bedrock depth will be set as 2x the characteristic water
+        depth, :attr:`h0`.
         """
         return self._bedrock_depth
 
@@ -586,10 +586,11 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         """
         Allow bedrock depth to vary with SLR.
 
-        If set to True, then `bedrock_depth` is updated as sea level rises
-        such that bedrock is updated to remain at `H_SL - bedrock_depth` as
-        opposed to being the static value of `bedrock_depth` relative to the
-        initial sea level.
+        If set to True, then :attr:`bedrock_depth` is updated as sea level
+        rises such that bedrock is updated to remain at a depth of
+        :attr:`H_SL` - :attr:`bedrock_depth` as
+        opposed to being the static value of :attr:`bedrock_depth` relative
+        to the initial sea level.
         """
         return self._lithification
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -597,6 +597,9 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @lithification.setter
     def lithification(self, lithification):
         self._lithification = lithification
+        # force bedrock to be turned on if lithification is on
+        if lithification is True:
+            self.bedrock = True
 
     @property
     def save_eta_figs(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -570,6 +570,22 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._bedrock_depth = float(bedrock_depth)
 
     @property
+    def lithification(self):
+        """
+        Allows bedrock depth to vary with SLR.
+
+        If set to True, then `bedrock_depth` is updated as sea level rises
+        such that bedrock is updated to begin at `H_SL - bedrock_depth` as
+        opposed to being the static value of `bedrock_depth` relative to the
+        initial sea level.
+        """
+        return self._lithification
+
+    @lithification.setter
+    def lithification(self, lithification):
+        self._lithification = lithification
+
+    @property
     def save_eta_figs(self):
         """
         save_eta_figs controls whether or not figures of topography are saved.

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -568,18 +568,23 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         """
         Set depth of bedrock.
 
-        If default value of `None` is used and :attr:`bedrock` is set to True,
-        then the bedrock depth will be set as 2x the characteristic water
-        depth, :attr:`h0`.
+        If default value of `None` is used, then the bedrock depth will be set
+        as 2x the characteristic water depth, :attr:`h0`. If the value assigned
+        to the bedrock depth is above the initial basement floor of the basin,
+        then an error is raised.
         """
         return self._bedrock_depth
 
     @bedrock_depth.setter
     def bedrock_depth(self, bedrock_depth):
         if bedrock_depth is None:
-            self._bedrock_depth = float(2 * self._h0)
-        else:
+            self._bedrock_depth = float(-1 * 2 * self._h0)
+        elif bedrock_depth < self._h0:
             self._bedrock_depth = float(bedrock_depth)
+        else:
+            raise ValueError('Invalid bedrock depth provided, must be' +
+                             ' less than or equal to the initial basement' +
+                             ' the basin')
 
     @property
     def lithification(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -550,7 +550,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @property
     def bedrock(self):
         """
-        defines whether or not bedrock exists.
+        Define whether or not bedrock exists.
+
+        Default is False, meaning that there is no bedrock (or basement) to the
+        basin and erosion can continue unbounded. If set to True, then the
+        value of `bedrock_depth` defines the basement (or bedrock) depth below
+        which no erosion will be allowed to occur.
         """
         return self._bedrock
 
@@ -561,21 +566,28 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @property
     def bedrock_depth(self):
         """
-        sets the depth of bedrock
+        Set depth of bedrock.
+
+        If default value of `None` is used and `bedrock` is set to True, then
+        the bedrock depth will be set as 2x the characteristic water depth,
+        `h0`.
         """
         return self._bedrock_depth
 
     @bedrock_depth.setter
     def bedrock_depth(self, bedrock_depth):
-        self._bedrock_depth = float(bedrock_depth)
+        if bedrock_depth is None:
+            self._bedrock_depth = float(2 * self._h0)
+        else:
+            self._bedrock_depth = float(bedrock_depth)
 
     @property
     def lithification(self):
         """
-        Allows bedrock depth to vary with SLR.
+        Allow bedrock depth to vary with SLR.
 
         If set to True, then `bedrock_depth` is updated as sea level rises
-        such that bedrock is updated to begin at `H_SL - bedrock_depth` as
+        such that bedrock is updated to remain at `H_SL - bedrock_depth` as
         opposed to being the static value of `bedrock_depth` relative to the
         initial sea level.
         """

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -329,7 +329,7 @@ class BaseRouter(object):
             # if new bed elev is below bedrock eroded volume must change
             # cannot be greater than 0 as this is erosion
             Vp_change = ((eta - bedrock_depth) / (dx * dx))
-            return np.minimum(Vp_change, 0)
+        return np.minimum(Vp_change, 0)
 
 
 @jitclass(r_spec)
@@ -351,7 +351,8 @@ class SandRouter(BaseRouter):
     """
     def __init__(self, _dt, dx, Vp_sed, u_max, qs0, u0, U_ero_sand, f_bedload,
                  ivec_flat, jvec_flat, iwalk_flat, jwalk_flat, distances_flat,
-                 dry_depth, gamma, beta, stepmax, theta_sed):
+                 dry_depth, gamma, beta, stepmax, theta_sed,
+                 _bedrock, _bedrock_depth):
 
         self._dt = _dt
         self._dx = dx
@@ -372,6 +373,9 @@ class SandRouter(BaseRouter):
         self._beta = beta
         self.stepmax = stepmax
         self.theta_sed = theta_sed
+
+        self._bedrock = _bedrock
+        self._bedrock_depth = _bedrock_depth
 
     def run(self, start_indices, eta, stage, depth, cell_type,
             uw, ux, uy, pad_stage, pad_depth, pad_cell_type, Vp_dep_mud, Vp_dep_sand,
@@ -565,7 +569,8 @@ class MudRouter(BaseRouter):
     """
     def __init__(self, _dt, dx, Vp_sed, u_max, U_dep_mud, U_ero_mud,
                  ivec_flat, jvec_flat, iwalk_flat, jwalk_flat, distances_flat,
-                 dry_depth, gamma, _lambda, beta, stepmax, theta_sed):
+                 dry_depth, gamma, _lambda, beta, stepmax, theta_sed,
+                 _bedrock, _bedrock_depth):
 
         self._dt = _dt
         self._dx = dx
@@ -585,6 +590,9 @@ class MudRouter(BaseRouter):
         self._beta = beta
         self.stepmax = stepmax
         self.theta_sed = theta_sed
+
+        self._bedrock = _bedrock
+        self._bedrock_depth = _bedrock_depth
 
     def run(self, start_indices, eta, stage, depth, cell_type,
             uw, ux, uy, pad_stage, pad_depth, pad_cell_type, Vp_dep_mud, Vp_dep_sand,

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -610,6 +610,31 @@ def test_sigma_max(tmp_path):
     assert np.all(_delta.sigma <= (1e-9 * _delta.dt))
 
 
+def test_bedrock(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'bedrock': True})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.bedrock is True
+    assert _delta.bedrock_depth == -1 * 2 * _delta._h0
+
+
+def test_bedrock_depth(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'bedrock': True,
+                                  'bedrock_depth': -15.0})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.bedrock is True
+    assert _delta.bedrock_depth == -15.0
+
+
+def test_lithification(tmp_path):
+    p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                 {'lithification': True})
+    _delta = DeltaModel(input_file=p)
+    assert _delta.bedrock is True
+    assert _delta.bedrock_depth == -1 * 2 * _delta._h0
+    assert _delta.lithification is True
+
 # test definition of the model domain
 
 def test_x(test_DeltaModel):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1249,6 +1249,16 @@ def test_negative_Csmooth(tmp_path):
         delta = DeltaModel(input_file=p)
 
 
+def test_invalid_bedrock_depth(tmp_path):
+    file_name = 'user_parameters.yaml'
+    p, f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+    utilities.write_parameter_to_file(f, 'bedrock_depth', 100)
+    f.close()
+    with pytest.raises(ValueError):
+        delta = DeltaModel(input_file=p)
+
+
 class TestScaleRelativeSeaLeveLRiseRate():
 
     def test_scale_If_1(self):

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -28,6 +28,23 @@ def test_finalize_timestep(test_DeltaModel):
     assert test_DeltaModel.H_SL == 0.3
 
 
+def test_finalize_timestep_lithification(test_DeltaModel):
+    # assert lithification is initially off
+    assert test_DeltaModel.lithification is False
+    # turn it on and assert that both lithification and bedrock are on
+    test_DeltaModel.lithification = True
+    assert test_DeltaModel.lithification is True
+    assert test_DeltaModel.bedrock is True
+    # assert initial bedrock depth
+    assert test_DeltaModel.bedrock_depth == -1 * 2 * test_DeltaModel.h0
+    # finalize where SL rises and so does bedrock boundary
+    test_DeltaModel.finalize_timestep()
+    # check that sea level rose as expected
+    assert test_DeltaModel.H_SL == 0.3
+    # check that bedrock boundary rose as expected too
+    assert test_DeltaModel.bedrock_depth == -1 * 2 * test_DeltaModel.h0 + 0.3
+
+
 def test_subsidence_in_update(tmp_path):
     p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                  {'toggle_subsidence': True,


### PR DESCRIPTION
Wanted to get some feedback/thoughts on this potential addition to the model.

---

Idea is to establish some parameters to simulate "bedrock" in the modeled basins. This implementation introduces 3 new yaml parameters:

- `bedrock` : a boolean that can be set to "True" to turn on the bedrock feature (default is False)
- `bedrock_depth` : a float that sets the initial bedrock depth, new functions prevent model from eroding sediment below this depth
- `lithification` : a boolean that can be set to "True" to do crude dynamic lithification of sediment (default is False). Basically it makes the value of `bedrock_depth` adjust dynamically with sea level, so if sea level rises 1m, the value of `bedrock_depth` is increased by 1m (e.g. if bedrock was 5m below sea level initially, it becomes 4m, "lithifying" any sediment deposited in that 1m of space that was previously reworkable)

Still need to run longer models and create some unit tests, but initial implementation doesn't add very much overhead to run times. But my general question is: **Is this addition something we think would be useful to add to the pydeltarcm model?**

The bedrock functionality influences the morphology as we might expect. Below is an example with a control (no bedrock) model, and a companion "shallow" bedrock model where the bedrock depth was set as the model basin depth (-5m). The original model with no limits on scouring incises a deep channel (deeper than -8m), whereas the model with bedrock is forced to develop wider channels.

![image](https://user-images.githubusercontent.com/1770513/101789726-3fe7f080-3ac7-11eb-8bcb-3aa2f06998bf.png)


Turned out to be a pretty small addition code-wise, so I am totally okay with not making this part of the core model and leaving it as a "hook" type of alternative implementation/model variant... 

---
To do:

- [x] add unit tests
- [ ] some longer comparison scenarios to default case
- [x] doc-strings for new functions/parameters
- [ ] proper documentation about the feature