### PR TITLE
Keywords params

### DIFF
--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -162,6 +162,16 @@ The simplest case to use the low-level API is to do
     >>> delta.finalize()
 
 However, you can also inspect/modify the :obj:`~pyDeltaRCM.DeltaModel.update` method, and change the order of operations, or add operations, as desired.
+If you are working with the low-level API, you can optionally pass any valid key in the YAML configuration file as a keyword argument during model instantiation. 
+For example:
+
+.. code::
+
+    >>> delta = DeltaModel(input_file='model_configuration.yml',
+    ...                    SLR=1e-9)
+
+
+Keyword arguments supplied at this point will supersede values specified in the YAML configuration.
 
 
 =============================

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -60,7 +60,12 @@ class init_tools(abc.ABC):
         _msg = 'Output log file initialized.'
         self.log_info(_msg, verbosity=0)
 
-    def import_files(self):
+    def import_files(self, kwargs_dict):
+        """Import the input files.
+
+        This method handles the parsing and validation of any options supplied
+        via the configuration.
+        """
 
         # This dictionary serves as a container to hold values for both the
         # user-specified file and the internal defaults.
@@ -90,6 +95,15 @@ class init_tools(abc.ABC):
                 raise e
         else:
             user_dict = dict()
+
+        # replace values in the user yaml file with anything specifed in the
+        #   **kwargs input
+        for kwk, kwv in kwargs_dict.items():
+            if kwk in user_dict.keys():
+                warnings.warn(UserWarning(
+                    'A keyword specification was also found in the '
+                    'user specified input YAML file: %s' % kwk))
+            user_dict[kwk] = kwv
 
         # go through and populate input vars with user and default values,
         # checking user values for correct type.

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -60,11 +60,24 @@ class init_tools(abc.ABC):
         _msg = 'Output log file initialized.'
         self.log_info(_msg, verbosity=0)
 
-    def import_files(self, kwargs_dict):
+    def import_files(self, kwargs_dict={}):
         """Import the input files.
 
         This method handles the parsing and validation of any options supplied
         via the configuration.
+
+        Parameters
+        ----------
+        kwargs_dict :obj:`dict`, optional
+
+            A dictionary with keys matching valid model parameter names that
+            can be specified in a configuration YAML file. Keys given in this
+            dictionary will supercede values specified in the YAML
+            configuration.
+
+        Returns
+        -------
+
         """
 
         # This dictionary serves as a container to hold values for both the

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -32,7 +32,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     closed and written to disk.
     """
 
-    def __init__(self, input_file=None, defer_output=False):
+    def __init__(self, input_file=None, defer_output=False, **kwargs):
         """Creates an instance of the pyDeltaRCM model.
 
         This method handles setting up the run, including parsing input files,

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -53,6 +53,14 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             :obj:`init_output_file`, :obj:`output_data`, and
             :obj:`output_checkpoint` method if `defer_output` is `True`.
 
+        **kwargs
+            Optionally, any parameter typically specified in the YAML file can
+            be passed as a keyword argument to the instantiation of the
+            DeltaModel. Keywords will override the specification of any value
+            in the YAML file. This functionality is intended for advanced use
+            cases, and should not be preffered to specifying all inputs in a
+            YAML configuration file.
+
         Returns
         -------
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -79,7 +79,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self.input_file = input_file
         _src_dir = os.path.realpath(os.path.dirname(__file__))
         self.default_file = os.path.join(_src_dir, 'default.yml')
-        self.import_files()
+        self.import_files(kwargs)
 
         self.init_output_infrastructure()
         self.init_logger()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -48,6 +48,30 @@ class Test__init__:
         assert delta.S0 == 0.005
         assert delta.Np_sed == 2
 
+    def test_override_single_default_kwarg(self, tmp_path):
+        _out_dir = str(tmp_path / 'out_dir')
+        delta = DeltaModel(out_dir=_out_dir, S0=0.005)
+        assert delta.S0 == 0.005
+
+    def test_override_two_defaults_kwargs(self, tmp_path):
+        _out_dir = str(tmp_path / 'out_dir')
+        delta = DeltaModel(
+            out_dir=_out_dir,
+            S0=0.005,
+            Np_sed=2)
+        assert delta.S0 == 0.005
+        assert delta.Np_sed == 2
+
+    def test_override_yaml_with_kwarg(self, tmp_path):
+        file_name = 'user_parameters.yaml'
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+        utilities.write_parameter_to_file(f, 'S0', 0.005)
+        f.close()
+        with pytest.warns(UserWarning):
+            delta = DeltaModel(input_file=p, S0=0.0333)
+        assert delta.S0 == 0.0333
+
     def test_override_bad_type_float_string(self, tmp_path):
         file_name = 'user_parameters.yaml'
         p, f = utilities.create_temporary_file(tmp_path, file_name)


### PR DESCRIPTION
Add support to specify any YAML parameter as a keyword during DeltaModel instantion.

This is helpful for advanced model configurations. Not intended for every-day use. The following is included in the DeltaModel docstring.

```
        **kwargs
            Optionally, any parameter typically specified in the YAML file can
            be passed as a keyword argument to the instantiation of the
            DeltaModel. Keywords will override the specification of any value
            in the YAML file. This functionality is intended for advanced use
            cases, and should not be preffered to specifying all inputs in a
            YAML configuration file.
``` 