### PR TITLE
Overhaul docs with checkpointed examples

### DIFF
--- a/docs/source/_resources/checkpoint.yaml
+++ b/docs/source/_resources/checkpoint.yaml
@@ -1,0 +1,3 @@
+out_dir: 'deltaRCM_Output'
+seed: 451220118313
+save_checkpoint: True

--- a/docs/source/_resources/checkpoint.yaml
+++ b/docs/source/_resources/checkpoint.yaml
@@ -1,3 +1,3 @@
-out_dir: 'deltaRCM_Output'
+out_dir: 'checkpoint'
 seed: 451220118313
 save_checkpoint: True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ napoleon_use_rtype = True
 # Autosummary / Automodapi settings
 autosummary_generate = True
 automodapi_inheritance_diagram = False
-autodoc_default_options = {'members': True, 'inherited-members': True,
+autodoc_default_options = {'members': True, 'inherited-members': False,
                            'private-members': True}
 
 # doctest

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -12,7 +12,23 @@ First, we instantiate the main :obj:`~pyDeltaRCM.deltaRCM_driver.pyDeltaRCM` mod
 
     >>> import pyDeltaRCM
 
-    >>> delta = pyDeltaRCM.DeltaModel()
+    >>> default_delta = pyDeltaRCM.DeltaModel()
+
+Instantiating the :obj:`~pyDeltaRCM.model.DeltaModel()` without any arguments will use a set of :doc:`default parameters <../reference/model/yaml_defaults>` to configure the model run.
+The default options are a reasonable set for exploring some controls of the model, and would work perfectly well for a simple demonstration here.
+However, to run a simulation with a non-default set of parameters, we can use a configuration file written in the YAML markup language named `10min_tutorial.yaml`.
+For example, we can specify where we would like the output file to be placed with the `out_dir` parameter, and ensure that our simulation is easily reproducible by setting the random `seed` parameter:
+
+.. code:: yaml
+
+    out_dir: '10min_tutorial'
+    seed: 451220118313
+
+Now, we can create a second instance of the :obj:`~pyDeltaRCM.model.DeltaModel()`, this time using the input yaml file.
+
+.. code::
+
+    >>> delta = pyDeltaRCM.DeltaModel(input_file='10min_tutorial.yaml')
 
 Next, since this is just a simple demo, we will run for a few short timesteps.
 The delta model is run forward with a call to the :meth:`~pyDeltaRCM.DeltaModel.update()` method of the delta model.

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -3,7 +3,11 @@
 ******************
 
 Use pyDeltaRCM in ten minutes!
+This simple guide will show you the absolute basics of getting a `pyDeltaRCM` model running, and give you some direction on where to go from there.
 
+
+A default model
+---------------
 
 You can get a model running with three simple lines of code.
 First, we instantiate the main :obj:`~pyDeltaRCM.deltaRCM_driver.pyDeltaRCM` model object.
@@ -16,13 +20,19 @@ First, we instantiate the main :obj:`~pyDeltaRCM.deltaRCM_driver.pyDeltaRCM` mod
 
 Instantiating the :obj:`~pyDeltaRCM.model.DeltaModel()` without any arguments will use a set of :doc:`default parameters <../reference/model/yaml_defaults>` to configure the model run.
 The default options are a reasonable set for exploring some controls of the model, and would work perfectly well for a simple demonstration here.
-However, to run a simulation with a non-default set of parameters, we can use a configuration file written in the YAML markup language named `10min_tutorial.yaml`.
-For example, we can specify where we would like the output file to be placed with the `out_dir` parameter, and ensure that our simulation is easily reproducible by setting the random `seed` parameter:
+
+
+The model with set parameters
+-----------------------------
+
+To run a simulation with a non-default set of parameters, we can use a configuration file written in the YAML markup language named `10min_tutorial.yaml`.
+For example, we can specify where we would like the output file to be placed with the `out_dir` parameter, ensure that our simulation is easily reproducible by setting the random `seed` parameter, and examine what is the effect of a high fraction of bedload:
 
 .. code:: yaml
 
     out_dir: '10min_tutorial'
     seed: 451220118313
+    f_bedload: 0.9
 
 Now, we can create a second instance of the :obj:`~pyDeltaRCM.model.DeltaModel()`, this time using the input yaml file.
 
@@ -54,3 +64,12 @@ We can visualize the delta bed elevation, though it's not very exciting after on
     >>> plt.show()
 
 .. plot:: 10min/model_run_visual.py
+
+
+Resources
+---------
+
+Consider reading through the :doc:`User Guide <user_guide>` as a first action, and determine how to set up the model to complete your experiment, including tutorials and examples for customizing the model to achieve any arbitrary behavior you need!
+
+* :doc:`user_guide`
+* :doc:`/reference/model/index`

--- a/docs/source/guides/user_guide.rst
+++ b/docs/source/guides/user_guide.rst
@@ -4,6 +4,10 @@ User Guide
 
 Guide to users!
 
+.. note::
+
+   Incomplete. Needs basic instructions on how to configure the model in a scripting setting. Something like the 10-min guide, just repeated here.
+
 
 ==============================
 Configuring an input YAML file

--- a/docs/source/info/hydrodynamics.rst
+++ b/docs/source/info/hydrodynamics.rst
@@ -32,7 +32,7 @@ While downstream of the land-ocean boundary (determined by a depth-or-velocity t
 The algorithm tracks the number of times each cell has been visited by a water parcel (``sfc_visit``), and the *total sum of expected elevations* of the water surface at each cell (``sfc_sum``), by adding the predicted surface elevation of each parcel step while iterating through each step of each parcel.
 
 Next, the output from :obj:`_accumulate_free_surface_walks` is used to calculate a new stage surface (``H_new``) based only on the water parcel paths and expected water surface elevations, approximately as ``H_new = sfc_sum / sfc_visit``.
-The updated water surface is combined with the previous timestep's water surface and an underrelaxation coefficient (:obj:`_omega_sfc`).
+The updated water surface is combined with the previous timestep's water surface and an under-relaxation coefficient (:obj:`_omega_sfc`).
 
 .. plot:: water_tools/compute_free_surface_outputs.py
 

--- a/docs/source/info/hydrodynamics.rst
+++ b/docs/source/info/hydrodynamics.rst
@@ -2,6 +2,8 @@
 Hydrodynamics
 *************
 
+.. currentmodule:: pyDeltaRCM.water_tools
+
 pyDeltaRCM approximates hydrodynamics through the use of a weighted random walk.
 See [1]_ and [2]_ for a complete description of hydrodynamic assumptions in the DeltaRCM model.
 In this documentation, we focus on the details of *model implementation*, rather than *model design*.
@@ -18,27 +20,27 @@ Combining parcels into free surface
 ===================================
 
 Following the routing of water parcels, these walks must be converted in some meaningful way to a model field representing a free surface (i.e., the water stage).
-First, the :obj:`compute_free_surface` is called, which takes as input the current bed elevation, and the path of each water parcel (top row in figure below).
+First, the :meth:`~water_tools.compute_free_surface` is called, which takes as input the current bed elevation, and the path of each water parcel (top row in figure below).
 
 .. plot:: water_tools/compute_free_surface_inputs.py
 
-The :obj:`compute_free_surface` method internally calls the :obj:`_accumulate_free_surface_walks` function to determine 1) the number of times each cell has been visited by a water parcel
+The :meth:`~water_tools.compute_free_surface` method internally calls the :func:`_accumulate_free_surface_walks` function to determine 1) the number of times each cell has been visited by a water parcel
 (``sfc_visit``), and 2) the *total sum of expected elevations* of the water surface at each cell (``sfc_sum``).
-:obj:`_accumulate_free_surface_walks` itself iterates through each water parcel, beginning from the end-point of the path, and working upstream; note that parcels that have been determined to "loop" (:obj:`_check_for_loops` and described above) are excluded from computation in determining the free surface.
-While downstream of the land-ocean boundary (determined by a depth-or-velocity threshold), the water surface elevation is assumed to be ``0``, whereas upstream of this boundary, the predicted elevation of the water surface is determined by the distance from the previously identified water surface elevation and the background land slope (:obj:`S0`), such the the water surface maintains an approximately constant slope for each parcel pathway.
+:func:`_accumulate_free_surface_walks` itself iterates through each water parcel, beginning from the end-point of the path, and working upstream; note that parcels that have been determined to "loop" (:func:`_check_for_loops` and described above) are excluded from computation in determining the free surface.
+While downstream of the land-ocean boundary (determined by a depth-or-velocity threshold), the water surface elevation is assumed to be ``0``, whereas upstream of this boundary, the predicted elevation of the water surface is determined by the distance from the previously identified water surface elevation and the background land slope (:attr:`~pyDeltaRCM.DeltaModel.S0`), such the the water surface maintains an approximately constant slope for each parcel pathway.
 
 .. plot:: water_tools/_accumulate_free_surface_walks.py
 
 The algorithm tracks the number of times each cell has been visited by a water parcel (``sfc_visit``), and the *total sum of expected elevations* of the water surface at each cell (``sfc_sum``), by adding the predicted surface elevation of each parcel step while iterating through each step of each parcel.
 
-Next, the output from :obj:`_accumulate_free_surface_walks` is used to calculate a new stage surface (``H_new``) based only on the water parcel paths and expected water surface elevations, approximately as ``H_new = sfc_sum / sfc_visit``.
-The updated water surface is combined with the previous timestep's water surface and an under-relaxation coefficient (:obj:`_omega_sfc`).
+Next, the output from :func:`_accumulate_free_surface_walks` is used to calculate a new stage surface (``H_new``) based only on the water parcel paths and expected water surface elevations, approximately as ``H_new = sfc_sum / sfc_visit``.
+The updated water surface is combined with the previous timestep's water surface and an under-relaxation coefficient (:attr:`~pyDeltaRCM.DeltaModel.omega_sfc`).
 
 .. plot:: water_tools/compute_free_surface_outputs.py
 
 With a new free surface computed, a few final operations prepare the surface for boundary condition updates and eventually being passed to the sediment routing operations.
 A non-linear smoothing operation is applied to the free surface, whereby wet cells are iteratively averaged with neighboring wet cells to yield an overall smoother surface.
-The smoothing is handled by :obj:`_smooth_free_surface` and depends on the number of iterations (:obj:`Nsmooth`) and a weighting coefficient (:obj:`Csmooth`).
+The smoothing is handled by :func:`_smooth_free_surface` and depends on the number of iterations (:attr:`~pyDeltaRCM.DeltaModel.Nsmooth`) and a weighting coefficient (:attr:`~pyDeltaRCM.DeltaModel.Csmooth`).
 
 .. plot:: water_tools/_smooth_free_surface.py
 

--- a/docs/source/info/hydrodynamics.rst
+++ b/docs/source/info/hydrodynamics.rst
@@ -16,6 +16,11 @@ Routing individual water parcels
    Incomplete.
 
 
+The following figure shows several examples of locations within the model domain, and the corresponding water routing weights determined for that location.
+
+.. plot:: water_tools/water_weights_examples.py
+
+
 Combining parcels into free surface
 ===================================
 

--- a/docs/source/info/hydrodynamics.rst
+++ b/docs/source/info/hydrodynamics.rst
@@ -3,6 +3,69 @@ Hydrodynamics
 *************
 
 pyDeltaRCM approximates hydrodynamics through the use of a weighted random walk.
+See [1]_ and [2]_ for a complete description of hydrodynamic assumptions in the DeltaRCM model.
+In this documentation, we focus on the details of *model implementation*, rather than *model design*.
+
+Routing individual water parcels
+================================
 
 .. note::
+
    Incomplete.
+
+
+Combining parcels into free surface
+===================================
+
+Following the routing of water parcels, these walks must be converted in some meaningful way to a model field representing a free surface (i.e., the water stage).
+First, the :obj:`compute_free_surface` is called, which takes as input the current bed elevation, and the path of each water parcel (top row in figure below).
+
+.. plot:: water_tools/compute_free_surface_inputs.py
+
+The :obj:`compute_free_surface` method internally calls the :obj:`_accumulate_free_surface_walks` function to determine 1) the number of times each cell has been visited by a water parcel
+(``sfc_visit``), and 2) the *total sum of expected elevations* of the water surface at each cell (``sfc_sum``).
+:obj:`_accumulate_free_surface_walks` itself iterates through each water parcel, beginning from the end-point of the path, and working upstream; note that parcels that have been determined to "loop" (:obj:`_check_for_loops` and described above) are excluded from computation in determining the free surface.
+While downstream of the land-ocean boundary (determined by a depth-or-velocity threshold), the water surface elevation is assumed to be ``0``, whereas upstream of this boundary, the predicted elevation of the water surface is determined by the distance from the previously identified water surface elevation and the background land slope (:obj:`S0`), such the the water surface maintains an approximately constant slope for each parcel pathway.
+
+.. plot:: water_tools/_accumulate_free_surface_walks.py
+
+The algorithm tracks the number of times each cell has been visited by a water parcel (``sfc_visit``), and the *total sum of expected elevations* of the water surface at each cell (``sfc_sum``), by adding the predicted surface elevation of each parcel step while iterating through each step of each parcel.
+
+Next, the output from :obj:`_accumulate_free_surface_walks` is used to calculate a new stage surface (``H_new``) based only on the water parcel paths and expected water surface elevations, approximately as ``H_new = sfc_sum / sfc_visit``.
+The updated water surface is combined with the previous timestep's water surface and an underrelaxation coefficient (:obj:`_omega_sfc`).
+
+.. plot:: water_tools/compute_free_surface_outputs.py
+
+With a new free surface computed, a few final operations prepare the surface for boundary condition updates and eventually being passed to the sediment routing operations.
+A non-linear smoothing operation is applied to the free surface, whereby wet cells are iteratively averaged with neighboring wet cells to yield an overall smoother surface.
+The smoothing is handled by :obj:`_smooth_free_surface` and depends on the number of iterations (:obj:`Nsmooth`) and a weighting coefficient (:obj:`Csmooth`).
+
+.. plot:: water_tools/_smooth_free_surface.py
+
+
+.. todo:: add component describing the smoothing.
+
+.. todo:: add component describing the flooding correction.
+
+
+
+
+Finalizing and boundary conditions to sediment routing
+======================================================
+
+.. todo::
+
+   Incomplete. Need to describe the updating of depth from stage, limiting everything to above H_SL, updating velocity and discharge fields, etc.
+
+
+References
+==========
+
+.. [1] A reduced-complexity model for river delta formation – Part 1: Modeling
+       deltas with channel dynamics, M. Liang, V. R. Voller, and C. Paola, Earth
+       Surf. Dynam., 3, 67–86, 2015. https://doi.org/10.5194/esurf-3-67-2015
+
+.. [2] A reduced-complexity model for river delta formation – Part 2:
+       Assessment of the flow routing scheme, M. Liang, N. Geleynse,
+       D. A. Edmonds, and P. Passalacqua, Earth Surf. Dynam., 3, 87–104, 2015.
+       https://doi.org/10.5194/esurf-3-87-2015

--- a/docs/source/info/morphodynamics.rst
+++ b/docs/source/info/morphodynamics.rst
@@ -2,6 +2,8 @@
 Morphodynamics
 **************
 
+.. currentmodule:: pyDeltaRCM.sed_tools
+
 pyDeltaRCM approximates sediment dispersal through the use of a weighted random
 walk dictated by water flux.
 In turn, sediment dispersal drives bed elevation change in the model domain by mass conservation.
@@ -17,6 +19,25 @@ Sediment Transport
 .. note::
    Incomplete.
 
+
+============================
+Changes in the bed elevation
+============================
+
+Change in the channel bed is the result of deposition or erosion by each sediment parcel (:obj:`_update_fields`), dictated by sediment mass conservation (i.e., Exner equation) and is equal to:
+
+.. math::
+
+    \Delta \eta = \Delta V / dx^2
+
+
+.. note::
+
+    Total sediment mass is preserved, but individual categories of sand and mud are not. I.e., it is assumed that there is infinite sand and/or mud to erode at any location where erosion is occurring.
+
+.. todo::
+
+   Incomplete.
 
 ===============
 Model Stability

--- a/docs/source/info/morphodynamics.rst
+++ b/docs/source/info/morphodynamics.rst
@@ -32,6 +32,6 @@ The reference volume (:math:`V_0`) impacts model stability. This volume characte
 
 .. math::
 
-    V_0 = h_0 {\\delta_c}^2,
+    V_0 = h_0 {\delta_c}^2
 
 where :math:`h_0` is the inlet channel depth (meters) and :math:`\\delta_c` is the cell length (meters).

--- a/docs/source/info/morphodynamics.rst
+++ b/docs/source/info/morphodynamics.rst
@@ -28,7 +28,7 @@ Model stability depends on...
    Incomplete.
 
 
-.. _reference_volume:
+.. _reference-volume:
 
 Reference Volume
 ----------------
@@ -39,7 +39,7 @@ The reference volume (:math:`V_0`) impacts model stability. This volume characte
 
     V_0 = h_0 {\delta_c}^2
 
-where :math:`h_0` is the inlet channel depth (meters) and :math:`\\delta_c` is the cell length (meters).
+where :math:`h_0` is the inlet channel depth (meters) and :math:`\delta_c` is the cell length (meters).
 
 
 References

--- a/docs/source/info/morphodynamics.rst
+++ b/docs/source/info/morphodynamics.rst
@@ -2,8 +2,36 @@
 Morphodynamics
 **************
 
-pyDeltaRCM approximates morphodynamics through the use of a weighted random
-walk.
+pyDeltaRCM approximates sediment dispersal through the use of a weighted random
+walk dictated by water flux.
+In turn, sediment dispersal drives bed elevation change in the model domain by mass conservation.
+
+
+==================
+Sediment Transport
+==================
 
 .. note::
    Incomplete.
+
+===============
+Model Stability
+===============
+
+Model stability depends on...
+
+.. note::
+   Incomplete.
+
+.. _reference_volume:
+
+Reference Volume
+----------------
+
+The reference volume (:math:`V_0`) impacts model stability. This volume characterizes the volume on one inlet-channel cell, from the channel bed to the water surface:
+
+.. math::
+
+    V_0 = h_0 {\\delta_c}^2,
+
+where :math:`h_0` is the inlet channel depth (meters) and :math:`\\delta_c` is the cell length (meters).

--- a/docs/source/info/morphodynamics.rst
+++ b/docs/source/info/morphodynamics.rst
@@ -6,6 +6,9 @@ pyDeltaRCM approximates sediment dispersal through the use of a weighted random
 walk dictated by water flux.
 In turn, sediment dispersal drives bed elevation change in the model domain by mass conservation.
 
+See [1]_ for a complete description of morphodynamic assumptions in the DeltaRCM model.
+In this documentation, we focus on the details of *model implementation*, rather than *model design*.
+
 
 ==================
 Sediment Transport
@@ -13,6 +16,7 @@ Sediment Transport
 
 .. note::
    Incomplete.
+
 
 ===============
 Model Stability
@@ -22,6 +26,7 @@ Model stability depends on...
 
 .. note::
    Incomplete.
+
 
 .. _reference_volume:
 
@@ -35,3 +40,11 @@ The reference volume (:math:`V_0`) impacts model stability. This volume characte
     V_0 = h_0 {\delta_c}^2
 
 where :math:`h_0` is the inlet channel depth (meters) and :math:`\\delta_c` is the cell length (meters).
+
+
+References
+==========
+
+.. [1] A reduced-complexity model for river delta formation – Part 1: Modeling
+       deltas with channel dynamics, M. Liang, V. R. Voller, and C. Paola, Earth
+       Surf. Dynam., 3, 67–86, 2015. https://doi.org/10.5194/esurf-3-67-2015

--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -58,7 +58,7 @@ Model Domain Parameters
 
 :attr:`pyDeltaRCM.model.DeltaModel.toggle_subsidence`
 
-:attr:`pyDeltaRCM.model.DeltaModel.sigma_max`
+:attr:`pyDeltaRCM.model.DeltaModel.subsidence_rate`
 
 :attr:`pyDeltaRCM.model.DeltaModel.start_subsidence`
 

--- a/docs/source/pyplots/debug_tools/debug_demo.py
+++ b/docs/source/pyplots/debug_tools/debug_demo.py
@@ -6,7 +6,8 @@ with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
     delta = pyDeltaRCM.DeltaModel(out_dir=output_dir)
 
 delta.show_attribute('cell_type', grid=False)
-delta.show_ind([144, 22, 33, 34, 35])
-delta.show_ind((12, 14), 'bs')
-delta.show_ind([(11, 4), (11, 5)], 'g^')
+delta.show_attribute('cell_type', grid=False)
+delta.show_ind([3378, 9145, 11568, 514, 13558])
+delta.show_ind((42, 94), 'bs')
+delta.show_ind([(41, 8), (42, 10)], 'g^')
 plt.show()

--- a/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
+++ b/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
@@ -1,0 +1,66 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyDeltaRCM
+import matplotlib
+
+
+n = 1
+cm = matplotlib.cm.get_cmap('tab10')
+
+
+# init delta model
+delta = pyDeltaRCM.DeltaModel(
+    '../../_resources/checkpoint.yaml',
+    resume_checkpoint='../../_resources/deltaRCM_Output')
+_shp = delta.eta.shape
+
+
+delta.init_water_iteration()
+delta.run_water_iteration()
+
+
+# define a function to fill in the walks of given idx
+def _plot_idxs_walks_to_step(delta_inds, _step, _idxs, _ax):
+    for i in range(len(_idxs)):
+        walk = delta_inds[_idxs[i], :]
+        walk = walk[:_step]
+        pyDeltaRCM.debug_tools.plot_line(walk, shape=_shp, color=cm(i))
+        yend, xend = pyDeltaRCM.shared_tools.custom_unravel(walk[-1], _shp)
+        _ax.plot(xend, yend,
+                 marker='o', ms=3, color=cm(i))
+
+
+# declare the idxs to use:
+idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
+pidx = 60
+
+
+# set up axis
+# fig, ax = plt.subplots(1, 4, figsize=(10, 5))
+fig = plt.figure(constrained_layout=True)
+gs = fig.add_gridspec(2, 2)
+
+
+# fill in axis0
+ax0 = fig.add_subplot(gs[0, 0])
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax0, grid=False)
+_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=pidx, _idxs=idxs, _ax=ax0)
+
+
+# fill in axis0
+ax1 = fig.add_subplot(gs[0, 1])
+pyDeltaRCM.debug_tools.plot_domain(delta.stage, ax=ax1, grid=False)
+_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=pidx, _idxs=idxs, _ax=ax1)
+
+
+ax2 = fig.add_subplot(gs[1, :])
+ax2.axhline(y=0, xmin=0, xmax=pidx+1, ls='--', color='0.6')
+for i in range(n):
+    walk = delta.free_surf_walk_inds[idxs[i], :]
+    walk = walk[:pidx]
+
+    ax2.plot(delta.eta.flat[walk], 'k-')
+    ax2.plot(delta.stage.flat[walk], '-', color=cm(i))
+
+plt.tight_layout()
+plt.show()

--- a/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
+++ b/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
@@ -9,9 +9,10 @@ cm = matplotlib.cm.get_cmap('tab10')
 
 
 # init delta model
-delta = pyDeltaRCM.DeltaModel(
-    '../../_resources/checkpoint.yaml',
-    resume_checkpoint='../../_resources/deltaRCM_Output')
+with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    delta = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir,
+        resume_checkpoint='../../_resources/checkpoint')
 _shp = delta.eta.shape
 
 
@@ -24,10 +25,13 @@ def _plot_idxs_walks_to_step(delta_inds, _step, _idxs, _ax):
     for i in range(len(_idxs)):
         walk = delta_inds[_idxs[i], :]
         walk = walk[:_step]
-        pyDeltaRCM.debug_tools.plot_line(walk, shape=_shp, color=cm(i))
+        # print(walk)
+        pyDeltaRCM.debug_tools.plot_line(
+            walk, shape=_shp, color='r',
+            multiline=True, nozeros=True)
         yend, xend = pyDeltaRCM.shared_tools.custom_unravel(walk[-1], _shp)
         _ax.plot(xend, yend,
-                 marker='o', ms=3, color=cm(i))
+                 marker='o', ms=3, color='r')
 
 
 # declare the idxs to use:
@@ -43,14 +47,19 @@ gs = fig.add_gridspec(2, 2)
 
 # fill in axis0
 ax0 = fig.add_subplot(gs[0, 0])
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax0, grid=False)
-_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=pidx, _idxs=idxs, _ax=ax0)
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax0, grid=False, cmap='cividis')
+_plot_idxs_walks_to_step(
+    delta.free_surf_walk_inds, _step=pidx, _idxs=idxs, _ax=ax0)
+ax0.set_title('bed elevation')
 
 
 # fill in axis0
 ax1 = fig.add_subplot(gs[0, 1])
-pyDeltaRCM.debug_tools.plot_domain(delta.stage, ax=ax1, grid=False)
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.stage, ax=ax1, grid=False)
 _plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=pidx, _idxs=idxs, _ax=ax1)
+ax1.set_title('water surface (stage)')
 
 
 ax2 = fig.add_subplot(gs[1, :])
@@ -62,9 +71,9 @@ for i in range(n):
     ax2.plot(delta.eta.flat[walk], 'k-')
     ax2.plot(delta.stage.flat[walk], '-', color=cm(i))
 
+ax2.set_ylabel('elevation')
+ax2.set_xlabel('steps along parcel path')
+
 plt.tight_layout()
 
-if __name__ == '__main__':
-    plt.savefig('_accumulate_free_surface_walks.png', transparent=True, dpi=300)
-else:
-    plt.show()
+plt.show()

--- a/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
+++ b/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
@@ -27,16 +27,16 @@ def _plot_idxs_walks_to_step(delta_inds, _step, _idxs, _ax):
         walk = walk[:_step]
         # print(walk)
         pyDeltaRCM.debug_tools.plot_line(
-            walk, shape=_shp, color='r',
+            walk, shape=_shp, color='c',
             multiline=True, nozeros=True)
         yend, xend = pyDeltaRCM.shared_tools.custom_unravel(walk[-1], _shp)
         _ax.plot(xend, yend,
-                 marker='o', ms=3, color='r')
+                 marker='o', ms=3, color='c')
 
 
 # declare the idxs to use:
 idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
-pidx = 60
+pidx = 85
 
 
 # set up axis

--- a/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
+++ b/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
@@ -63,4 +63,8 @@ for i in range(n):
     ax2.plot(delta.stage.flat[walk], '-', color=cm(i))
 
 plt.tight_layout()
-plt.show()
+
+if __name__ == '__main__':
+    plt.savefig('_accumulate_free_surface_walks.png', transparent=True, dpi=300)
+else:
+    plt.show()

--- a/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
+++ b/docs/source/pyplots/water_tools/_accumulate_free_surface_walks.py
@@ -1,7 +1,14 @@
+import warnings
+
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 import pyDeltaRCM
-import matplotlib
+
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
 
 
 n = 1

--- a/docs/source/pyplots/water_tools/_check_for_loops.py
+++ b/docs/source/pyplots/water_tools/_check_for_loops.py
@@ -19,7 +19,7 @@ _shp = delta.eta.shape
 
 
 # determine the index to plot at
-pidx = 22 #5, 8, 15, 22, 
+pidx = 22
 
 
 # run an interation from the checkpoint
@@ -46,7 +46,6 @@ for pidx in range(200):
                     new_direction,
                     delta.ravel_walk_flat)
 
-
     # copy inputs and then run the function to get new outputs
     new_inds0 = np.copy(new_inds)
     new_inds, looped = water_tools._check_for_loops(
@@ -64,6 +63,7 @@ for pidx in range(200):
     # if np.any(looped):
     if whr_neq.size > 0:
         breakpoint()
+
 
 # make a function to plot each point of interest as two points and an arrow
 def _plot_a_point(i):

--- a/docs/source/pyplots/water_tools/_check_for_loops.py
+++ b/docs/source/pyplots/water_tools/_check_for_loops.py
@@ -19,51 +19,54 @@ _shp = delta.eta.shape
 
 
 # determine the index to plot at
-pidx = 40
+pidx = 22 #5, 8, 15, 22, 
 
 
 # run an interation from the checkpoint
 delta.init_water_iteration()
 delta.run_water_iteration()
 
-
-# here, we recreate some steps of each iteration, in order to set up the
-#   arrays needed to display the action of _check_for_loops
-#
-#   1. extract the water weights
-current_inds = delta.free_surf_walk_inds[:, pidx-1]
-#
-#   2. use water weights and random pick to determine d8 direction
-water_weights_flat = delta.water_weights.reshape(-1, 9)
-new_direction = water_tools._choose_next_direction(
-    current_inds, water_weights_flat)
-new_direction = new_direction.astype(np.int)
-#
-#   3. use the new directions for each parcel to determine the new ind for
-#   each parcel
-new_inds = water_tools._calculate_new_ind(
-                current_inds,
-                new_direction,
-                delta.iwalk_flat,
-                delta.jwalk_flat,
-                delta.eta.shape)
+for pidx in range(200):
+    # here, we recreate some steps of each iteration, in order to set up the
+    #   arrays needed to display the action of _check_for_loops
+    #
+    #   1. extract the water weights
+    current_inds = delta.free_surf_walk_inds[:, pidx-1]
+    #
+    #   2. use water weights and random pick to determine d8 direction
+    water_weights_flat = delta.water_weights.reshape(-1, 9)
+    new_direction = water_tools._choose_next_directions(
+        current_inds, water_weights_flat)
+    new_direction = new_direction.astype(np.int)
+    #
+    #   3. use the new directions for each parcel to determine the new ind for
+    #   each parcel
+    new_inds = water_tools._calculate_new_inds(
+                    current_inds,
+                    new_direction,
+                    delta.ravel_walk_flat)
 
 
-# copy inputs and then run the function to get new outputs
-new_inds0 = np.copy(new_inds)
-new_inds, looped = water_tools._check_for_loops(
-    delta.free_surf_walk_inds[:, :pidx], new_inds0, pidx+1, delta.L0,
-    delta.eta.shape, delta.CTR)
+    # copy inputs and then run the function to get new outputs
+    new_inds0 = np.copy(new_inds)
+    new_inds, looped = water_tools._check_for_loops(
+        delta.free_surf_walk_inds[:, :pidx], new_inds0, pidx + 1, delta.L0,
+        delta.CTR, delta.stage - delta.H_SL)
 
-looped = looped.astype(np.bool)
-neq = new_inds != new_inds0
-ds0 = np.copy(new_inds)
-whr_neq = np.where(neq)[0]
+    looped = looped.astype(np.bool)
+    neq = new_inds != new_inds0
+    ds0 = np.copy(new_inds)
+    whr_neq = np.where(neq)[0]
 
+    # declare the idxs to use:
+    # idxs = np.random.randint(low=0, high=delta._Np_water, size=10)
+
+    # if np.any(looped):
+    if whr_neq.size > 0:
+        breakpoint()
 
 # make a function to plot each point of interest as two points and an arrow
 def _plot_a_point(i):
-    cm
     x0, y0 = shared_tools.custom_unravel(new_inds0[whr_neq[i]])
     x, y = shared_tools.custom_unravel(new_inds[whr_neq[i]])
     delta.show_ind(x0, y0, '.', c=cm(i), ax=ax)
@@ -75,5 +78,6 @@ def _plot_a_point(i):
 fig, ax = plt.subplots()
 delta.show_attribute('eta', ax=ax, grid=False)
 for npt in range(n):
+    breakpoint()
     _plot_a_point(npt)
 plt.show()

--- a/docs/source/pyplots/water_tools/_check_for_loops.py
+++ b/docs/source/pyplots/water_tools/_check_for_loops.py
@@ -1,10 +1,16 @@
-import matplotlib.pyplot as plt
+import warnings
+
 import numpy as np
 import matplotlib
+import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
 import pyDeltaRCM
 from pyDeltaRCM import water_tools
+
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
 
 
 n = 10

--- a/docs/source/pyplots/water_tools/_check_for_loops.py
+++ b/docs/source/pyplots/water_tools/_check_for_loops.py
@@ -1,10 +1,10 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib
+from matplotlib.patches import Rectangle
 
 import pyDeltaRCM
 from pyDeltaRCM import water_tools
-from pyDeltaRCM import shared_tools
 
 
 n = 10
@@ -20,66 +20,84 @@ _shp = delta.eta.shape
 
 
 # determine the index to plot at
-pidx = 22
-
+pidx = 40
+Npts = 5
+jidx = np.random.randint(0, delta._Np_water, Npts)
 
 # run an interation from the checkpoint
 delta.init_water_iteration()
 delta.run_water_iteration()
 
-for pidx in range(200):
-    # here, we recreate some steps of each iteration, in order to set up the
-    #   arrays needed to display the action of _check_for_loops
-    #
-    #   1. extract the water weights
-    current_inds = delta.free_surf_walk_inds[:, pidx-1]
-    #
-    #   2. use water weights and random pick to determine d8 direction
-    water_weights_flat = delta.water_weights.reshape(-1, 9)
-    new_direction = water_tools._choose_next_directions(
-        current_inds, water_weights_flat)
-    new_direction = new_direction.astype(np.int)
-    #
-    #   3. use the new directions for each parcel to determine the new ind for
-    #   each parcel
-    new_inds = water_tools._calculate_new_inds(
-                    current_inds,
-                    new_direction,
-                    delta.ravel_walk_flat)
+# here, we recreate some steps of each iteration, in order to set up the
+#   arrays needed to display the action of _check_for_loops
+#
+#   1. extract the water walks
+current_inds = delta.free_surf_walk_inds[:, pidx-1]
+#
+#   2. use water weights and random pick to determine d8 direction
+water_weights_flat = delta.water_weights.reshape(-1, 9)
+new_direction = water_tools._choose_next_directions(
+    current_inds, water_weights_flat)
+new_direction = new_direction.astype(np.int)
+#
+#   3. use the new directions for each parcel to determine the new ind for
+#   each parcel
+new_inds = water_tools._calculate_new_inds(
+                current_inds,
+                new_direction,
+                delta.ravel_walk_flat)
+new_inds0 = np.copy(new_inds)
 
-    # copy inputs and then run the function to get new outputs
-    new_inds0 = np.copy(new_inds)
-    new_inds, looped = water_tools._check_for_loops(
-        delta.free_surf_walk_inds[:, :pidx], new_inds0, pidx + 1, delta.L0,
-        delta.CTR, delta.stage - delta.H_SL)
+# choose N indices randomly to jump
+new_inds[jidx] = delta.free_surf_walk_inds[jidx, pidx-2]
 
-    looped = looped.astype(np.bool)
-    neq = new_inds != new_inds0
-    ds0 = np.copy(new_inds)
-    whr_neq = np.where(neq)[0]
-
-    # declare the idxs to use:
-    # idxs = np.random.randint(low=0, high=delta._Np_water, size=10)
-
-    # if np.any(looped):
-    # if whr_neq.size > 0:
-    #     breakpoint()
-
-
-# make a function to plot each point of interest as two points and an arrow
-def _plot_a_point(i):
-    x0, y0 = shared_tools.custom_unravel(new_inds0[whr_neq[i]])
-    x, y = shared_tools.custom_unravel(new_inds[whr_neq[i]])
-    delta.show_ind(x0, y0, '.', c=cm(i), ax=ax)
-    delta.show_ind(x, y, '.', c=cm(i), ax=ax)
-    ax.arrow(x0, y0, (x-x0), (y-y0), c=cm(i))
+# copy inputs and then run the function to get new outputs
+new_inds, looped = water_tools._check_for_loops(
+    delta.free_surf_walk_inds[:, :pidx-1], new_inds, pidx + 1, delta.L0,
+    delta.CTR, delta.stage - delta.H_SL)
 
 
 # make the figure
-fig, ax = plt.subplots()
-delta.show_attribute('eta', ax=ax, grid=False, cmap='cividis')
-if whr_neq.size > 0:
-    for npt in range(n):
-        _plot_a_point(npt)
+fig, ax = plt.subplots(1, 2, figsize=(10, 4))
+
+delta.show_attribute('eta', ax=ax[0], grid=False, cmap='cividis')
+delta.show_attribute('eta', ax=ax[1], grid=False, cmap='cividis')
+
+
+def _fill_out_an_axis(_ax, _sc=1):
+    for j in range(len(jidx)):
+        walk = delta.free_surf_walk_inds[jidx[j], :]
+        walk = walk[:pidx-2]
+        yend, xend = pyDeltaRCM.shared_tools.custom_unravel(
+            walk[-1], _shp)
+        ynew, xnew = pyDeltaRCM.shared_tools.custom_unravel(
+            new_inds[jidx[j]], _shp)
+        pyDeltaRCM.debug_tools.plot_line(
+            walk, shape=_shp, color=cm(j),
+            multiline=True, nozeros=True, lw=1.5*_sc, ax=_ax)
+        _ax.plot(xend, yend,
+                 marker='o', ms=3*_sc, color=cm(j))
+        _ax.plot(xnew, ynew,
+                 marker='o', ms=3*_sc, color=cm(j))
+
+    # return the last set
+    return yend, xend, ynew, xnew
+
+
+# fill out both axes with the same info
+_fill_out_an_axis(_ax=ax[0])
+yend, xend, ynew, xnew = _fill_out_an_axis(_ax=ax[1], _sc=2)
+
+# sub region of the original image
+_f = int(delta.W / delta.L)  # ensure x-y scale same
+_s = 10
+x1, x2, y1, y2 = xend-(_s*_f), xnew+(_s*_f), yend-(_s), ynew+(_s)
+ax[1].set_xlim(x1, x2)
+ax[1].set_ylim(y2, y1)
+ax[1].set_xticks([])
+ax[1].set_yticks([])
+
+_r = Rectangle((x1, y2), _s*_f*2, -_s*2, ec='k', fc='none')
+ax[0].add_patch(_r)
 
 plt.show()

--- a/docs/source/pyplots/water_tools/_check_for_loops.py
+++ b/docs/source/pyplots/water_tools/_check_for_loops.py
@@ -1,0 +1,79 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib
+
+import pyDeltaRCM
+from pyDeltaRCM import water_tools
+from pyDeltaRCM import shared_tools
+
+
+n = 10
+cm = matplotlib.cm.get_cmap('tab10')
+
+
+# init delta model
+delta = pyDeltaRCM.DeltaModel(
+    '../../_resources/checkpoint.yaml',
+    resume_checkpoint='../../_resources/deltaRCM_Output')
+_shp = delta.eta.shape
+
+
+# determine the index to plot at
+pidx = 40
+
+
+# run an interation from the checkpoint
+delta.init_water_iteration()
+delta.run_water_iteration()
+
+
+# here, we recreate some steps of each iteration, in order to set up the
+#   arrays needed to display the action of _check_for_loops
+#
+#   1. extract the water weights
+current_inds = delta.free_surf_walk_inds[:, pidx-1]
+#
+#   2. use water weights and random pick to determine d8 direction
+water_weights_flat = delta.water_weights.reshape(-1, 9)
+new_direction = water_tools._choose_next_direction(
+    current_inds, water_weights_flat)
+new_direction = new_direction.astype(np.int)
+#
+#   3. use the new directions for each parcel to determine the new ind for
+#   each parcel
+new_inds = water_tools._calculate_new_ind(
+                current_inds,
+                new_direction,
+                delta.iwalk_flat,
+                delta.jwalk_flat,
+                delta.eta.shape)
+
+
+# copy inputs and then run the function to get new outputs
+new_inds0 = np.copy(new_inds)
+new_inds, looped = water_tools._check_for_loops(
+    delta.free_surf_walk_inds[:, :pidx], new_inds0, pidx+1, delta.L0,
+    delta.eta.shape, delta.CTR)
+
+looped = looped.astype(np.bool)
+neq = new_inds != new_inds0
+ds0 = np.copy(new_inds)
+whr_neq = np.where(neq)[0]
+
+
+# make a function to plot each point of interest as two points and an arrow
+def _plot_a_point(i):
+    cm
+    x0, y0 = shared_tools.custom_unravel(new_inds0[whr_neq[i]])
+    x, y = shared_tools.custom_unravel(new_inds[whr_neq[i]])
+    delta.show_ind(x0, y0, '.', c=cm(i), ax=ax)
+    delta.show_ind(x, y, '.', c=cm(i), ax=ax)
+    ax.arrow(x0, y0, (x-x0), (y-y0), c=cm(i))
+
+
+# make the figure
+fig, ax = plt.subplots()
+delta.show_attribute('eta', ax=ax, grid=False)
+for npt in range(n):
+    _plot_a_point(npt)
+plt.show()

--- a/docs/source/pyplots/water_tools/_check_for_loops.py
+++ b/docs/source/pyplots/water_tools/_check_for_loops.py
@@ -12,9 +12,10 @@ cm = matplotlib.cm.get_cmap('tab10')
 
 
 # init delta model
-delta = pyDeltaRCM.DeltaModel(
-    '../../_resources/checkpoint.yaml',
-    resume_checkpoint='../../_resources/deltaRCM_Output')
+with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    delta = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir,
+        resume_checkpoint='../../_resources/checkpoint')
 _shp = delta.eta.shape
 
 
@@ -61,8 +62,8 @@ for pidx in range(200):
     # idxs = np.random.randint(low=0, high=delta._Np_water, size=10)
 
     # if np.any(looped):
-    if whr_neq.size > 0:
-        breakpoint()
+    # if whr_neq.size > 0:
+    #     breakpoint()
 
 
 # make a function to plot each point of interest as two points and an arrow
@@ -76,8 +77,9 @@ def _plot_a_point(i):
 
 # make the figure
 fig, ax = plt.subplots()
-delta.show_attribute('eta', ax=ax, grid=False)
-for npt in range(n):
-    breakpoint()
-    _plot_a_point(npt)
+delta.show_attribute('eta', ax=ax, grid=False, cmap='cividis')
+if whr_neq.size > 0:
+    for npt in range(n):
+        _plot_a_point(npt)
+
 plt.show()

--- a/docs/source/pyplots/water_tools/_smooth_free_surface.py
+++ b/docs/source/pyplots/water_tools/_smooth_free_surface.py
@@ -1,7 +1,12 @@
+import warnings
+
 import matplotlib.pyplot as plt
-import numpy as np
-import pyDeltaRCM
 import matplotlib
+
+import pyDeltaRCM
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
 
 
 n = 10

--- a/docs/source/pyplots/water_tools/_smooth_free_surface.py
+++ b/docs/source/pyplots/water_tools/_smooth_free_surface.py
@@ -1,0 +1,63 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyDeltaRCM
+import matplotlib
+
+
+n = 10
+cm = matplotlib.cm.get_cmap('tab10')
+
+
+# init delta model
+with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    delta = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir,
+        resume_checkpoint='../../_resources/checkpoint')
+
+
+_shp = delta.eta.shape
+
+
+# manually call only the necessary paths
+delta.init_water_iteration()
+delta.run_water_iteration()
+
+# lines cobbled together from compute_free_surface and finalize_free_surface
+delta.sfc_visit, delta.sfc_sum = pyDeltaRCM.water_tools._accumulate_free_surface_walks(
+    delta.free_surf_walk_inds, delta.free_surf_flag, delta.cell_type,
+    delta.uw, delta.ux, delta.uy, delta.depth,
+    delta._dx, delta._u0, delta.h0, delta._H_SL, delta._S0)
+Hnew = delta.eta + delta.depth
+Hnew[delta.sfc_visit > 0] = (delta.sfc_sum[delta.sfc_visit > 0] /
+                             delta.sfc_visit[delta.sfc_visit > 0])
+Hnew[Hnew < delta._H_SL] = delta._H_SL
+Hnew[Hnew < delta.eta] = delta.eta[Hnew < delta.eta]
+
+# now run the smoothing function to get grids
+Hsmth = pyDeltaRCM.water_tools._smooth_free_surface(
+    Hnew, delta.cell_type, delta._Nsmooth, delta._Csmooth)
+
+# set up axis
+fig, ax = plt.subplots(1, 3, sharex=True, sharey=True, figsize=(12, 4))
+
+# fill in axis0
+pyDeltaRCM.debug_tools.plot_domain(
+    Hnew, ax=ax[0], grid=False, cmap='viridis')
+ax[0].set_title('stage before smoothing')
+
+# fill in axis1
+pyDeltaRCM.debug_tools.plot_domain(
+    Hsmth, ax=ax[1], grid=False, cmap='viridis')
+ax[1].set_title('stage after smoothing')
+
+
+# fill in axis2
+_diff = Hsmth - Hnew
+pyDeltaRCM.debug_tools.plot_domain(
+    _diff, ax=ax[2], grid=False, cmap='RdBu',
+    vmin=-0.1, vmax=0.1)
+ax[2].set_title('difference (after - before)')
+
+
+plt.tight_layout()
+plt.show()

--- a/docs/source/pyplots/water_tools/compute_free_surface.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface.py
@@ -9,9 +9,10 @@ cm = matplotlib.cm.get_cmap('tab10')
 
 
 # init delta model
-delta = pyDeltaRCM.DeltaModel(
-    '../../_resources/checkpoint.yaml',
-    resume_checkpoint='../../_resources/deltaRCM_Output')
+with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    delta = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir,
+        resume_checkpoint='../../_resources/checkpoint')
 _shp = delta.eta.shape
 
 
@@ -39,9 +40,6 @@ stage_new[sfc_visit > 0] = (sfc_sum[sfc_visit > 0] /
 
 # set up axis
 fig, ax = plt.subplots(3, 2, sharex=True, sharey=True, figsize=(9, 7))
-# fig = plt.figure(constrained_layout=True)
-# gs = fig.add_gridspec(2, 2)
-
 
 # fill in axis
 pyDeltaRCM.debug_tools.plot_domain(
@@ -50,9 +48,9 @@ pyDeltaRCM.debug_tools.plot_domain(
 pyDeltaRCM.debug_tools.plot_domain(
     delta.eta, ax=ax[0, 1], grid=False, cmap='cividis',
     label='bed elevation (m)')
-delta.show_line(delta.free_surf_walk_inds[::10, :], 'k-',
-                ax=ax[0, 1], alpha=0.1, nozeros=True)
-
+delta.show_line(delta.free_surf_walk_inds[::10, :].T, 'k-',
+                ax=ax[0, 1], alpha=0.1,
+                multiline=True, nozeros=True)
 
 pyDeltaRCM.debug_tools.plot_domain(
     delta.sfc_visit, ax=ax[1, 0], grid=False, cmap='Greys',
@@ -61,7 +59,6 @@ pyDeltaRCM.debug_tools.plot_domain(
     delta.sfc_sum, ax=ax[1, 1], grid=False, cmap='Blues',
     label='sfc_sum (m)')
 
-
 pyDeltaRCM.debug_tools.plot_domain(
     Hnew, ax=ax[2, 0], grid=False,
     label='H_new (m)')
@@ -69,10 +66,5 @@ pyDeltaRCM.debug_tools.plot_domain(
     stage_new, ax=ax[2, 1], grid=False,
     label='stage (m)')
 
-
 plt.tight_layout()
-
-if __name__ == '__main__':
-    plt.savefig('compute_free_surface.png', transparent=True, dpi=300)
-else:
-    plt.show()
+plt.show()

--- a/docs/source/pyplots/water_tools/compute_free_surface.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface.py
@@ -1,0 +1,78 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyDeltaRCM
+import matplotlib
+
+
+n = 1
+cm = matplotlib.cm.get_cmap('tab10')
+
+
+# init delta model
+delta = pyDeltaRCM.DeltaModel(
+    '../../_resources/checkpoint.yaml',
+    resume_checkpoint='../../_resources/deltaRCM_Output')
+_shp = delta.eta.shape
+
+
+delta.init_water_iteration()
+delta.run_water_iteration()
+delta.compute_free_surface()
+
+
+pidx = 60
+
+sfc_visit, sfc_sum = pyDeltaRCM.water_tools._accumulate_free_surface_walks(
+    delta.free_surf_walk_inds, delta.free_surf_flag, delta.cell_type,
+    delta.uw, delta.ux, delta.uy, delta.depth,
+    delta._dx, delta._u0, delta.h0, delta._H_SL, delta._S0)
+
+
+Hnew = np.full_like(sfc_visit, np.nan)
+Hnew[sfc_visit > 0] = (sfc_sum[sfc_visit > 0] /
+                       sfc_visit[sfc_visit > 0])
+
+
+stage_new = delta.eta + delta.depth
+stage_new[sfc_visit > 0] = (sfc_sum[sfc_visit > 0] /
+                            sfc_visit[sfc_visit > 0])
+
+# set up axis
+fig, ax = plt.subplots(3, 2, sharex=True, sharey=True, figsize=(9, 7))
+# fig = plt.figure(constrained_layout=True)
+# gs = fig.add_gridspec(2, 2)
+
+
+# fill in axis
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0, 0], grid=False, cmap='cividis',
+    label='bed elevation (m)')
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0, 1], grid=False, cmap='cividis',
+    label='bed elevation (m)')
+delta.show_line(delta.free_surf_walk_inds[::10, :], 'r-',
+                ax=ax[0, 1], alpha=0.1, nozeros=True)
+
+
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.sfc_visit, ax=ax[1, 0], grid=False, cmap='Reds',
+    label='sfc_visit (-)')
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.sfc_sum, ax=ax[1, 1], grid=False, cmap='Blues',
+    label='sfc_sum (m)')
+
+
+pyDeltaRCM.debug_tools.plot_domain(
+    Hnew, ax=ax[2, 0], grid=False,
+    label='H_new (m)')
+pyDeltaRCM.debug_tools.plot_domain(
+    stage_new, ax=ax[2, 1], grid=False,
+    label='stage (m)')
+
+
+plt.tight_layout()
+
+if __name__ == '__main__':
+    plt.savefig('compute_free_surface.png', transparent=True, dpi=300)
+else:
+    plt.show()

--- a/docs/source/pyplots/water_tools/compute_free_surface.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface.py
@@ -50,12 +50,12 @@ pyDeltaRCM.debug_tools.plot_domain(
 pyDeltaRCM.debug_tools.plot_domain(
     delta.eta, ax=ax[0, 1], grid=False, cmap='cividis',
     label='bed elevation (m)')
-delta.show_line(delta.free_surf_walk_inds[::10, :], 'r-',
+delta.show_line(delta.free_surf_walk_inds[::10, :], 'k-',
                 ax=ax[0, 1], alpha=0.1, nozeros=True)
 
 
 pyDeltaRCM.debug_tools.plot_domain(
-    delta.sfc_visit, ax=ax[1, 0], grid=False, cmap='Reds',
+    delta.sfc_visit, ax=ax[1, 0], grid=False, cmap='Greys',
     label='sfc_visit (-)')
 pyDeltaRCM.debug_tools.plot_domain(
     delta.sfc_sum, ax=ax[1, 1], grid=False, cmap='Blues',

--- a/docs/source/pyplots/water_tools/compute_free_surface_inputs.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface_inputs.py
@@ -1,7 +1,13 @@
-import matplotlib.pyplot as plt
-import numpy as np
-import pyDeltaRCM
+import warnings
+
 import matplotlib
+import matplotlib.pyplot as plt
+
+import pyDeltaRCM
+
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
 
 
 n = 1

--- a/docs/source/pyplots/water_tools/compute_free_surface_inputs.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface_inputs.py
@@ -1,0 +1,36 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyDeltaRCM
+import matplotlib
+
+
+n = 1
+cm = matplotlib.cm.get_cmap('tab10')
+
+
+# init delta model
+with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    delta = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir,
+        resume_checkpoint='../../_resources/checkpoint')
+_shp = delta.eta.shape
+
+
+delta.init_water_iteration()
+delta.run_water_iteration()
+
+
+fig, ax = plt.subplots(1, 2, sharex=True, sharey=True, figsize=(9, 3))
+
+# fill in axis
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0], grid=False, cmap='cividis',
+    label='bed elevation (m)')
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[1], grid=False, cmap='cividis',
+    label='bed elevation (m)')
+delta.show_line(delta.free_surf_walk_inds[::10, :].T, 'k-',
+                ax=ax[1], alpha=0.1,
+                multiline=True, nozeros=True)
+
+fig.show()

--- a/docs/source/pyplots/water_tools/compute_free_surface_outputs.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface_outputs.py
@@ -38,33 +38,21 @@ stage_new = delta.eta + delta.depth
 stage_new[sfc_visit > 0] = (sfc_sum[sfc_visit > 0] /
                             sfc_visit[sfc_visit > 0])
 
-# set up axis
-fig, ax = plt.subplots(3, 2, sharex=True, sharey=True, figsize=(9, 7))
 
-# fill in axis
-pyDeltaRCM.debug_tools.plot_domain(
-    delta.eta, ax=ax[0, 0], grid=False, cmap='cividis',
-    label='bed elevation (m)')
-pyDeltaRCM.debug_tools.plot_domain(
-    delta.eta, ax=ax[0, 1], grid=False, cmap='cividis',
-    label='bed elevation (m)')
-delta.show_line(delta.free_surf_walk_inds[::10, :].T, 'k-',
-                ax=ax[0, 1], alpha=0.1,
-                multiline=True, nozeros=True)
+fig, ax = plt.subplots(2, 2, sharex=True, sharey=True, figsize=(9, 4))
 
 pyDeltaRCM.debug_tools.plot_domain(
-    delta.sfc_visit, ax=ax[1, 0], grid=False, cmap='Greys',
+    delta.sfc_visit, ax=ax[0, 0], grid=False, cmap='Greys',
     label='sfc_visit (-)')
 pyDeltaRCM.debug_tools.plot_domain(
-    delta.sfc_sum, ax=ax[1, 1], grid=False, cmap='Blues',
+    delta.sfc_sum, ax=ax[0, 1], grid=False, cmap='Blues',
     label='sfc_sum (m)')
 
 pyDeltaRCM.debug_tools.plot_domain(
-    Hnew, ax=ax[2, 0], grid=False,
+    Hnew, ax=ax[1, 0], grid=False,
     label='H_new (m)')
 pyDeltaRCM.debug_tools.plot_domain(
-    stage_new, ax=ax[2, 1], grid=False,
+    stage_new, ax=ax[1, 1], grid=False,
     label='stage (m)')
 
-plt.tight_layout()
-plt.show()
+fig.show()

--- a/docs/source/pyplots/water_tools/compute_free_surface_outputs.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface_outputs.py
@@ -1,7 +1,14 @@
+import warnings
+
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 import pyDeltaRCM
-import matplotlib
+
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
 
 
 n = 1

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -46,7 +46,7 @@ def _plot_idxs_walks_to_step(delta_inds, _step, _idxs, _ax):
 
 # declare the idxs to use:
 idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
-ps = [5, 20, 60]
+ps = [5, 25, 75]
 
 # set up axis
 fig, ax = plt.subplots(2, 3, sharex=True, sharey=True, figsize=(12, 4))

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -12,59 +12,76 @@ cm = matplotlib.cm.get_cmap('tab10')
 delta = pyDeltaRCM.DeltaModel()
 _shp = delta.eta.shape
 
+# init delta model
+delta_later = pyDeltaRCM.DeltaModel(
+    '../../_resources/checkpoint.yaml',
+    resume_checkpoint='../../_resources/deltaRCM_Output')
+_shp = delta_later.eta.shape
+
+
 
 # manually call only the necessary paths
 delta.init_water_iteration()
 delta.run_water_iteration()
 
+delta_later.init_water_iteration()
+delta_later.run_water_iteration()
+
 
 # define a function to fill in the walks of given idx
-def _plot_idxs_walks_to_step(_step, _idxs, _ax):
-    # _step = delta.free_surf_walk_indices.shape[1]
+def _plot_idxs_walks_to_step(delta_inds, _step, _idxs, _ax):
     for i in range(len(_idxs)):
         _hld = np.zeros((_step, 2))
         iidx = _idxs[i]
-        for j in range(_step):
-            walk = delta.free_surf_walk_indices[iidx, j]
-            _hld[j, 1], _hld[j, 0] = pyDeltaRCM.shared_tools.custom_unravel(
-                walk, _shp)
-        _hld[_hld[:, 0] == 0, :] = np.nan
-        _ax.plot(_hld[:, 0], _hld[:, 1], color=cm(i))
-        idx_last = np.where(~np.isnan(_hld[:, 0]))[0][-1]
-        _ax.plot(_hld[idx_last, 0], _hld[idx_last, 1],
+        walk = delta_inds[iidx, :]
+        walk = walk[:_step]
+        pyDeltaRCM.debug_tools.plot_line(walk, shape=_shp, color=cm(i))
+        yend, xend = pyDeltaRCM.shared_tools.custom_unravel(walk[-1], _shp)
+        _ax.plot(xend, yend,
                  marker='o', ms=3, color=cm(i))
 
 
 # declare the idxs to use:
 idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
-
+ps = [5, 15, 40, 60]
 
 # set up axis
-fig, ax = plt.subplots(1, 4, sharex=True, sharey=True, figsize=(12, 3))
-
+fig, ax = plt.subplots(2, 4, sharex=True, sharey=True, figsize=(10, 5))
+vmin, vmax = delta.eta.min(), delta.eta.max()
 
 # fill in axis0
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0], grid=False)
-_plot_idxs_walks_to_step(_step=5, _idxs=idxs, _ax=ax[0])
-ax[0].set_title('after 2 steps')
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 0], grid=False)
+_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[0, 0])
+ax[0, 0].set_title('after {} steps'.format(ps[0]))
+pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 0], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[1, 0])
+# ax[1, 0].set_title('after {} steps'.format(ps[0]))
 
 
 # fill in axis1
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[1], grid=False)
-_plot_idxs_walks_to_step(_step=15, _idxs=idxs, _ax=ax[1])
-ax[1].set_title('after 5 steps')
-
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 1], grid=False)
+_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[0, 1])
+ax[0, 1].set_title('after {} steps'.format(ps[1]))
+pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 1], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[1, 1])
+# ax[1, 1].set_title('after {} steps'.format(ps[1]))
 
 # fill in axis2
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[2], grid=False)
-_plot_idxs_walks_to_step(_step=20, _idxs=idxs, _ax=ax[2])
-ax[2].set_title('after 10 steps')
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 2], grid=False)
+_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[0, 2])
+ax[0, 2].set_title('after {} steps'.format(ps[2]))
+pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 2], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[1, 2])
+# ax[1, 2].set_title('after {} steps'.format(ps[2]))
 
 
 # fill in axis3
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[3], grid=False)
-_plot_idxs_walks_to_step(_step=40, _idxs=idxs, _ax=ax[3])
-ax[3].set_title('after 15 steps')
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 3], grid=False)
+_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[0, 3])
+ax[0, 3].set_title('after {} steps'.format(ps[3]))
+pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 3], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[1, 3])
+# ax[1, 3].set_title('after {} steps'.format(ps[3]))
 
 
 plt.tight_layout()

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -50,39 +50,56 @@ fig, ax = plt.subplots(2, 4, sharex=True, sharey=True, figsize=(10, 5))
 vmin, vmax = delta.eta.min(), delta.eta.max()
 
 # fill in axis0
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 0], grid=False)
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0, 0], grid=False)
 _plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[0, 0])
 ax[0, 0].set_title('after {} steps'.format(ps[0]))
-pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 0], grid=False, vmin=vmin, vmax=vmax)
+pyDeltaRCM.debug_tools.plot_domain(
+    delta_later.eta, ax=ax[1, 0], grid=False, vmin=vmin, vmax=vmax)
 _plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[1, 0])
 # ax[1, 0].set_title('after {} steps'.format(ps[0]))
 
 
 # fill in axis1
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 1], grid=False)
-_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[0, 1])
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0, 1], grid=False)
+_plot_idxs_walks_to_step(
+    delta.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[0, 1])
 ax[0, 1].set_title('after {} steps'.format(ps[1]))
-pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 1], grid=False, vmin=vmin, vmax=vmax)
-_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[1, 1])
+pyDeltaRCM.debug_tools.plot_domain(
+    delta_later.eta, ax=ax[1, 1], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(
+    delta_later.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[1, 1])
 # ax[1, 1].set_title('after {} steps'.format(ps[1]))
 
 # fill in axis2
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 2], grid=False)
-_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[0, 2])
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0, 2], grid=False)
+_plot_idxs_walks_to_step(
+    delta.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[0, 2])
 ax[0, 2].set_title('after {} steps'.format(ps[2]))
-pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 2], grid=False, vmin=vmin, vmax=vmax)
-_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[1, 2])
+pyDeltaRCM.debug_tools.plot_domain(
+    delta_later.eta, ax=ax[1, 2], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(
+    delta_later.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[1, 2])
 # ax[1, 2].set_title('after {} steps'.format(ps[2]))
 
 
 # fill in axis3
-pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0, 3], grid=False)
-_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[0, 3])
+pyDeltaRCM.debug_tools.plot_domain(
+    delta.eta, ax=ax[0, 3], grid=False)
+_plot_idxs_walks_to_step(
+    delta.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[0, 3])
 ax[0, 3].set_title('after {} steps'.format(ps[3]))
-pyDeltaRCM.debug_tools.plot_domain(delta_later.eta, ax=ax[1, 3], grid=False, vmin=vmin, vmax=vmax)
-_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[1, 3])
+pyDeltaRCM.debug_tools.plot_domain(
+    delta_later.eta, ax=ax[1, 3], grid=False, vmin=vmin, vmax=vmax)
+_plot_idxs_walks_to_step(
+    delta_later.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[1, 3])
 # ax[1, 3].set_title('after {} steps'.format(ps[3]))
 
 
 plt.tight_layout()
-plt.show()
+if __name__ == '__main__':
+    plt.savefig('run_water_iteration.png', transparent=True, dpi=300)
+else:
+    plt.show()

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -1,7 +1,14 @@
+import warnings
+
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+
 import pyDeltaRCM
-import matplotlib
+
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
 
 
 n = 10

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -3,56 +3,69 @@ import numpy as np
 import pyDeltaRCM
 import matplotlib
 
+
 n = 10
 cm = matplotlib.cm.get_cmap('tab10')
 
+
 # init delta model
 delta = pyDeltaRCM.DeltaModel()
+_shp = delta.eta.shape
+
 
 # manually call only the necessary paths
 delta.init_water_iteration()
 delta.run_water_iteration()
 
+
 # define a function to fill in the walks of given idx
-_shp = delta.eta.shape
 def _plot_idxs_walks_to_step(_step, _idxs, _ax):
-	# _step = delta.free_surf_walk_indices.shape[1]
-	for i in range(len(_idxs)):
-	    _hld = np.zeros((_step, 2))
-	    iidx = _idxs[i]
-	    for j in range(_step):
-	        walk = delta.free_surf_walk_indices[iidx, j]
-	        _hld[j, 1], _hld[j, 0] = pyDeltaRCM.shared_tools.custom_unravel(walk, _shp)
-	    _hld[_hld[:, 0] == 0, :] = np.nan
-	    _ax.plot(_hld[:, 0], _hld[:, 1], color=cm(i))
-	    idx_last = np.where(~np.isnan(_hld[:, 0]))[0][-1]
-	    _ax.plot(_hld[idx_last, 0], _hld[idx_last, 1], marker='o', ms=3, color=cm(i))
+    # _step = delta.free_surf_walk_indices.shape[1]
+    for i in range(len(_idxs)):
+        _hld = np.zeros((_step, 2))
+        iidx = _idxs[i]
+        for j in range(_step):
+            walk = delta.free_surf_walk_indices[iidx, j]
+            _hld[j, 1], _hld[j, 0] = pyDeltaRCM.shared_tools.custom_unravel(
+                walk, _shp)
+        _hld[_hld[:, 0] == 0, :] = np.nan
+        _ax.plot(_hld[:, 0], _hld[:, 1], color=cm(i))
+        idx_last = np.where(~np.isnan(_hld[:, 0]))[0][-1]
+        _ax.plot(_hld[idx_last, 0], _hld[idx_last, 1],
+                 marker='o', ms=3, color=cm(i))
+
 
 # declare the idxs to use:
 idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
 
+
 # set up axis
 fig, ax = plt.subplots(1, 4, sharex=True, sharey=True, figsize=(12, 3))
 
+
 # fill in axis0
 pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0], grid=False)
-_plot_idxs_walks_to_step(_step=2, _idxs=idxs, _ax=ax[0])
+_plot_idxs_walks_to_step(_step=5, _idxs=idxs, _ax=ax[0])
 ax[0].set_title('after 2 steps')
+
 
 # fill in axis1
 pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[1], grid=False)
-_plot_idxs_walks_to_step(_step=5, _idxs=idxs, _ax=ax[1])
+_plot_idxs_walks_to_step(_step=15, _idxs=idxs, _ax=ax[1])
 ax[1].set_title('after 5 steps')
+
 
 # fill in axis2
 pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[2], grid=False)
-_plot_idxs_walks_to_step(_step=10, _idxs=idxs, _ax=ax[2])
+_plot_idxs_walks_to_step(_step=20, _idxs=idxs, _ax=ax[2])
 ax[2].set_title('after 10 steps')
+
 
 # fill in axis3
 pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[3], grid=False)
-_plot_idxs_walks_to_step(_step=15, _idxs=idxs, _ax=ax[3])
+_plot_idxs_walks_to_step(_step=40, _idxs=idxs, _ax=ax[3])
 ax[3].set_title('after 15 steps')
+
 
 plt.tight_layout()
 plt.show()

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -1,0 +1,58 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pyDeltaRCM
+import matplotlib
+
+n = 10
+cm = matplotlib.cm.get_cmap('tab10')
+
+# init delta model
+delta = pyDeltaRCM.DeltaModel()
+
+# manually call only the necessary paths
+delta.init_water_iteration()
+delta.run_water_iteration()
+
+# define a function to fill in the walks of given idx
+_shp = delta.eta.shape
+def _plot_idxs_walks_to_step(_step, _idxs, _ax):
+	# _step = delta.free_surf_walk_indices.shape[1]
+	for i in range(len(_idxs)):
+	    _hld = np.zeros((_step, 2))
+	    iidx = _idxs[i]
+	    for j in range(_step):
+	        walk = delta.free_surf_walk_indices[iidx, j]
+	        _hld[j, 1], _hld[j, 0] = pyDeltaRCM.shared_tools.custom_unravel(walk, _shp)
+	    _hld[_hld[:, 0] == 0, :] = np.nan
+	    _ax.plot(_hld[:, 0], _hld[:, 1], color=cm(i))
+	    idx_last = np.where(~np.isnan(_hld[:, 0]))[0][-1]
+	    _ax.plot(_hld[idx_last, 0], _hld[idx_last, 1], marker='o', ms=3, color=cm(i))
+
+# declare the idxs to use:
+idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
+
+# set up axis
+fig, ax = plt.subplots(1, 4, sharex=True, sharey=True, figsize=(12, 3))
+
+# fill in axis0
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[0], grid=False)
+_plot_idxs_walks_to_step(_step=2, _idxs=idxs, _ax=ax[0])
+ax[0].set_title('after 2 steps')
+
+# fill in axis1
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[1], grid=False)
+_plot_idxs_walks_to_step(_step=5, _idxs=idxs, _ax=ax[1])
+ax[1].set_title('after 5 steps')
+
+# fill in axis2
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[2], grid=False)
+_plot_idxs_walks_to_step(_step=10, _idxs=idxs, _ax=ax[2])
+ax[2].set_title('after 10 steps')
+
+# fill in axis3
+pyDeltaRCM.debug_tools.plot_domain(delta.eta, ax=ax[3], grid=False)
+_plot_idxs_walks_to_step(_step=15, _idxs=idxs, _ax=ax[3])
+ax[3].set_title('after 15 steps')
+
+plt.tight_layout()
+plt.show()

--- a/docs/source/pyplots/water_tools/run_water_iteration.py
+++ b/docs/source/pyplots/water_tools/run_water_iteration.py
@@ -9,15 +9,16 @@ cm = matplotlib.cm.get_cmap('tab10')
 
 
 # init delta model
-delta = pyDeltaRCM.DeltaModel()
-_shp = delta.eta.shape
+with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    delta = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir)
 
-# init delta model
-delta_later = pyDeltaRCM.DeltaModel(
-    '../../_resources/checkpoint.yaml',
-    resume_checkpoint='../../_resources/deltaRCM_Output')
+    delta_later = pyDeltaRCM.DeltaModel(
+        out_dir=output_dir,
+        resume_checkpoint='../../_resources/checkpoint')
+
+
 _shp = delta_later.eta.shape
-
 
 
 # manually call only the necessary paths
@@ -31,75 +32,64 @@ delta_later.run_water_iteration()
 # define a function to fill in the walks of given idx
 def _plot_idxs_walks_to_step(delta_inds, _step, _idxs, _ax):
     for i in range(len(_idxs)):
-        _hld = np.zeros((_step, 2))
         iidx = _idxs[i]
         walk = delta_inds[iidx, :]
         walk = walk[:_step]
-        pyDeltaRCM.debug_tools.plot_line(walk, shape=_shp, color=cm(i))
-        yend, xend = pyDeltaRCM.shared_tools.custom_unravel(walk[-1], _shp)
+        pyDeltaRCM.debug_tools.plot_line(
+            walk, shape=_shp, color=cm(i),
+            nozeros=True)
+        yend, xend = pyDeltaRCM.shared_tools.custom_unravel(
+            walk[-1], _shp)
         _ax.plot(xend, yend,
                  marker='o', ms=3, color=cm(i))
 
 
 # declare the idxs to use:
 idxs = np.random.randint(low=0, high=delta._Np_water, size=n)
-ps = [5, 15, 40, 60]
+ps = [5, 20, 60]
 
 # set up axis
-fig, ax = plt.subplots(2, 4, sharex=True, sharey=True, figsize=(10, 5))
+fig, ax = plt.subplots(2, 3, sharex=True, sharey=True, figsize=(12, 4))
 vmin, vmax = delta.eta.min(), delta.eta.max()
 
 # fill in axis0
 pyDeltaRCM.debug_tools.plot_domain(
-    delta.eta, ax=ax[0, 0], grid=False)
-_plot_idxs_walks_to_step(delta.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[0, 0])
+    delta.eta, ax=ax[0, 0], grid=False, cmap='cividis')
+_plot_idxs_walks_to_step(
+    delta.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[0, 0])
 ax[0, 0].set_title('after {} steps'.format(ps[0]))
 pyDeltaRCM.debug_tools.plot_domain(
-    delta_later.eta, ax=ax[1, 0], grid=False, vmin=vmin, vmax=vmax)
-_plot_idxs_walks_to_step(delta_later.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[1, 0])
+    delta_later.eta, ax=ax[1, 0], grid=False, vmin=vmin, vmax=vmax, cmap='cividis')
+_plot_idxs_walks_to_step(
+    delta_later.free_surf_walk_inds, _step=ps[0], _idxs=idxs, _ax=ax[1, 0])
 # ax[1, 0].set_title('after {} steps'.format(ps[0]))
 
 
 # fill in axis1
 pyDeltaRCM.debug_tools.plot_domain(
-    delta.eta, ax=ax[0, 1], grid=False)
+    delta.eta, ax=ax[0, 1], grid=False, cmap='cividis')
 _plot_idxs_walks_to_step(
     delta.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[0, 1])
 ax[0, 1].set_title('after {} steps'.format(ps[1]))
 pyDeltaRCM.debug_tools.plot_domain(
-    delta_later.eta, ax=ax[1, 1], grid=False, vmin=vmin, vmax=vmax)
+    delta_later.eta, ax=ax[1, 1], grid=False, vmin=vmin, vmax=vmax, cmap='cividis')
 _plot_idxs_walks_to_step(
     delta_later.free_surf_walk_inds, _step=ps[1], _idxs=idxs, _ax=ax[1, 1])
 # ax[1, 1].set_title('after {} steps'.format(ps[1]))
 
+
 # fill in axis2
 pyDeltaRCM.debug_tools.plot_domain(
-    delta.eta, ax=ax[0, 2], grid=False)
+    delta.eta, ax=ax[0, 2], grid=False, cmap='cividis')
 _plot_idxs_walks_to_step(
     delta.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[0, 2])
 ax[0, 2].set_title('after {} steps'.format(ps[2]))
 pyDeltaRCM.debug_tools.plot_domain(
-    delta_later.eta, ax=ax[1, 2], grid=False, vmin=vmin, vmax=vmax)
+    delta_later.eta, ax=ax[1, 2], grid=False, vmin=vmin, vmax=vmax, cmap='cividis')
 _plot_idxs_walks_to_step(
     delta_later.free_surf_walk_inds, _step=ps[2], _idxs=idxs, _ax=ax[1, 2])
-# ax[1, 2].set_title('after {} steps'.format(ps[2]))
-
-
-# fill in axis3
-pyDeltaRCM.debug_tools.plot_domain(
-    delta.eta, ax=ax[0, 3], grid=False)
-_plot_idxs_walks_to_step(
-    delta.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[0, 3])
-ax[0, 3].set_title('after {} steps'.format(ps[3]))
-pyDeltaRCM.debug_tools.plot_domain(
-    delta_later.eta, ax=ax[1, 3], grid=False, vmin=vmin, vmax=vmax)
-_plot_idxs_walks_to_step(
-    delta_later.free_surf_walk_inds, _step=ps[3], _idxs=idxs, _ax=ax[1, 3])
 # ax[1, 3].set_title('after {} steps'.format(ps[3]))
 
 
 plt.tight_layout()
-if __name__ == '__main__':
-    plt.savefig('run_water_iteration.png', transparent=True, dpi=300)
-else:
-    plt.show()
+plt.show()

--- a/docs/source/pyplots/water_tools/water_weights_examples.py
+++ b/docs/source/pyplots/water_tools/water_weights_examples.py
@@ -1,0 +1,97 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib
+from mpl_toolkits import mplot3d
+
+import pyDeltaRCM
+from pyDeltaRCM import water_tools
+from pyDeltaRCM import shared_tools
+
+_delta = pyDeltaRCM.DeltaModel()
+
+ivec_flat = _delta.ivec_flat
+jvec_flat = _delta.jvec_flat
+distances_flat = _delta.distances_flat
+
+ct_nbrs = np.ones((3, 3))
+theta_water = 1
+gamma = 0.05
+dry_depth = 0.1
+ind = (100, 100)
+
+
+def _get_back_weights(eta_nbrs, depth_nbrs, stage_nbrs, _qx, _qy):
+
+    _eta_nbrs = eta_nbrs.ravel()
+    _depth_nbrs = depth_nbrs.ravel()
+    _stage_nbrs = stage_nbrs.ravel()
+    _stage = _stage_nbrs[4]
+
+    weight_sfc, weight_int = shared_tools.get_weight_sfc_int(
+        _stage, _stage_nbrs,
+        _qx, _qy, ivec_flat, jvec_flat,
+        distances_flat)
+
+    water_weights = water_tools._get_weight_at_cell_water(
+        ind, weight_sfc, weight_int,
+        _depth_nbrs, ct_nbrs.ravel(),
+        dry_depth, gamma, theta_water)
+
+    return water_weights
+
+
+# stage_nbrs = pad_stage[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
+# depth_nbrs = pad_depth[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
+# ct_nbrs = pad_cell_type[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
+
+eta_nbrs = np.array([[2,    1.25, 1.5],
+                     [1.25, 1.0,  1.5],
+                     [1.25, 1.0, 0.75]])
+depth_nbrs = np.array([[3, 3.75, 2.5],
+                       [2.5, 2,  2.],
+                       [2.5, 2, 2]])
+stage_nbrs = eta_nbrs + depth_nbrs
+
+qx = 1
+qy = 0
+
+# wts = _get_back_weights(eta_nbrs, depth_nbrs, stage_nbrs, qx, qy)
+
+
+def _plot_array(_arr, _ax, colspec, **kwargs):
+    if colspec == 'bed':
+        cm = matplotlib.cm.get_cmap('viridis', 10)
+    elif colspec == 'stage':
+        cm = matplotlib.cm.get_cmap('viridis', 10)
+
+    for i in range(_arr.shape[0]):
+        for j in range(_arr.shape[0]):
+            # create x,y
+            xx, yy = np.meshgrid(np.arange(i, i+2), np.arange(j, j+2))
+            # _arr[i:i+2, j:j+2]
+            _p_arr = np.ones((2, 2)) * _arr[i, j]
+            x = _arr[i, j]
+            v = (10-0)*((x-np.min(_arr))/(np.max(_arr)-np.min(_arr)))+0  # rescale value in 1-100
+            _ax.plot_surface(xx, yy, _p_arr, color=cm(int(v)), **kwargs)
+
+
+# fig, ax = plt.subplots()
+fig = plt.figure()
+ax = plt.axes(projection='3d')
+# ax.imshow(wts.reshape(3, 3))
+# _plot_array(eta_nbrs, _ax=ax, colspec='bed')
+
+_xx, _yy = np.meshgrid(np.arange(3), np.arange(3))
+x, y = _xx.ravel(), _yy.ravel()
+
+top = eta_nbrs.ravel()
+bottom = np.zeros_like(top)
+width = depth = 1
+ax.bar3d(x, y, bottom, width, depth, top, shade=True)
+
+
+# _plot_array(stage_nbrs, _ax=ax, colspec='stage')
+_xx, _yy = np.meshgrid(np.arange(4), np.arange(4))
+ax.plot_surface(_xx, _yy, stage_nbrs)
+ax.set_zlim(0, 20)
+plt.show()

--- a/docs/source/pyplots/water_tools/water_weights_examples.py
+++ b/docs/source/pyplots/water_tools/water_weights_examples.py
@@ -1,8 +1,15 @@
+import warnings
+
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-import matplotlib
 
 import pyDeltaRCM
+
+
+# filter out the warning raised about no netcdf being found
+warnings.filterwarnings("ignore", category=UserWarning)
+
 
 n = 10
 cm = matplotlib.cm.get_cmap('tab10')

--- a/docs/source/reference/debug_tools/index.rst
+++ b/docs/source/reference/debug_tools/index.rst
@@ -4,15 +4,34 @@
 debug_tools
 ***********
 
+.. currentmodule:: pyDeltaRCM.debug_tools
+
 The debugging tools are defined in ``pyDeltaRCM.debug_tools``. 
+
+.. todo::
+
+    Add paragraph description of the module. What stages are defined here generally?
 
 
 Public API methods attached to model
 ------------------------------------
 
-.. currentmodule:: pyDeltaRCM.debug_tools
+The following methods are defined in the ``debug_tools`` class, of the ``pyDeltaRCM.debug_tools`` module.
+They are then attached as methods of the `DeltaModel` and can be called at any time during run.
 
-.. autosummary:: 
-    :toctree: ../../_autosummary
+.. autosummary::
 
     debug_tools
+
+.. autoclass:: debug_tools
+
+
+Public plotting methods
+-----------------------
+
+The functions defined below are (generally) the actual workers that handle the plotting for the methods defined above and attached to model.
+We expose these functions here because they are be useful in the documentation, where they are used extensively.
+
+.. autofunction:: plot_domain
+.. autofunction:: plot_ind
+.. autofunction:: plot_line

--- a/docs/source/reference/hook_tools/index.rst
+++ b/docs/source/reference/hook_tools/index.rst
@@ -2,14 +2,20 @@
 hook_tools
 *********************************
 
-The tools are defined in ``pyDeltaRCM.hook_tools``. 
+.. currentmodule:: pyDeltaRCM.hook_tools
+
+.. todo::
+
+    Add paragraph description of the module. What stages are defined here generally? Link to relevant documentation about hooks in user guide and model list.
+
 
 Public API methods attached to model
 ------------------------------------
 
-.. currentmodule:: pyDeltaRCM.hook_tools
+The following methods are defined in the ``hook_tools`` class, of the ``pyDeltaRCM.hook_tools`` module. 
 
-.. autosummary:: 
-    :toctree: ../../_autosummary
+.. autosummary::
 
     hook_tools
+
+.. autoclass:: hook_tools

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -4,9 +4,13 @@
 API reference
 =============
 
+The :obj:`DeltaModel` class, defined in `pyDeltaRCM.model`, is the main class of pyDeltaRCM, which provides the object that is manipulated to evolve the numerical delta model.
+This class uses "mix-in" classes, which are defined in separate files (Python `modules`), that break out logically based on the various stages of model use, and components of the model iteration sequence.
+Most model functionality is organized into the various mix-in classes, that are then inherited by the `DeltaModel`. 
+Additionally, several routines of the model are organized into module-level functions, which are "jitted" via the `numba <https://numba.pydata.org/>`_  code optimizer library for Python.
 
-This page gives an overview of all public pyDeltaRCM objects, functions and
-methods.
+This index lists the `pyDeltaRCM` organization, hopefully providing enough information to begin to determine where various components of the model are implemented.
+The index includes model classes, methods, and attributes, as well as additionally utility classes and functions.
 
 .. toctree::
    :maxdepth: 2
@@ -29,7 +33,7 @@ References
 * :ref:`search`
 
 
-.. Search the Index
-.. ==================
+Search the Index
+==================
 
-.. * :ref:`genindex`
+* :ref:`genindex`

--- a/docs/source/reference/init_tools/index.rst
+++ b/docs/source/reference/init_tools/index.rst
@@ -4,15 +4,19 @@
 init_tools
 **********
 
-The initialization tools are defined in ``pyDeltaRCM.init_tools``. 
+.. todo::
 
+    Add paragraph description of the module. What stages are defined here generally? Make a table with the main ones like in water tools?
 
 Public API methods attached to model
 ------------------------------------
 
+The following methods are defined in the ``init_tools`` class, of the ``pyDeltaRCM.init_tools`` module. 
+
 .. currentmodule:: pyDeltaRCM.init_tools
 
-.. autosummary:: 
-	:toctree: ../../_autosummary
+.. autosummary::
 
-	init_tools
+    init_tools
+
+.. autoclass:: init_tools

--- a/docs/source/reference/iteration_tools/index.rst
+++ b/docs/source/reference/iteration_tools/index.rst
@@ -4,16 +4,20 @@
 iteration_tools
 ***************
 
+.. currentmodule:: pyDeltaRCM.iteration_tools
 
-The functions are defined in ``pyDeltaRCM.iteration_tools``. 
+.. todo::
+
+    Add paragraph description of the module. What stages are defined here generally? Make a table with the main ones like in water tools?
 
 
 Public API methods attached to model
 ------------------------------------
 
-.. currentmodule:: pyDeltaRCM.iteration_tools
+The following methods are defined in the ``iteration_tools`` class, of the ``pyDeltaRCM.iteration_tools`` module. 
 
 .. autosummary::
-    :toctree: ../../_autosummary
-    
+
     iteration_tools
+
+.. autoclass:: iteration_tools

--- a/docs/source/reference/model/index.rst
+++ b/docs/source/reference/model/index.rst
@@ -8,6 +8,7 @@ This is the main model code.
 
 This class is defined in ``pyDeltaRCM.model``. 
 
+
 The DeltaModel class and all attributes and methods
 ---------------------------------------------------
 

--- a/docs/source/reference/model/index.rst
+++ b/docs/source/reference/model/index.rst
@@ -17,8 +17,6 @@ The DeltaModel class and all attributes and methods
 	:toctree: ../../_autosummary
 
 	~DeltaModel
-		:inherited-members:
-		:members:
 
 
 

--- a/docs/source/reference/model/index.rst
+++ b/docs/source/reference/model/index.rst
@@ -17,6 +17,9 @@ The DeltaModel class and all attributes and methods
 	:toctree: ../../_autosummary
 
 	~DeltaModel
+		:inherited-members:
+		:members:
+
 
 
 

--- a/docs/source/reference/preprocessor/index.rst
+++ b/docs/source/reference/preprocessor/index.rst
@@ -4,24 +4,37 @@
 Preprocessor
 *********************************
 
+.. currentmodule:: pyDeltaRCM.preprocessor
+
 The high-level API is principally defined in ``pyDeltaRCM.preprocessor``. 
 
+.. todo::
+
+    add paragraph description of the module. What can we do with this? Why does it exist? Link to the relevant documentation in the user guide and examples.
 
 
 Preprocessor classes and API
 ----------------------------
 
-.. currentmodule:: pyDeltaRCM.preprocessor
+The following classes are defined in the ``pyDeltaRCM.preprocessor`` module and enable the high-level model API to work at both the command line and as a Python object.
 
 .. autosummary:: 
     :toctree: ../../_autosummary
 
     PreprocessorCLI
+        :members:
+        :inherited-members:
+
     Preprocessor
+        :members:
+        :inherited-members:
+    
     BasePreprocessor
 
 Preprocessor function and utilities
 -----------------------------------
+
+.. todo:: add description, what are these?
 
 .. autofunction:: preprocessor_wrapper
 .. autofunction:: scale_relative_sea_level_rise_rate

--- a/docs/source/reference/sed_tools/index.rst
+++ b/docs/source/reference/sed_tools/index.rst
@@ -4,29 +4,52 @@
 sed_tools
 *********************************
 
+.. currentmodule:: pyDeltaRCM.sed_tools
+
+.. todo:: add paragraph description of the module
+
+
 The tools are defined in ``pyDeltaRCM.sed_tools``. 
+
 
 Public API methods attached to model
 ------------------------------------
 
-.. currentmodule:: pyDeltaRCM.sed_tools
+The following methods are defined in the ``sed_tools`` class, of the ``pyDeltaRCM.sed_tools`` module. 
 
-.. autosummary:: 
-    :toctree: ../../_autosummary
+.. autosummary::
 
     sed_tools
 
+.. autoclass:: sed_tools
+
+
 Router classes
 --------------
+
+The following classes are defined in the ``pyDeltaRCM.sed_tools`` module. These sediment routing classes are jitted for speed.
 
 .. autosummary:: 
     :toctree: ../../_autosummary
 
     SandRouter
+        :members:
+        :inherited-members:
+        :private-members:
+    
     MudRouter
+        :members:
+        :inherited-members:
+        :private-members:
+    
     BaseRouter
+        :members:
+        :inherited-members:
+        :private-members:
 
+sed_tools helper functions
+----------------------------
 
-Additionally, the sediment routing function:
+Additionally, the sediment parcel step-weighting function is defined at the module level in ``pyDeltaRCM.sed_tools``.
 
 .. autofunction:: _get_weight_at_cell_sediment

--- a/docs/source/reference/shared_tools/index.rst
+++ b/docs/source/reference/shared_tools/index.rst
@@ -4,27 +4,36 @@
 shared_tools
 *********************************
 
+.. currentmodule:: pyDeltaRCM.shared_tools
+
+
+.. todo:: add paragraph description of the module
+
+
 The tools are defined in ``pyDeltaRCM.shared_tools``.
 
 
 Shared functions
 ----------------
 
-.. currentmodule:: pyDeltaRCM.shared_tools
+This module defines several functions that are used throughout the model, and so are organized here for convenience.
 
-.. autofunction:: set_random_seed
 .. autofunction:: get_random_uniform
 .. autofunction:: get_start_indices
 .. autofunction:: get_steps
 .. autofunction:: random_pick
 .. autofunction:: custom_unravel
 .. autofunction:: custom_ravel
+.. autofunction:: custom_pad
 .. autofunction:: get_weight_sfc_int
-.. autofunction:: _get_version
+.. autofunction:: custom_yaml_loader
 
 
 Time scaling functions
 ----------------------
+
+Scaling of real-world time and model time is an important topic covered in detail in :doc:`/info/modeltime`.
+Several functions are defined here which can help with scaling between model and real-world time.
 
 .. autofunction:: scale_model_time
 .. autofunction:: _scale_factor
@@ -33,4 +42,10 @@ Time scaling functions
 Utilities
 ---------
 
+Additionally, functions defined in ``pyDeltaRCM.shared_tools`` manage the random state of the model, and help with documentation and version management.
+
+.. autofunction:: set_random_seed
+.. autofunction:: get_random_state
+.. autofunction:: set_random_state
 .. autofunction:: _docs_temp_directory
+.. autofunction:: _get_version

--- a/docs/source/reference/water_tools/index.rst
+++ b/docs/source/reference/water_tools/index.rst
@@ -6,11 +6,6 @@ water_tools
 
 .. currentmodule:: pyDeltaRCM.water_tools
 
-The tools are defined in ``pyDeltaRCM.water_tools``. 
-
-.. autosummary::
-
-    water_tools
 
 The :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep` routine manages the water routing.
 During :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep`, water iteration is repeated a total of :obj:`~pyDeltaRCM.model.DeltaModel.itermax` times.
@@ -27,15 +22,20 @@ During each of these iterations of the water routing, the following methods are 
 Public API methods attached to model
 ------------------------------------
 
+The following methods are defined in the ``water_tools`` class, of the ``pyDeltaRCM.water_tools`` module. 
+
+.. autosummary::
+
+    water_tools
+
 .. autoclass:: water_tools
 
 
 water_tools helper functions
 ----------------------------
 
-Note that these routines are jitted for speed. They generally take a large
-number of arrays and constants and return a new array(s) to continue with the
-model progression.
+The following routines are jitted for speed.
+They generally take a large number of arrays and constants and return a new array(s) to continue with the model progression within the methods defined above.
 
 .. autofunction:: _get_weight_at_cell_water
 .. autofunction:: _choose_next_directions

--- a/docs/source/reference/water_tools/index.rst
+++ b/docs/source/reference/water_tools/index.rst
@@ -4,18 +4,30 @@
 water_tools
 *********************************
 
+.. currentmodule:: pyDeltaRCM.water_tools
+
 The tools are defined in ``pyDeltaRCM.water_tools``. 
+
+.. autosummary::
+
+    water_tools
+
+The :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep` routine manages the water routing.
+During :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep`, water iteration is repeated a total of :obj:`~pyDeltaRCM.model.DeltaModel.itermax` times.
+During each of these iterations of the water routing, the following methods are called *in order*:
+
+.. autosummary::
+
+    water_tools.init_water_iteration
+	water_tools.run_water_iteration
+	water_tools.compute_free_surface
+	water_tools.finalize_water_iteration
 
 
 Public API methods attached to model
 ------------------------------------
 
-.. currentmodule:: pyDeltaRCM.water_tools
-
-.. autosummary:: 
-    :toctree: ../../_autosummary
-
-    water_tools
+.. autoclass:: water_tools
 
 
 water_tools helper functions

--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -21,20 +21,17 @@ class debug_tools(abc.ABC):
     these tools interactively at that breakpoint. Note, for Python < 3.7 use
     ``pdb.set_trace()``.
 
-    .. testsetup::
-        >>> self = pyDeltaRCM.DeltaModel()
-
     Examples
     --------
 
     Within a debugging shell:
 
-    .. doctest::
+    .. code::
 
         >>> self.show_attribute('cell_type', grid=False)
-        >>> self.show_ind([144, 22, 33, 34, 35])
-        >>> self.show_ind((12, 14), 'bs')
-        >>> self.show_ind([(11, 4), (11, 5)], 'g^')
+        >>> self.show_ind([3378, 9145, 11568, 514, 13558])
+        >>> self.show_ind((42, 94), 'bs')
+        >>> self.show_ind([(41, 8), (42, 10)], 'g^')
         >>> plt.show()
 
     .. plot:: debug_tools/debug_demo.py

--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -180,7 +180,6 @@ class debug_tools(abc.ABC):
             if ind.ndim > 2:
                 raise NotImplementedError('Not implemented for arrays > 2d.')
             elif ind.ndim > 1:
-                breakpoint()
                 if multiline:
                     # travel along axis, extracting lines
                     cm = matplotlib.cm.get_cmap('tab10')
@@ -335,7 +334,21 @@ def plot_line(_ind, *args, shape=None, nozeros=False, **kwargs):
                     else:
                         pxpys[i, :] = shared_tools.custom_unravel(_ind[i], _shape)
             else:
-                pxpys = np.fliplr(_ind)
+                if _ind.ndim > 1:
+                    pxpys = np.fliplr(_ind)
+                else:
+                    if (_shape is None):
+                        raise ValueError(
+                            'Shape of array must be given to unravel index.')
+                    pxpys = np.zeros((_ind.shape[0], 2))
+                    for i in range(_ind.shape[0]):
+                        if _ind[i] == 0:
+                            if nozeros:
+                                pxpys[i, :] = np.nan, np.nan
+                            else:
+                                pxpys[i, :] = shared_tools.custom_unravel(_ind[i], _shape)
+                        else:
+                            pxpys[i, :] = shared_tools.custom_unravel(_ind[i], _shape)
 
     _l, = ax.plot(pxpys[:, 1], pxpys[:, 0], *args, **kwargs)
 

--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -178,7 +178,7 @@ class debug_tools(abc.ABC):
             raise NotImplementedError
 
 
-def plot_domain(attr, ax=None, grid=True, block=False, label=None):
+def plot_domain(attr, ax=None, grid=True, block=False, label=None, **kwargs):
     """Plot the model domain.
 
     Public function to plot *any* 2d grid with helper display utils.
@@ -211,7 +211,8 @@ def plot_domain(attr, ax=None, grid=True, block=False, label=None):
 
     cobj = ax.imshow(attr,
                      cmap=plt.get_cmap('viridis'),
-                     interpolation='none')
+                     interpolation='none',
+                     **kwargs)
     divider = axtk.axes_divider.make_axes_locatable(ax)
     cax = divider.append_axes("right", size="2%", pad=0.05)
     cbar = plt.colorbar(cobj, cax=cax)

--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -145,6 +145,15 @@ class debug_tools(abc.ABC):
             Whether to show the plot automatically. Default is `False` (do not
             show automatically).
 
+        multiline : :obj:`bool`, optional
+            When a 2D array is passed as `ind`, this boolean indicates whether
+            to treat each column of the array as a separate line. Default is
+            `False`.
+
+        nozeros : :obj:`bool`, optional
+            Whether to show segements of lines with a flat index `== 0 `.
+            Default is `False`.
+
         Other Parameters
         ----------------
         *args : :obj:`str`, optional
@@ -152,17 +161,26 @@ class debug_tools(abc.ABC):
 
         **kwargs : optional
             Any `kwargs` supported by `matplotlib.pyplot.plt`.
+
+        Returns
+        -------
+        lines : :obj:`list`
+            Lines plotted by call to `show_line`, returned as a list, even if
+            only one line plotted.
+
         """
         _shape = self.depth.shape
         if isinstance(ind, list):
             for _, iind in enumerate(ind):
-                plot_line(iind.flatten(),
-                          shape=_shape, nozeros=nozeros,
-                          *args, **kwargs)
+                _l = plot_line(iind.flatten(),
+                               shape=_shape, nozeros=nozeros,
+                               *args, **kwargs)
+                lines = [_l]
         elif isinstance(ind, np.ndarray):
             if ind.ndim > 2:
                 raise NotImplementedError('Not implemented for arrays > 2d.')
             elif ind.ndim > 1:
+                breakpoint()
                 if multiline:
                     # travel along axis, extracting lines
                     cm = matplotlib.cm.get_cmap('tab10')
@@ -173,11 +191,13 @@ class debug_tools(abc.ABC):
                                        color=cm(i), **kwargs)
                         lines.append(_l)
                 else:
-                    plot_line(ind, *args, nozeros=nozeros, **kwargs)
+                    _l = plot_line(ind, *args, nozeros=nozeros, **kwargs)
+                    lines = [_l]
             else:
-                plot_line(ind.flatten(),
-                          shape=_shape, nozeros=nozeros,
-                          *args, **kwargs)
+                _l = plot_line(ind.flatten(),
+                               shape=_shape, nozeros=nozeros,
+                               *args, **kwargs)
+                lines = [_l]
 
         else:
             raise NotImplementedError

--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -269,7 +269,14 @@ def plot_domain(attr, ax=None, grid=True, block=False, label=None, **kwargs):
 def plot_ind(_ind, *args, shape=None, **kwargs):
     """Plot points within the model domain.
 
+    .. todo:: write a complete docstring with parameters etc.
+
     Method called by :obj:`show_ind`.
+
+    Examples
+    --------
+
+    .. todo:: add examples, pull from tests.
     """
     ax = kwargs.pop('ax', None)
     block = kwargs.pop('block', False)
@@ -301,6 +308,13 @@ def plot_line(_ind, *args, shape=None, nozeros=False, **kwargs):
     """Plot a line within the model domain.
 
     Method called by :obj:`show_line`.
+
+    .. todo:: write a complete docstring with parameters etc.
+
+    Examples
+    --------
+
+    .. todo:: add examples, pull from tests.
     """
     ax = kwargs.pop('ax', None)
     block = kwargs.pop('block', False)

--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -166,9 +166,12 @@ class debug_tools(abc.ABC):
                 if multiline:
                     # travel along axis, extracting lines
                     cm = matplotlib.cm.get_cmap('tab10')
+                    lines = []
                     for i in np.arange(ind.shape[1]):
-                        plot_line(ind[:, i], *args, multiline=multiline,
-                                  nozeros=nozeros, shape=_shape, color=cm(i), **kwargs)
+                        _l = plot_line(ind[:, i], *args, multiline=multiline,
+                                       nozeros=nozeros, shape=_shape,
+                                       color=cm(i), **kwargs)
+                        lines.append(_l)
                 else:
                     plot_line(ind, *args, nozeros=nozeros, **kwargs)
             else:
@@ -178,6 +181,7 @@ class debug_tools(abc.ABC):
 
         else:
             raise NotImplementedError
+        return lines
 
 
 def plot_domain(attr, ax=None, grid=True, block=False, label=None, **kwargs):
@@ -313,7 +317,9 @@ def plot_line(_ind, *args, shape=None, nozeros=False, **kwargs):
             else:
                 pxpys = np.fliplr(_ind)
 
-    ax.plot(pxpys[:, 1], pxpys[:, 0], *args, **kwargs)
+    _l, = ax.plot(pxpys[:, 1], pxpys[:, 0], *args, **kwargs)
 
     if block:
         plt.show()
+
+    return _l

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -125,7 +125,7 @@ save_checkpoint:
   type: 'bool'
   default: False
 resume_checkpoint:
-  type: 'bool'
+  type: ['bool', 'str']
   default: False
 omega_sfc:
   type: ['float', 'int']

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -661,10 +661,7 @@ class init_tools(abc.ABC):
 
         _msg = 'Locating checkpoint file'
         self.log_info(_msg, verbosity=2)
-        if (self._checkpoint_file is None):
-            ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
-        else:
-            ckp_file = self._checkpoint_file
+        ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
         checkpoint = np.load(ckp_file, allow_pickle=True)
 
         # write saved variables back to the model
@@ -736,9 +733,6 @@ class init_tools(abc.ABC):
                 if self.save_strata:
                     self.strata_counter = int(0)
                 self.init_output_file()
-
-                # note we do not output data and a new checkpoint here!
-
             else:
                 # rename the old netCDF4 file
                 _msg = 'Renaming old NetCDF4 output file'

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -661,7 +661,7 @@ class init_tools(abc.ABC):
 
         _msg = 'Locating checkpoint file'
         self.log_info(_msg, verbosity=2)
-        ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
+        ckp_file = os.path.join(self._checkpoint_folder, 'checkpoint.npz')
         checkpoint = np.load(ckp_file, allow_pickle=True)
 
         # write saved variables back to the model

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -661,7 +661,10 @@ class init_tools(abc.ABC):
 
         _msg = 'Locating checkpoint file'
         self.log_info(_msg, verbosity=2)
-        ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
+        if (self._checkpoint_file is None):
+            ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
+        else:
+            ckp_file = self._checkpoint_file
         checkpoint = np.load(ckp_file, allow_pickle=True)
 
         # write saved variables back to the model

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -830,10 +830,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @resume_checkpoint.setter
     def resume_checkpoint(self, resume_checkpoint):
         if isinstance(resume_checkpoint, str):
-            self._checkpoint_file = resume_checkpoint
+            self._checkpoint_folder = resume_checkpoint
             self._resume_checkpoint = True
         else:
-            self._checkpoint_file = None
+            self._checkpoint_folder = None
             self._resume_checkpoint = resume_checkpoint
 
     @property

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1060,9 +1060,9 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         """The time step.
 
         The value of the timestep (:math:`\\Delta t`) is a balance between
-        computation efficiency and model stability [1]_. The :ref:`reference
-        volume </info/morphodynamics/reference_volume>`, which characterizes
-        the volume of an inlet-channel cell, and the sediment discharge to the
+        computation efficiency and model stability [1]_. The
+        :ref:`reference-volume`, which characterizes the
+        volume of an inlet-channel cell, and the sediment discharge to the
         model domain scale the timestep as:
 
         .. math::
@@ -1071,7 +1071,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         where :math:`Q_{s0}` is the sediment discharge into the model domain
         (m:sup:`3`/s), :math:`V_0` is the reference volume, and :math:`N_0` is
-        the :obj:`inlet width <N0_meters>`.
+        the number of cells across the channel (determined by :obj:`N0_meters`
+        and :obj:`dx`).
 
         .. [1] A reduced-complexity model for river delta formation – Part 1:
                Modeling deltas with channel dynamics, M. Liang, V. R. Voller,
@@ -1087,7 +1088,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @property
     def time_step(self):
-        """Alias for `dt`.
+        """Alias for :obj:`dt`.
         """
         return self._dt
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1052,6 +1052,25 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     def dt(self):
         """The time step.
 
+        The value of the timestep (:math:`\\Delta t`) is a balance between
+        computation efficiency and model stability [1]_. The :ref:`reference
+        volume </info/morphodynamics/reference_volume>`, which characterizes
+        the volume of an inlet-channel cell, and the sediment discharge to the
+        model domain scale the timestep as:
+
+        .. math::
+
+            \\Delta t = \\frac{0.1 {N_0}^2 V_0}{Q_{s0}}
+
+        where :math:`Q_{s0}` is the sediment discharge into the model domain
+        (m:sup:`3`/s), :math:`V_0` is the reference volume, and :math:`N_0` is
+        the :obj:`inlet width <N0_meters>`.
+
+        .. [1] A reduced-complexity model for river delta formation – Part 1:
+               Modeling deltas with channel dynamics, M. Liang, V. R. Voller,
+               and C. Paola, Earth Surf. Dynam., 3, 67–86, 2015.
+               https://doi.org/10.5194/esurf-3-67-2015
+
         Raises
         ------
         UserWarning
@@ -1088,7 +1107,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     def save_time_since_data(self):
         """Time since data last output.
 
-        The number of times the :obj:`update` method has been called.
+        The elapsed time (seconds) since data was output with
+        :obj:`output_data`.
         """
         return self._save_time_since_data
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -829,7 +829,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @resume_checkpoint.setter
     def resume_checkpoint(self, resume_checkpoint):
-        self._resume_checkpoint = resume_checkpoint
+        if isinstance(resume_checkpoint, str):
+            self._checkpoint_file = resume_checkpoint
+            self._resume_checkpoint = True
+        else:
+            self._checkpoint_file = None
+            self._resume_checkpoint = resume_checkpoint
 
     @property
     def omega_sfc(self):

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -824,6 +824,13 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     def resume_checkpoint(self):
         """
         resume_checkpoint controls loading of a checkpoint if run is resuming.
+
+        When setting this option in the YAML or command line, you can specify
+        a `bool` (e.g., `resume_checkpoint: True`) which will search in the
+        :obj:`out_dir` directory for a file named ``checkpoint.npz``.
+        Alternatively, you can specify an alternative folder to search for the
+        checkpoint *as a string* (e.g., `resume_checkpoint:
+        '/some/other/path'`).
         """
         return self._resume_checkpoint
 
@@ -833,7 +840,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             self._checkpoint_folder = resume_checkpoint
             self._resume_checkpoint = True
         else:
-            self._checkpoint_folder = None
+            self._checkpoint_folder = self.prefix
             self._resume_checkpoint = resume_checkpoint
 
     @property
@@ -1060,7 +1067,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         .. math::
 
-            \\Delta t = \\frac{0.1 {N_0}^2 V_0}{Q_{s0}}
+            \\Delta t = \\dfrac{0.1 {N_0}^2 V_0}{Q_{s0}}
 
         where :math:`Q_{s0}` is the sediment discharge into the model domain
         (m:sup:`3`/s), :math:`V_0` is the reference volume, and :math:`N_0` is

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -1054,15 +1054,20 @@ class Preprocessor(BasePreprocessor):
 
 
 def preprocessor_wrapper():
-    """Wrapper for CLI interface.
+    """Wrapper for command line interface.
 
-    The entry_points setup of a command line interface requires a function, so
-    we use this simple wrapper to instantiate and run the jobs.
+    The `entry_points` setup of a command line interface requires a function,
+    so we use this simple wrapper to instantiate and run the jobs.
 
-    Works by creating an instance of the
+    This function creates an instance of the
     :obj:`~pyDeltaRCM.preprocessor.PreprocessorCLI` and calls the
     :meth:`~pyDeltaRCM.preprocessor.PreprocessorCLI.run_jobs` to execute all
-    jobs.
+    jobs configured in the preprocessor. In code:
+
+    .. code:: python
+
+        pp = PreprocessorCLI()
+        pp.run_jobs()
     """
     pp = PreprocessorCLI()
     pp.run_jobs()

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -154,7 +154,13 @@ class sed_tools(abc.ABC):
 @njit
 def _get_weight_at_cell_sediment(ind, weight_int, depth_nbrs, ct_nbrs,
                                  dry_depth, theta, distances_flat):
+    """Get neighbor weight array for sediment routing.
 
+    .. todo::
+
+        Expand description. Include example? Equation? Link to Morphodynamics
+        document.
+    """
     dry = (depth_nbrs <= dry_depth)
     wall = (ct_nbrs == -2)
     ctr = (np.arange(9) == 4)
@@ -308,7 +314,8 @@ class BaseRouter(object):
 
             Total sediment mass is preserved, but individual categories
             of sand and mud are not. I.e., it is assumed that there is infinite
-            sand and/or mud to erode at any location where erosion is occuring.
+            sand and/or mud to erode at any location where erosion is
+            occurring.
 
         Parameters
         ----------

--- a/pyDeltaRCM/shared_tools.py
+++ b/pyDeltaRCM/shared_tools.py
@@ -18,26 +18,51 @@ earth_grav = 9.81
 
 @njit
 def set_random_seed(_seed):
+    """Set the random seed from an integer.
+
+    .. todo:: Description needed. Where is it used?
+
+    """
     np.random.seed(_seed)
 
 
 def get_random_state():
+    """Set the random state as a tuple.
+
+    .. todo:: Description needed. Where is it used?
+
+    """
     ptr = _helperlib.rnd_get_np_state_ptr()
     return _helperlib.rnd_get_state(ptr)
 
 
 def set_random_state(_state_tuple):
+    """Set the random state from a tuple.
+
+    .. todo:: Description needed. Where is it used?
+
+    """
     ptr = _helperlib.rnd_get_np_state_ptr()
     _helperlib.rnd_set_state(ptr, _state_tuple)
 
 
 @njit
 def get_random_uniform(limit):
+    """
+
+    .. todo:: Description needed. Where is it used?
+
+    """
     return np.random.uniform(0, limit)
 
 
 @njit
 def get_start_indices(inlet, inlet_weights, num_starts):
+    """Get start indices.
+
+    .. todo:: Description needed. Where is it used?
+
+    """
     norm_weights = inlet_weights / np.sum(inlet_weights)
     idxs = []
     for _ in np.arange(num_starts):
@@ -48,7 +73,11 @@ def get_start_indices(inlet, inlet_weights, num_starts):
 
 @njit
 def get_steps(new_cells, iwalk, jwalk):
-    """Find the values giving the next step."""
+    """Find the values giving the next step.
+
+    .. todo:: Description needed. Where is it used?
+
+    """
     istep = iwalk[new_cells]
     jstep = jwalk[new_cells]
     dist = np.sqrt(istep * istep + jstep * jstep)
@@ -65,6 +94,12 @@ def random_pick(prob):
     Return the index of the selected weight in array probs
     Takes a numpy array that is the precalculated probability
     around the cell flattened to 1D.
+
+    Examples
+    --------
+
+    .. todo:: Examples needed (pull from tests?).
+
     """
     arr = np.arange(len(prob))
     cumprob = np.cumsum(prob)
@@ -73,7 +108,16 @@ def random_pick(prob):
 
 @njit('UniTuple(int64, 2)(int64, UniTuple(int64, 2))')
 def custom_unravel(i, shape):
-    """Unravel indexes for 2D array."""
+    """Unravel indexes for 2D array.
+
+    .. todo:: Description needed. Where is it used?
+
+    Examples
+    --------
+
+    .. todo:: Examples needed (pull from tests?).
+
+    """
     if i > (shape[1] * shape[0]):
         raise IndexError("Index is out of matrix bounds")
     x = i // shape[1]
@@ -83,7 +127,15 @@ def custom_unravel(i, shape):
 
 @njit('int64(UniTuple(int64, 2), UniTuple(int64, 2))')
 def custom_ravel(tup, shape):
-    """Ravel indexes for 2D array."""
+    """Ravel indexes for 2D array.
+
+    .. todo:: Description needed. Where is it used?
+
+    Examples
+    --------
+
+    .. todo:: Examples needed (pull from tests?).
+    """
     if tup[0] > shape[0] or tup[1] > shape[1]:
         raise IndexError("Index is out of matrix bounds")
     x = tup[0] * shape[1]
@@ -93,7 +145,15 @@ def custom_ravel(tup, shape):
 
 @njit
 def custom_pad(arr):
-    """pad as np.pad(arr, 1, 'edge')
+    """Pad an array as ``np.pad(arr, 1, 'edge')``.
+
+    .. todo:: Description needed. Where is it used?
+
+    Examples
+    --------
+
+    .. todo:: Examples needed (pull from tests?).
+
     """
     old_shape = arr.shape
     new_shape = (old_shape[0]+2, old_shape[1]+2)
@@ -123,6 +183,11 @@ def get_weight_sfc_int(stage, stage_nbrs, qx, qy, ivec, jvec, distances):
 
     Determines the surfaces for weighting the random walks based on the stage
     and discharge fields.
+
+    .. todo::
+
+        Expand description. Where is it used? Include an example? Equations?
+        Link to Hydrodyanmics doc?
     """
     weight_sfc = np.maximum(0, (stage - stage_nbrs) / distances)
     weight_int = np.maximum(0, (qx * jvec + qy * ivec) / distances)
@@ -133,6 +198,13 @@ def _get_version():
     """Extract version from file.
 
     Extract version number from single file, and make it availabe everywhere.
+
+    .. todo:: Description needed. Where is it used?
+
+    Examples
+    --------
+
+    .. todo:: Examples needed (pull from tests?).
     """
     from . import _version
     return _version.__version__()

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -153,6 +153,11 @@ class water_tools(abc.ABC):
         function :obj:`accumulate_free_surface_walks`. Following this
         computation, the free surface is smoothed by steps in
         :obj:`finalize_free_surface`.
+
+        Examples
+        --------
+
+        .. plot:: water_tools/compute_free_surface.py
         """
         _msg = 'Computing free surface from water parcels'
         self.log_info(_msg, verbosity=2)

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -37,6 +37,12 @@ class water_tools(abc.ABC):
 
         All parcels are processed in parallel, taking one step for each loop
         of the ``while`` loop.
+
+        Example
+        -------
+        On the initial delta surface, see how ten selected parcels are routed through the domain:
+
+        .. plot:: water_tools/run_water_iteration.py
         """
         _msg = 'Beginning stepping of water parcels'
         self.log_info(_msg, verbosity=2)

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -701,6 +701,31 @@ def _check_for_loops(free_surf_walk_inds, new_inds, _step,
         A binary integer array indicating whether a parcel was determined to
         have been looped, and should be disqualified from the free surface
         computation.
+
+    Examples
+    --------
+
+    The following shows an example of how water parcels that looped along
+    their paths would be relocated.
+
+    .. plot::
+
+        new_inds0 = np.copy(new_inds)
+        new_inds, looped = _check_for_loops(
+            self.free_surf_walk_inds, new_inds, _step, self.L0,
+            self.eta.shape, self.CTR)
+        looped = looped.astype(np.bool)
+        neq = new_inds != new_inds0
+
+        print(np.where(neq)[0])
+        print([shared_tools.custom_unravel(i, self.eta.shape) for i in new_inds[neq]])
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        self.show_attribute('cell_type', ax=ax, grid=False)
+        self.show_ind(new_inds[neq], 'r.', ax=ax)
+        self.show_ind(new_inds0[neq], 'b.', ax=ax)
+        self.show_ind(self.free_surf_walk_inds[neq, :_step], 'k-', ax=ax)
+        plt.show()
     """
     nparcels = free_surf_walk_inds.shape[0]
     domain_shape = stage_above_SL.shape

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -708,24 +708,8 @@ def _check_for_loops(free_surf_walk_inds, new_inds, _step,
     The following shows an example of how water parcels that looped along
     their paths would be relocated.
 
-    .. plot::
+    .. plot:: water_tools/_check_for_loops.py
 
-        new_inds0 = np.copy(new_inds)
-        new_inds, looped = _check_for_loops(
-            self.free_surf_walk_inds, new_inds, _step, self.L0,
-            self.eta.shape, self.CTR)
-        looped = looped.astype(np.bool)
-        neq = new_inds != new_inds0
-
-        print(np.where(neq)[0])
-        print([shared_tools.custom_unravel(i, self.eta.shape) for i in new_inds[neq]])
-        import matplotlib.pyplot as plt
-        fig, ax = plt.subplots()
-        self.show_attribute('cell_type', ax=ax, grid=False)
-        self.show_ind(new_inds[neq], 'r.', ax=ax)
-        self.show_ind(new_inds0[neq], 'b.', ax=ax)
-        self.show_ind(self.free_surf_walk_inds[neq, :_step], 'k-', ax=ax)
-        plt.show()
     """
     nparcels = free_surf_walk_inds.shape[0]
     domain_shape = stage_above_SL.shape

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -679,7 +679,7 @@ def _check_for_loops(free_surf_walk_inds, new_inds, _step,
 
     new_inds
         Array recording the new index for each water parcel, if the step is
-        taken. Shape is `(:obj:`Np_water`, 1)`, with each element recording
+        taken. Shape is `(Np_water, 1)`, with each element recording
         the *flat* index into the domain shape.
 
     _step
@@ -824,7 +824,8 @@ def _accumulate_free_surface_walks(free_surf_walk_inds, free_surf_flag,
     Examples
     --------
 
-    The following shows an example of the walk of a few water parcels, along with the resultant computed water surface.
+    The following shows an example of the walk of a few water parcels, along
+    with the resultant computed water surface.
 
     .. plot:: water_tools/_accumulate_free_surface_walks.py
 
@@ -905,6 +906,12 @@ def _smooth_free_surface(Hin, cell_type, Nsmooth, Csmooth):
 
     Csmooth
         Underrelaxation coefficient for smoothing iterations.
+
+    Examples
+    --------
+    The following shows an example of the water surface smoothing process.
+
+    .. plot:: water_tools/_smooth_free_surface.py
     """
     # grab relevant shape information
     L, W = Hin.shape

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -11,6 +11,8 @@ from . import shared_tools
 class water_tools(abc.ABC):
 
     def init_water_iteration(self):
+        """Init the water iteration routine.
+        """
         _msg = 'Initializing water iteration'
         self.log_info(_msg, verbosity=2)
 

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -815,6 +815,14 @@ def _accumulate_free_surface_walks(free_surf_walk_inds, free_surf_flag,
 
         4. repeat from 2, for each parcel.
 
+
+    Examples
+    --------
+
+    The following shows an example of the walk of a few water parcels, along with the resultant computed water surface.
+
+    .. plot:: water_tools/_accumulate_free_surface_walks.py
+
     """
     _shape = uw.shape
     Hnew = np.zeros(_shape)


### PR DESCRIPTION
This PR overhauls the documentation, building on the effort started in #144. 

Most significantly, the PR introduces a single `checkpoint.npz` file at `/docs/source/_resources/checkpoint/checkpoint.npz`, which is used for demonstrations throughout the documentation. The checkpoint can be used within a documentation example as:

```python
# init delta model
with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
    delta = pyDeltaRCM.DeltaModel(
        out_dir=output_dir,
        resume_checkpoint='../../_resources/checkpoint')
```

This will create and tear down any temporary files needed to make the documentation example.

Additionally, I have included in this PR a number of figures showing the results of various components of the model graphically. I believe this is the best way to make our documentation useful.

Throughout, I have added `.. todo::` notes, which I will collate into issues to be addressed for version 2.0.