### PR TITLE
Fix an edge case random number problem

### DIFF
--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -69,8 +69,11 @@ def random_pick(prob):
     Takes a numpy array that is the precalculated cumulative probability
     around the cell flattened to 1D.
     """
-    arr = np.arange(len(prob))
-    return arr[np.searchsorted(np.cumsum(prob), get_random_uniform(1))]
+    len_prob = len(prob)
+    arr = np.arange(len_prob)
+    idx = np.searchsorted(np.cumsum(prob), get_random_uniform(1))
+    idx = np.minimum(idx, len_prob-1)
+    return arr[idx]
 
 
 @njit

--- a/tests/test_shared_tools.py
+++ b/tests/test_shared_tools.py
@@ -80,6 +80,29 @@ def test_random_pick_anybut_first(test_DeltaModel):
     assert np.sum(_rets == 8) > 0
 
 
+@pytest.mark.xfail(strict=True, reason='cannot mock a jitted function')
+def test_random_pick_edgecase(mocker):
+    """
+    This test PASSES if `export NUMBA_DISABLE_JIT=1` is declared.
+    I.e., if the mock can work...
+    """
+    mocked = mocker.patch('pyDeltaRCM.shared_tools.get_random_uniform')
+
+    probs = np.array([0, 0,          0.23647638,
+                      0, 0,          0.49098423,
+                      0, 0.01803146, 0.2545079])
+    mocked.return_value = 0
+    assert shared_tools.random_pick(probs.flatten()) == 0
+    mocked.return_value = 0.1
+    assert shared_tools.random_pick(probs.flatten()) == 2
+    mocked.return_value = 0.9999
+    assert shared_tools.random_pick(probs.flatten()) == 8
+    mocked.return_value = 0.9999999
+    assert shared_tools.random_pick(probs.flatten()) == 8
+    mocked.return_value = 1
+    assert shared_tools.random_pick(probs.flatten()) == 8
+
+
 def test_custom_unravel_square():
     arr = np.arange(9).reshape((3, 3))
     # test upper left corner


### PR DESCRIPTION
This PR fixes an edge case indexing bug. Problem arose when probabilities of cell options going into `shared_tools.random_pick` were not exactly `sum(probs)==1` due to rounding or some other cause. If the random number generated in this case was between 1 and the `sum(probs)`, the returned index would be `9` into a `(9,)` shaped array, and triggering an index error ([this is an example of the error](https://github.com/DeltaRCM/pyDeltaRCM/issues/107#issuecomment-752637750)). 

Now, the returned idx is limited to the length of the vector. This is a slight fudge, i.e., making the probability of the last cell slightly larger than it would otherwise be, but it does not appear to be an issue.