### PR TITLE
Checkpointing fix

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -696,7 +696,7 @@ class init_tools(abc.ABC):
                         dst.createDimension(name, None)
                     else:
                         dst.createDimension(name, len(dimension))
-            # copy groups
+            # copy groups (meta)
             for name in src.groups.keys():
                 dst.createGroup(name)
                 for vname, variable in src.groups[name].variables.items():
@@ -718,7 +718,5 @@ class init_tools(abc.ABC):
         # set object attribute for model
         self.output_netcdf = Dataset(file_path, 'r+', format='NETCDF4')
 
-        # open-close then delete old netCDF4 file
-        _tfile = Dataset(_tmp_name, 'r', format='NETCDF4')
-        _tfile.close()
+        # delete old netCDF4 file
         os.remove(_tmp_name)

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -618,7 +618,7 @@ class init_tools(abc.ABC):
         """
         _msg = 'Loading from checkpoint.'
         self.log_info(_msg, verbosity=0)
-        
+
         _msg = 'Locating checkpoint file'
         self.log_info(_msg, verbosity=2)
         ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
@@ -717,6 +717,9 @@ class init_tools(abc.ABC):
 
         # set object attribute for model
         self.output_netcdf = Dataset(file_path, 'r+', format='NETCDF4')
+
+        # synch netcdf file
+        self.output_netcdf.sync()
 
         # delete old netCDF4 file
         os.remove(_tmp_name)

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -718,5 +718,7 @@ class init_tools(abc.ABC):
         # set object attribute for model
         self.output_netcdf = Dataset(file_path, 'r+', format='NETCDF4')
 
-        # delete old netCDF4 file
+        # open-close then delete old netCDF4 file
+        _tfile = Dataset(_tmp_name, 'r', format='NETCDF4')
+        _tfile.close()
         os.remove(_tmp_name)

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -14,7 +14,6 @@ import time as time_lib
 import yaml
 import re
 import abc
-import copy
 
 from . import shared_tools
 from . import sed_tools

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -616,9 +616,9 @@ class init_tools(abc.ABC):
         Uses the file at the path determined by `self.prefix` and a file named
         `checkpoint.npz`.
         """
-        _msg = 'Loading from checkpoint'
+        _msg = 'Loading from checkpoint.'
         self.log_info(_msg, verbosity=0)
-
+        
         _msg = 'Locating checkpoint file'
         self.log_info(_msg, verbosity=2)
         ckp_file = os.path.join(self.prefix, 'checkpoint.npz')

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -14,6 +14,7 @@ import time as time_lib
 import yaml
 import re
 import abc
+import copy
 
 from . import shared_tools
 from . import sed_tools
@@ -466,7 +467,7 @@ class init_tools(abc.ABC):
             _msg = 'Target output NetCDF4 file: {file}'.format(
                 file=file_path)
             self.log_info(_msg, verbosity=2)
-            
+
             if os.path.exists(file_path):
                 _msg = 'Replacing existing netCDF file'
                 self.logger.warning(_msg)
@@ -569,6 +570,41 @@ class init_tools(abc.ABC):
             _msg = 'Output netCDF file created'
             self.log_info(_msg, verbosity=2)
 
+            # insert checkpoint values if provided
+            if self.resume_checkpoint:
+
+                # copying values to put back later
+                current_time = copy.copy(self._time)
+                figure_config = copy.copy(self._save_any_figs)
+                curr_save_since_last = copy.copy(self._save_time_since_last)
+                curr_save_iter = copy.copy(self._save_iter)
+
+                # setting false values to re-create netCDF file
+                self._time = 0  # pretend it is time 0
+                self._save_any_figs = False  # disable figure saving for now
+                self._save_time_since_last = 0
+                self._save_iter = 0
+
+                while self._time <= current_time:
+                    if self._save_time_since_last >= self.save_dt:
+                        self.record_stratigraphy()
+                        self.output_data()
+                        self._save_iter += int(1)
+                        self._save_time_since_last = 0
+                    # update time
+                    self._time += self.dt
+                    self._save_time_since_last += self.dt
+
+                # reset model parameters from checkpoint
+                self._time = current_time
+                self._save_any_figs = figure_config
+                self._save_time_since_last = curr_save_since_last
+                self._save_iter = curr_save_iter
+
+                _msg = 'Inserted checkpoint values into netCDF file.'
+                self.log_info(_msg, verbosity=2)
+
+
     def init_subsidence(self):
         """Initialize subsidence pattern.
 
@@ -622,7 +658,7 @@ class init_tools(abc.ABC):
         self.log_info(_msg, verbosity=2)
         ckp_file = os.path.join(self.prefix, 'checkpoint.npz')
         checkpoint = np.load(ckp_file, allow_pickle=True)
-        
+
         # write saved variables back to the model
         _msg = 'Loading variables into model'
         self.log_info(_msg, verbosity=2)

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -92,10 +92,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         else:
             self.init_stratigraphy()
-
-        # always re-init output file, will clobber when checkpointing
-        if not defer_output:
-            self.init_output_file()
+            if not defer_output:
+                self.init_output_file()
 
         _msg = 'Model initialization complete'
         self.log_info(_msg)

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -85,9 +85,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self.init_subsidence()
 
         # if resume flag set to True, load checkpoint, open netCDF4
-        if self.resume_checkpoint:
-            _msg = 'Loading from checkpoint.'
-            self.log_info(_msg)
+        if self.resume_checkpoint is True:
             self.load_checkpoint()
 
         else:

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -85,8 +85,9 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self.init_subsidence()
 
         # if resume flag set to True, load checkpoint, open netCDF4
-        if self.resume_checkpoint is True:
-            self.load_checkpoint()
+        if self.resume_checkpoint:
+            if defer_output:
+                self.load_checkpoint()
 
         else:
             self.init_stratigraphy()

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -86,14 +86,16 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         # if resume flag set to True, load checkpoint, open netCDF4
         if self.resume_checkpoint:
-            _msg = 'Loading from checkpoint and reopening netCDF4 file.'
+            _msg = 'Loading from checkpoint.'
             self.log_info(_msg)
             self.load_checkpoint()
 
         else:
             self.init_stratigraphy()
-            if not defer_output:
-                self.init_output_file()
+
+        # always re-init output file, will clobber when checkpointing
+        if not defer_output:
+            self.init_output_file()
 
         _msg = 'Model initialization complete'
         self.log_info(_msg)

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -86,8 +86,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         # if resume flag set to True, load checkpoint, open netCDF4
         if self.resume_checkpoint:
-            if defer_output:
-                self.load_checkpoint()
+            self.load_checkpoint()
 
         else:
             self.init_stratigraphy()

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -596,7 +596,7 @@ class _ParallelJob(_BaseJob, multiprocessing.Process):
             # try to initialize and run the model
             try:
                 # initialize the output files (defer_output=True above)
-                # unless resuming from checkpoint, then output file exists
+                # unless resuming from checkpoint, then load the checkpoint
                 if self.deltamodel.resume_checkpoint:
                     self.deltamodel.load_checkpoint()
                 else:

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -120,7 +120,15 @@ class BasePreprocessor(abc.ABC):
             print('Writing YAML file for job ' + str(int(i)))
 
         d = Path(ith_dir)
-        d.mkdir()
+        try:
+            d.mkdir()
+        except FileExistsError:
+            if 'resume_checkpoint' in self.yaml_dict and \
+              self.yaml_dict['resume_checkpoint'] is True:
+                pass
+            else:
+                raise FileExistsError(
+                    'Job output directory (%s) already exists.' % str(p))
         ith_p = d / (str(ith_id) + '.yml')
         write_yaml_config_to_file(ith_config, ith_p)
         return ith_p
@@ -202,8 +210,12 @@ class BasePreprocessor(abc.ABC):
             try:
                 p.mkdir()
             except FileExistsError:
-                raise FileExistsError(
-                    'Job output directory (%s) already exists.' % str(p))
+                if 'resume_checkpoint' in self.yaml_dict and \
+                  self.yaml_dict['resume_checkpoint'] is True:
+                    pass
+                else:
+                    raise FileExistsError(
+                        'Job output directory (%s) already exists.' % str(p))
 
             # preallocate the matrix expansion job yamls and output table
             self.file_list = []  # create job yamls list
@@ -584,7 +596,9 @@ class _ParallelJob(_BaseJob, multiprocessing.Process):
             # try to initialize and run the model
             try:
                 # initialize the output files (defer_output=True above)
-                self.deltamodel.init_output_file()
+                # unless resuming from checkpoint, then output file exists
+                if self.deltamodel.resume_checkpoint is False:
+                    self.deltamodel.init_output_file()
 
                 # run the simualtion
                 while self.deltamodel._time < self._job_end_time:

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -597,7 +597,9 @@ class _ParallelJob(_BaseJob, multiprocessing.Process):
             try:
                 # initialize the output files (defer_output=True above)
                 # unless resuming from checkpoint, then output file exists
-                if self.deltamodel.resume_checkpoint is False:
+                if self.deltamodel.resume_checkpoint:
+                    self.deltamodel.load_checkpoint()
+                else:
                     self.deltamodel.init_output_file()
 
                 # run the simualtion

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -120,15 +120,15 @@ class BasePreprocessor(abc.ABC):
             print('Writing YAML file for job ' + str(int(i)))
 
         d = Path(ith_dir)
-        try:
-            d.mkdir()
-        except FileExistsError:
+        if d.is_dir():
             if 'resume_checkpoint' in self.yaml_dict and \
               self.yaml_dict['resume_checkpoint'] is True:
                 pass
             else:
                 raise FileExistsError(
                     'Job output directory (%s) already exists.' % str(p))
+        else:
+            d.mkdir()
         ith_p = d / (str(ith_id) + '.yml')
         write_yaml_config_to_file(ith_config, ith_p)
         return ith_p
@@ -207,15 +207,15 @@ class BasePreprocessor(abc.ABC):
             # create directory at root
             self.jobs_root = self.yaml_dict['out_dir']  # checked above for exist
             p = Path(self.jobs_root)
-            try:
-                p.mkdir()
-            except FileExistsError:
+            if p.is_dir():
                 if 'resume_checkpoint' in self.yaml_dict and \
                   self.yaml_dict['resume_checkpoint'] is True:
                     pass
                 else:
                     raise FileExistsError(
                         'Job output directory (%s) already exists.' % str(p))
+            else:
+                p.mkdir()
 
             # preallocate the matrix expansion job yamls and output table
             self.file_list = []  # create job yamls list

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -489,3 +489,217 @@ def test_checkpoint_nc(tmp_path):
 
     # checkpoint interval aligns w/ timestep dt so these should match
     assert output['time'][-1].tolist() == resumeModel.time
+
+
+def test_checkpoint_diff_dt(tmp_path):
+    """Test when checkpoint_dt does not match dt or save_dt."""
+    # define a yaml for the base model run
+    file_name = 'base_run.yaml'
+    base_p, base_f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(base_f, 'Length', 10.0)
+    utilities.write_parameter_to_file(base_f, 'Width', 10.0)
+    utilities.write_parameter_to_file(base_f, 'seed', 0)
+    utilities.write_parameter_to_file(base_f, 'dx', 1.0)
+    utilities.write_parameter_to_file(base_f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(base_f, 'Np_water', 10)
+    utilities.write_parameter_to_file(base_f, 'u0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(base_f, 'h0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'SLR', 0.001)
+    utilities.write_parameter_to_file(base_f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(base_f, 'save_dt', 50)
+    utilities.write_parameter_to_file(base_f, 'save_strata', True)
+    utilities.write_parameter_to_file(base_f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_depth_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_discharge_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'checkpoint_dt', 500)
+    utilities.write_parameter_to_file(base_f, 'out_dir', tmp_path / 'test')
+    base_f.close()
+    baseModel = DeltaModel(input_file=base_p)
+
+    for _ in range(0, 2):
+        baseModel.update()
+    baseModel.finalize()
+
+    assert baseModel.time == 600.0  # dt=300 * 2 = 600
+
+    # try defining a new model but plan to load checkpoint from baseModel
+    file_name = 'base_run.yaml'
+    base_p, base_f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(base_f, 'Length', 10.0)
+    utilities.write_parameter_to_file(base_f, 'Width', 10.0)
+    utilities.write_parameter_to_file(base_f, 'seed', 0)
+    utilities.write_parameter_to_file(base_f, 'dx', 1.0)
+    utilities.write_parameter_to_file(base_f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(base_f, 'Np_water', 10)
+    utilities.write_parameter_to_file(base_f, 'u0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(base_f, 'h0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'SLR', 0.001)
+    utilities.write_parameter_to_file(base_f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(base_f, 'save_dt', 50)
+    utilities.write_parameter_to_file(base_f, 'save_strata', True)
+    utilities.write_parameter_to_file(base_f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_depth_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_discharge_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_checkpoint', False)
+    utilities.write_parameter_to_file(base_f, 'resume_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'out_dir', tmp_path / 'test')
+    base_f.close()
+    resumeModel = DeltaModel(input_file=base_p)
+
+    assert resumeModel.time == 600.0  # checkpoint dt was 500 but smaller than
+    # saving dt which was 300, so 300*2=600 should be time we resume from
+    assert resumeModel.time == baseModel.time  # should be same when resumed
+
+    # advance it two more steps
+    for _ in range(0, 2):
+        resumeModel.update()
+    resumeModel.finalize()
+
+    # assert that ouput netCDF4 exists
+    exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    # load it into memory and check values in the netCDF4
+    output = Dataset(exp_path_nc, 'r', allow_pickle=True)
+    out_vars = output.variables.keys()
+    # check that expected variables are in the file
+    assert 'x' in out_vars
+    assert 'y' in out_vars
+    assert 'time' in out_vars
+    assert 'eta' in out_vars
+    assert 'depth' in out_vars
+    assert 'discharge' in out_vars
+    # check attributes of variables
+    assert output['time'][0].tolist() == 0.0
+    assert output['time'][-1].tolist() == 1200.0
+    assert output['eta'][0].shape == (10, 10)
+    assert output['eta'][-1].shape == (10, 10)
+    assert output['depth'][-1].shape == (10, 10)
+    assert output['discharge'][-1].shape == (10, 10)
+    # check time
+    assert baseModel.dt == 300.0  # base model timestep
+    assert baseModel.time == 600.0  # ran 4 steps, so 300*2=600
+    assert resumeModel.dt == 300.0  # resume model timestep size
+    assert resumeModel.time == 1200.0  # ran 2 steps on top of base model
+    # should be 600 + (2*300) = 1200
+    assert len(output['time'][:].tolist()) == 5  # 0-300-600-900-1200
+    # checkpoint interval aligns w/ timestep dt so these should match
+    assert output['time'][-1].tolist() == resumeModel.time
+
+
+def test_multi_checkpoints(tmp_path):
+    """Test using checkpoints multiple times for a given model run."""
+    # define a yaml for the base model run
+    file_name = 'base_run.yaml'
+    base_p, base_f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(base_f, 'Length', 10.0)
+    utilities.write_parameter_to_file(base_f, 'Width', 10.0)
+    utilities.write_parameter_to_file(base_f, 'seed', 0)
+    utilities.write_parameter_to_file(base_f, 'dx', 1.0)
+    utilities.write_parameter_to_file(base_f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(base_f, 'Np_water', 10)
+    utilities.write_parameter_to_file(base_f, 'u0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(base_f, 'h0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'SLR', 0.001)
+    utilities.write_parameter_to_file(base_f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(base_f, 'save_dt', 50)
+    utilities.write_parameter_to_file(base_f, 'save_strata', True)
+    utilities.write_parameter_to_file(base_f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_depth_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_discharge_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'checkpoint_dt', 600)
+    utilities.write_parameter_to_file(base_f, 'out_dir', tmp_path / 'test')
+    base_f.close()
+    baseModel = DeltaModel(input_file=base_p)
+
+    # run base for 2 timesteps
+    for _ in range(0, 2):
+        baseModel.update()
+    baseModel.finalize()
+
+    assert baseModel.time == 600.0  # dt=300 * 2 = 600
+
+    # try defining a new model but plan to load checkpoint from baseModel
+    file_name = 'base_run.yaml'
+    base_p, base_f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(base_f, 'Length', 10.0)
+    utilities.write_parameter_to_file(base_f, 'Width', 10.0)
+    utilities.write_parameter_to_file(base_f, 'seed', 0)
+    utilities.write_parameter_to_file(base_f, 'dx', 1.0)
+    utilities.write_parameter_to_file(base_f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(base_f, 'Np_water', 10)
+    utilities.write_parameter_to_file(base_f, 'u0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(base_f, 'h0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'SLR', 0.001)
+    utilities.write_parameter_to_file(base_f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(base_f, 'save_dt', 50)
+    utilities.write_parameter_to_file(base_f, 'save_strata', True)
+    utilities.write_parameter_to_file(base_f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_depth_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_discharge_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'resume_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'checkpoint_dt', 600)
+    utilities.write_parameter_to_file(base_f, 'out_dir', tmp_path / 'test')
+    base_f.close()
+    resumeModel = DeltaModel(input_file=base_p)
+
+    assert resumeModel.time == 600.0  # checkpoint dt was 500 but smaller than
+    # saving dt which was 300, so 300*2=600 should be time we resume from
+    assert resumeModel.time == baseModel.time  # should be same when resumed
+
+    # advance it two more steps
+    for _ in range(0, 2):
+        resumeModel.update()
+    resumeModel.finalize()
+
+    # create another resume model
+    resumeModel02 = DeltaModel(input_file=base_p)
+
+    assert resumeModel02.time == resumeModel.time  # should be same
+    assert resumeModel02.time == 1200.0  # 300*4 = 1200
+
+    # step it twice
+    for _ in range(0, 2):
+        resumeModel02.update()
+    resumeModel02.finalize()
+
+    # assert that ouput netCDF4 exists
+    exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc)
+
+    # load it into memory and check values in the netCDF4
+    output = Dataset(exp_path_nc, 'r', allow_pickle=True)
+    out_vars = output.variables.keys()
+    # check that expected variables are in the file
+    assert 'x' in out_vars
+    assert 'y' in out_vars
+    assert 'time' in out_vars
+    assert 'eta' in out_vars
+    assert 'depth' in out_vars
+    assert 'discharge' in out_vars
+    # check attributes of variables
+    assert output['time'][0].tolist() == 0.0
+    assert output['time'][-1].tolist() == 1800.0
+    assert output['eta'][0].shape == (10, 10)
+    assert output['eta'][-1].shape == (10, 10)
+    assert output['depth'][-1].shape == (10, 10)
+    assert output['discharge'][-1].shape == (10, 10)
+    # check time
+    assert baseModel.dt == 300.0  # base model timestep
+    assert baseModel.time == 600.0  # ran 2 steps, so 300*2=600
+    assert resumeModel.dt == 300.0  # resume model timestep size
+    assert resumeModel.time == 1200.0  # ran 2 steps on top of base model
+    # should be 600 + (2*300) = 1200
+    assert resumeModel02.dt == 300.0  # same dt
+    assert resumeModel02.time == 1800.0  # ran 2 steps + resume, 1200+600=1800
+
+    assert len(output['time'][:].tolist()) == 7  # 0-300-600-900-1200-1500-1800
+    # checkpoint interval aligns w/ timestep dt so these should match
+    assert output['time'][-1].tolist() == resumeModel02.time

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -68,6 +68,7 @@ def test_long_multi_validation(tmp_path):
 
     _exp2 = np.array([-4.9709163, -1.5536911, -3.268889, -3.2696986, -2.0843806])
     assert np.all(delta.eta[:5, 62] == pytest.approx(_exp2))
+    delta.finalize()
 
 
 def test_limit_inds_error_inlet_size_fixed_bug_example_1(tmp_path):
@@ -104,6 +105,7 @@ def test_limit_inds_error_inlet_size_fixed_bug_example_1(tmp_path):
 
     _exp = np.array([-4.9988008, -4.7794013, -4.5300136, -4.4977293, -4.56228])
     assert np.all(delta.eta[:5, 30] == pytest.approx(_exp))
+    delta.finalize()
 
 
 def test_limit_inds_error_inlet_size_fixed_bug_example_2(tmp_path):
@@ -140,6 +142,7 @@ def test_limit_inds_error_inlet_size_fixed_bug_example_2(tmp_path):
 
     _exp = np.array([-4.9975486, -4.9140935, -5.15276, -5.3690896, -5.1903167])
     assert np.all(delta.eta[:5, 30] == pytest.approx(_exp))
+    delta.finalize()
 
 
 def test_limit_inds_error_fixed_bug_example_3(tmp_path):
@@ -177,6 +180,7 @@ def test_limit_inds_error_fixed_bug_example_3(tmp_path):
 
     _exp = np.array([-4.99961, -4.605685, -3.8314152, -4.9007816, -5.])
     assert np.all(delta.eta[:5, 2] == pytest.approx(_exp))
+    delta.finalize()
 
 
 def test_model_similarity(tmp_path):

--- a/tests/test_consistent.py
+++ b/tests/test_consistent.py
@@ -248,7 +248,7 @@ def test_simple_checkpoint(tmp_path):
 
     for _ in range(0, 3):
         longModel.update()
-    longModel.output_netcdf.close()
+    longModel.finalize()
 
     # try defining a new model but plan to load checkpoint from longModel
     file_name = 'base_run.yaml'
@@ -274,7 +274,7 @@ def test_simple_checkpoint(tmp_path):
 
     # advance it one step to catch up to longModel
     resumeModel.update()
-    resumeModel.output_netcdf.close()
+    resumeModel.finalize()
 
     # the longModel and resumeModel should match
     assert longModel.time == resumeModel.time
@@ -312,7 +312,7 @@ def test_simple_checkpoint(tmp_path):
 
     # advance it one step to catch up to resumeModel
     resumeModel2.update()
-    resumeModel2.output_netcdf.close()
+    resumeModel2.finalize()
 
     # the two models that resumed from the checkpoint should be the same
     assert resumeModel2.time == resumeModel.time
@@ -352,7 +352,7 @@ def test_longer_checkpoint(tmp_path):
 
     for _ in range(0, 7):
         longModel.update()
-    longModel.output_netcdf.close()
+    longModel.finalize()
 
     # try defining a new model but plan to load checkpoint from longModel
     file_name = 'base_run.yaml'
@@ -379,7 +379,7 @@ def test_longer_checkpoint(tmp_path):
     # advance it three steps to catch up to longModel
     for _ in range(0, 3):
         resumeModel.update()
-    resumeModel.output_netcdf.close()
+    resumeModel.finalize()
 
     # the longModel and resumeModel should match
     assert longModel.time == resumeModel.time
@@ -423,7 +423,7 @@ def test_checkpoint_nc(tmp_path):
 
     for _ in range(0, 4):
         baseModel.update()
-    baseModel.output_netcdf.close()
+    baseModel.finalize()
 
     # try defining a new model but plan to load checkpoint from baseModel
     file_name = 'base_run.yaml'
@@ -453,7 +453,7 @@ def test_checkpoint_nc(tmp_path):
     # advance it six steps
     for _ in range(0, 6):
         resumeModel.update()
-    resumeModel.output_netcdf.close()
+    resumeModel.finalize()
 
     # assert that ouput netCDF4 exists
     exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1334,7 +1334,8 @@ def test_subsidence_bounds(tmp_path):
     utilities.write_parameter_to_file(f, 'theta1', -np.pi / 2)
     utilities.write_parameter_to_file(f, 'theta1', 0)
     f.close()
-    delta = DeltaModel(input_file=p)
+    with pytest.warns(UserWarning):
+        delta = DeltaModel(input_file=p)
     # assert subsidence mask is binary
     assert np.all(delta.subsidence_mask == delta.subsidence_mask.astype(bool))
     # check specific regions

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1395,3 +1395,34 @@ class TestScaleRelativeSeaLeveLRiseRate():
     def test_scale_If_0p1(self):
         scaled = preprocessor.scale_relative_sea_level_rise_rate(5, If=0.1)
         assert scaled == 5 / 1000 / 365.25 / 86400 * 10
+
+
+def test_load_nocheckpoint(tmp_path):
+    """Try loading a checkpoint file when one doesn't exist."""
+    # define a yaml
+    file_name = 'trial_run.yaml'
+    base_p, base_f = utilities.create_temporary_file(tmp_path, file_name)
+    utilities.write_parameter_to_file(base_f, 'Length', 10.0)
+    utilities.write_parameter_to_file(base_f, 'Width', 10.0)
+    utilities.write_parameter_to_file(base_f, 'seed', 0)
+    utilities.write_parameter_to_file(base_f, 'dx', 1.0)
+    utilities.write_parameter_to_file(base_f, 'L0_meters', 1.0)
+    utilities.write_parameter_to_file(base_f, 'Np_water', 10)
+    utilities.write_parameter_to_file(base_f, 'u0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'N0_meters', 2.0)
+    utilities.write_parameter_to_file(base_f, 'h0', 1.0)
+    utilities.write_parameter_to_file(base_f, 'SLR', 0.001)
+    utilities.write_parameter_to_file(base_f, 'Np_sed', 10)
+    utilities.write_parameter_to_file(base_f, 'save_dt', 50)
+    utilities.write_parameter_to_file(base_f, 'save_strata', True)
+    utilities.write_parameter_to_file(base_f, 'save_eta_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_depth_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_discharge_grids', True)
+    utilities.write_parameter_to_file(base_f, 'save_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'resume_checkpoint', True)
+    utilities.write_parameter_to_file(base_f, 'out_dir', tmp_path / 'test')
+    base_f.close()
+
+    # try loading the model yaml despite no checkpoint existing
+    with pytest.raises(FileNotFoundError):
+        _ = DeltaModel(input_file=base_p)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1155,7 +1155,10 @@ def test_py_hlvl_parallel_float(tmp_path):
     #       *exactly* two jobs were run in parallel.
 
 
+@pytest.mark.skipif(platform.system() != 'Linux', reason='Parallel support \
+                    only on Linux OS.')
 def test_py_hlvl_parallel_checkpoint(tmp_path):
+    """Test checkpointing in parallel."""
     file_name = 'user_parameters.yaml'
     p, f = utilities.create_temporary_file(tmp_path, file_name)
     utilities.write_parameter_to_file(f, 'verbose', 2)
@@ -1179,20 +1182,15 @@ def test_py_hlvl_parallel_checkpoint(tmp_path):
     assert len(pp.file_list) == 2
     assert pp._is_completed is False
     # assertions after running jobs
-    if platform.system() == 'Linux':
-        pp.run_jobs()
-        assert isinstance(pp.job_list[0], preprocessor._ParallelJob)
-        assert pp._is_completed is True
-        exp_path_nc0 = os.path.join(
-            tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
-        exp_path_nc1 = os.path.join(
-            tmp_path / 'test', 'job_001', 'pyDeltaRCM_output.nc')
-        assert os.path.isfile(exp_path_nc0)
-        assert os.path.isfile(exp_path_nc1)
-    else:
-        with pytest.raises(NotImplementedError,
-                           match=r'Parallel simulations *.'):
-            pp.run_jobs()
+    pp.run_jobs()
+    assert isinstance(pp.job_list[0], preprocessor._ParallelJob)
+    assert pp._is_completed is True
+    exp_path_nc0 = os.path.join(
+        tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+    exp_path_nc1 = os.path.join(
+        tmp_path / 'test', 'job_001', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc0)
+    assert os.path.isfile(exp_path_nc1)
     # check that checkpoint files exist
     exp_path_ckpt0 = os.path.join(
         tmp_path / 'test', 'job_000', 'checkpoint.npz')
@@ -1232,20 +1230,15 @@ def test_py_hlvl_parallel_checkpoint(tmp_path):
     assert len(pp.file_list) == 2
     assert pp._is_completed is False
     # assertions after running jobs
-    if platform.system() == 'Linux':
-        pp.run_jobs()
-        assert isinstance(pp.job_list[0], preprocessor._ParallelJob)
-        assert pp._is_completed is True
-        exp_path_nc0 = os.path.join(
-            tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
-        exp_path_nc1 = os.path.join(
-            tmp_path / 'test', 'job_001', 'pyDeltaRCM_output.nc')
-        assert os.path.isfile(exp_path_nc0)
-        assert os.path.isfile(exp_path_nc1)
-    else:
-        with pytest.raises(NotImplementedError,
-                           match=r'Parallel simulations *.'):
-            pp.run_jobs()
+    pp.run_jobs()
+    assert isinstance(pp.job_list[0], preprocessor._ParallelJob)
+    assert pp._is_completed is True
+    exp_path_nc0 = os.path.join(
+        tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+    exp_path_nc1 = os.path.join(
+        tmp_path / 'test', 'job_001', 'pyDeltaRCM_output.nc')
+    assert os.path.isfile(exp_path_nc0)
+    assert os.path.isfile(exp_path_nc1)
     # check that checkpoint files still exist
     exp_path_ckpt0 = os.path.join(
         tmp_path / 'test', 'job_000', 'checkpoint.npz')

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -34,7 +34,8 @@ def test_subsidence_in_update(tmp_path):
                                   'sigma_max': 1e-8,
                                   'start_subsidence': 0,
                                   'seed': 0})
-    _delta = DeltaModel(input_file=p)
+    with pytest.warns(UserWarning):
+        _delta = DeltaModel(input_file=p)
     assert _delta.dt == 20000
     assert _delta.sigma_max == 1e-8
     assert _delta.sigma[17, 5] == 0.0  # outside the sigma mask
@@ -52,7 +53,8 @@ def test_subsidence_in_update_delayed_start(tmp_path):
                                   'sigma_max': 1e-8,
                                   'start_subsidence': 20000,
                                   'seed': 0})
-    _delta = DeltaModel(input_file=p)
+    with pytest.warns(UserWarning):
+        _delta = DeltaModel(input_file=p)
     assert _delta.dt == 20000
     assert _delta.sigma_max == 1e-8
     assert _delta.sigma[17, 5] == 0.0  # outside the sigma mask
@@ -73,7 +75,8 @@ def test_subsidence_changed_with_timestep(tmp_path):
     p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                  {'toggle_subsidence': True,
                                   'sigma_max': 1e-8})
-    _delta = DeltaModel(input_file=p)
+    with pytest.warns(UserWarning):
+        _delta = DeltaModel(input_file=p)
     assert _delta.dt == 20000
     assert _delta.sigma[17, 6] == 0.0002
     _delta.time_step = 86400

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -255,6 +255,7 @@ def test_make_checkpoint(tmp_path, test_DeltaModel):
     test_DeltaModel.update()
     exp_path_npz = os.path.join(tmp_path / 'out_dir', 'checkpoint.npz')
     assert os.path.isfile(exp_path_npz)
+    test_DeltaModel.finalize()
     # check loading checkpoint and see if it works
     check_DeltaModel.load_checkpoint()
     assert check_DeltaModel._time == test_DeltaModel._time


### PR DESCRIPTION
Fixes the issue with use of the checkpointing functionality when multiple `finalize()` calls are made (#101). Core part of the issue was that when `finalize()` is called, the function `output_strata()` is used which tries to define new dimensions and variables - NetCDF does not let you just over-write data like this. 

To resolve the issue, the old netCDF file is renamed, and then all of its contents are copied into a new netCDF file excluding values that will be created by `output_strata()`, then the old netCDF file is deleted. In this way, `finalize()` can be called and the associated variables can be created at that time without any issues. I don't think this method of copying netCDF variables from one file to another loads them into memory, so this isn't expected to cause RAM issues or be overly slow/cumbersome.

Besides that the PR is mostly unit tests to ensure checkpointing works as intended. Some of the unit tests on windows seem to be failing randomly now? These are not tests (nor functionality) that was modified by this PR, and the failures seem to be related to accessibility of netCDF4 output files... so that is a bit of a mystery, maybe every test should call `finalize()` at the end to close the associated output file? 

---

*To do:*

- [x] add unit test where `checkpoint_dt` does not align with `save_dt` or `dt`
- [x] add unit test where model is run, checkpoint, and finalized - resumed, multiple times
- [x] add test for parallel functionality + checkpointing
- [x] add test for case where yaml has `resume_checkpoint: True` but no checkpoint exists

---

Closes #101.