### PR TITLE
Np warning, #131

### DIFF
--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -585,7 +585,9 @@ class iteration_tools(abc.ABC):
         # advance _time_iter since this is before update step fully finishes
         _time_iter = self._time_iter + int(1)
         # get rng state
-        rng_state = shared_tools.get_random_state()
+        rng_state_list = shared_tools.get_random_state()
+        rng_state = np.array(rng_state_list,
+                             dtype=object)  # convert to object before saving
 
         np.savez_compressed(ckp_file, time=self.time, H_SL=self._H_SL,
                             time_iter=_time_iter,


### PR DESCRIPTION
Fix warning raised on checkpointing (#131). 

Problem was the saving of the random state. During the npz saving in the checkpoint, the arguments were converted to numpy objects. 

The random state is a tuple by default, so the conversion to array raised a warning about asserting the type of the array being created. So, we just needed to explicitly convert before saving.

Added a test to verify the issue before finding the fix, and have included this (now passing) test. I'm not sure the test is really helpful, but I added it anyway.