### PR TITLE
fix bug with preprocessor resuming from checkpoints, changed with the…

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -283,6 +283,7 @@ class BasePreprocessor(abc.ABC):
             specified in the command line interface.
             """
             self.deltamodel = DeltaModel(input_file=input_file)
+            _curr_time = self.deltamodel._time
 
             self.timesteps = ('timesteps', cli_dict, yaml_dict)
             self.time = ('time', cli_dict, yaml_dict)
@@ -291,11 +292,13 @@ class BasePreprocessor(abc.ABC):
 
             # determine job end time, *in model time*
             if not (self.timesteps is None):
-                self._job_end_time = (self.timesteps * self.deltamodel._dt)
+                self._job_end_time = _curr_time + \
+                    ((self.timesteps * self.deltamodel._dt))
             elif not (self.time is None):
-                self._job_end_time = (self.time) * self.If
+                self._job_end_time = _curr_time + ((self.time) * self.If)
             elif not (self.time_years is None):
-                self._job_end_time = (self.time_years) * self.If * 86400 * 365.25
+                self._job_end_time = _curr_time + \
+                    ((self.time_years) * self.If * 86400 * 365.25)
             else:
                 raise ValueError(
                     'You must specify a run duration configuration in either '


### PR DESCRIPTION
Fix a bug with preprocessor resuming from checkpoints. 

The bug was introduced when I changed the approach to timestepping to use `while _time < _end_time:`.

The problem was that when resuming from checkpoint, the computed end time for the run would be, e.g., `10 * timestep`, but if resuming from a run that already ran `100 * timestep`, then the current model time would be greater than the end time and the while loop would never enter. 

So, the fix is to compute the new end time as: ` _end_time = _curr_time+ (computed_time)`. In the case of a fresh run (not resuming from checkpoint), `_curr_time` is just `0`.