### PR TITLE
Feat dictyaml

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -921,10 +921,10 @@ def scale_relative_sea_level_rise_rate(mmyr, If=1):
 
     .. math::
 
-        \widehat{RSLR} = (RSLR / 1000) \cdot \dfrac{1}{I_f \cdot 365.25 \cdot 86400}
+        \\widehat{RSLR} = (RSLR / 1000) \\cdot \\dfrac{1}{I_f \\cdot 365.25 \\cdot 86400}
 
     This conversion makes it such that when one real-world year has elapsed
-    (:math:`I_f \cdot 365.25 \cdot 86400` seconds in model time), the relative
+    (:math:`I_f \\cdot 365.25 \\cdot 86400` seconds in model time), the relative
     sea level has changed by the number of millimeters specified in the input
     :obj:`mmyr`.
 


### PR DESCRIPTION
Add the ability to pass a _dict_ as an input to the `preprocessor`, rather than the path to a file. This allows for additional preconfiguration of model runs for custom experiments. For example, if I wanted to build a 10 m stack of stratigraphy from simulations with different sea level rises:

First, set up a yaml with the basic configurations I want to use. This is just for readability.

```yaml
out_dir: '/scratch/ordinariness_large'
Length: 24000.
Width: 48000.
dx: 200
N0_meters: 2000
f_bedload: 0.5
h0: 3
u0: 1.0
seed: 111
parallel: True
```

Then, with a  python script, set up the runs and execute

```python
import numpy as np
import yaml

import pyDeltaRCM
from pyDeltaRCM.shared_tools import day_in_yr


if __name__ == '__main__':

    #################################
    # parameter choices for scaling
    #################################
    If = 7 / day_in_yr  # intermittency factor for year-scaling
    SLR_mmyr = np.array([1, 2, 5, 10])  # the matrix I want to run
    SLR = pyDeltaRCM.preprocessor.scale_relative_sea_level_rise_rate(
        SLR_mmyr, If)
    deposit = 10  # thickness of deposit, meters

    #################################
    # configure a dictionary as input
    #################################
    input_file = 'slr_stacks.yaml'
    _file = open(input_file, mode='r')
    param_dict = yaml.load(_file, Loader=yaml.FullLoader)
    _file.close()

    # add a matrix with SLR to the dict
    param_dict['matrix'] = {'SLR': SLR}

    # let the preprocessor write the initial matrix (i.e., expand the SLR)
    pp = pyDeltaRCM.Preprocessor(param_dict)

    # supplement each file with the computed job end time
    whch_SLR = [hdr.strip() == 'SLR' for hdr in pp.matrix_table_header.split(',')]
    for j, j_file in enumerate(pp.file_list):
        job_SLR = pp.matrix_table[j, whch_SLR]
        endtime = float(deposit) / float(job_SLR)

        f = open(j_file, 'a+')
        f.write('time: ' + str(endtime))
        f.close()

    #################################
    # run the jobs
    #################################
    pp.run_jobs()
```

There may be cleaner ways to do this custom configuration, and maybe some options we want to support directly, but adding the ability to configure from a dict really allows anything. Eventually I'd like to add a section of examples to the documentation, so I'm creating a label for keeping track of things I'd like to add, called "use case example".