### PR TITLE
Matrix table as preprocessor attribute and as an output file at the root of the jobs folder

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -212,14 +212,14 @@ class BasePreprocessor(abc.ABC):
 
             # loop through each job to write out info
             for i in range(jobs):
-                
+
                 # being with the fixed config
                 _ith_config = _fixed_config.copy()
 
                 # find job id and create output file
                 ith_id = 'job_' + str(i).zfill(3)
                 ith_dir = os.path.join(self.jobs_root, ith_id)
-                
+
                 # write the job number into output table
                 self.matrix_table[i, 0] = ith_id
 
@@ -228,7 +228,7 @@ class BasePreprocessor(abc.ABC):
 
                 # loop through each var of this job
                 for j, val in enumerate(_combs[i]):
-                    
+
                     # write info into fixed config dict
                     _ith_config[var_list[j]] = val
 
@@ -243,9 +243,10 @@ class BasePreprocessor(abc.ABC):
             #   this is useful for references by custom
             #   Python preprocessing / postprocessing
             matrix_table_file = os.path.join(self.jobs_root, 'jobs_parameters.txt')
+            self.matrix_table_header = ', '.join(['job_id', *var_list])
             np.savetxt(matrix_table_file, self.matrix_table,
                        fmt='%s', delimiter=',', comments='',
-                       header=', '.join(['job_id', *var_list]))
+                       header=self.matrix_table_header)
 
     def construct_job_file_list(self):
         """Construct the job list.

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -205,17 +205,47 @@ class BasePreprocessor(abc.ABC):
                 raise FileExistsError(
                     'Job output directory (%s) already exists.' % str(p))
 
-            # loop, create job yamls
-            self.file_list = []
+            # preallocate the matrix expansion job yamls and output table
+            self.file_list = []  # create job yamls list
+            self.matrix_table = np.empty(  # output table
+                (jobs, dims+1), dtype='O')
+
+            # loop through each job to write out info
             for i in range(jobs):
+                
+                # being with the fixed config
                 _ith_config = _fixed_config.copy()
+
+                # find job id and create output file
                 ith_id = 'job_' + str(i).zfill(3)
                 ith_dir = os.path.join(self.jobs_root, ith_id)
+                
+                # write the job number into output table
+                self.matrix_table[i, 0] = ith_id
+
+                # get config for this job
                 _ith_config['out_dir'] = ith_dir
+
+                # loop through each var of this job
                 for j, val in enumerate(_combs[i]):
+                    
+                    # write info into fixed config dict
                     _ith_config[var_list[j]] = val
+
+                    # write info into output table
+                    self.matrix_table[i, j+1] = val
+
+                # write out the job specific yaml file
                 ith_p = self.write_yaml_config(i, _ith_config, ith_dir, ith_id)
                 self.file_list.append(ith_p)
+
+            # store the matrix expansion
+            #   this is useful for references by custom
+            #   Python preprocessing / postprocessing
+            matrix_table_file = os.path.join(self.jobs_root, 'jobs_parameters.txt')
+            np.savetxt(matrix_table_file, self.matrix_table,
+                       fmt='%s', delimiter=',', comments='',
+                       header=', '.join(['job_id', *var_list]))
 
     def construct_job_file_list(self):
         """Construct the job list.


### PR DESCRIPTION
add a matrix table as attribute of `Preprocessor`, and output to the root folder a csv of the job parameters, which is useful for postprocessing (i.e., model comparison).