### PR TITLE
Decouple checkpointing from the netcdf file

### DIFF
--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -93,15 +93,15 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self.init_sediment_routers()
         self.init_subsidence()
 
+        # initialize the stratigraphy infrastructure
+        self.init_stratigraphy()
+
         # if resume flag set to True, load checkpoint, open netCDF4
         if self.resume_checkpoint:
             # load values from the checkpoint and don't init final features
             self.load_checkpoint()
 
         else:
-            # initialize the stratigraphy infrastructure
-            self.init_stratigraphy()
-
             # initialize the output file
             if not defer_output:
                 self.init_output_file()

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -424,3 +424,111 @@ class TestCheckpointingIntegrations:
         assert out_fin['time'][-1].tolist() == expected_last_save_time * 2
         # close netcdf file
         out_fin.close()
+
+
+class TestCheckpointingCreatingLoading:
+
+    def test_load_checkpoint_with_netcdf(self, tmp_path):
+        """Test that a run can be resumed when there are outputs.
+        """
+        # define a yaml with outputs (defaults will output strata)
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True})
+        _delta = DeltaModel(input_file=p)
+
+        # replace eta with a random field for checkpointing success check
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+
+        _delta._save_time_since_checkpoint = float("inf")
+        _delta.output_checkpoint()  # force another checkpoint
+        _delta.finalize()
+
+        # paths exists
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+        _delta = []  # clear
+
+        # can be resumed
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'resume_checkpoint': True})
+        _delta = DeltaModel(input_file=p)
+
+        # check that fields match
+        assert np.all(_delta.eta == _rand_field)
+
+    def test_create_checkpoint_without_netcdf(self, tmp_path):
+        """Test that a checkpoint can be created when there are no outputs
+        """
+        # define a yaml with NO outputs, but checkpoint
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'save_strata': False})
+
+        _delta = DeltaModel(input_file=p)
+
+        # replace eta with a random field for checkpointing success check
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+
+        _delta._save_time_since_checkpoint = float("inf")
+        _delta.output_checkpoint()  # force another checkpoint
+        _delta.finalize()
+
+        # should be no file
+        assert not os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+
+        # can be resumed
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'resume_checkpoint': True,
+                                      'save_strata': False})
+        _delta = DeltaModel(input_file=p)
+
+        # check that fields match
+        assert np.all(_delta.eta == _rand_field)
+
+    def test_load_checkpoint_without_netcdf(self, tmp_path):
+        """Test that a run can be resumed when there are outputs.
+        """
+        # define a yaml with NO outputs, but checkpoint
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'save_strata': True})
+        _delta = DeltaModel(input_file=p)
+
+        # replace eta with a random field for checkpointing success check
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+
+        _delta._save_time_since_checkpoint = float("inf")
+        _delta.output_checkpoint()  # force another checkpoint
+        _delta.finalize()
+
+        # check that files exist, and then delete nc
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+        os.remove(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+
+        # now try to resume, will WARN on not finding netcdf
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'resume_checkpoint': True})
+        with pytest.warns(UserWarning, match=r'NetCDF4 output *.'):
+            _delta = DeltaModel(input_file=p)
+
+        # assert that a new output file exists file exists
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+
+        # check that fields match
+        assert np.all(_delta.eta == _rand_field)

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -1,8 +1,10 @@
 # unit tests for init_tools.py
 
 import pytest
+import unittest.mock as mock
 
 import numpy as np
+import os
 
 from pyDeltaRCM.model import DeltaModel
 
@@ -182,6 +184,182 @@ class TestInitSubsidence:
         # check specific regions
         assert np.all(delta.subsidence_mask[75:, 60:] == 1)
         assert np.all(delta.subsidence_mask[:, :55] == 0)
+
+
+class TestLoadCheckpoint:
+
+    @mock.patch('pyDeltaRCM.shared_tools.set_random_state')
+    def test_load_standard_strata(self, patched, tmp_path):
+        """Test that a run can be resumed when there are outputs.
+        """
+        # create one delta, just to have a checkpoint file
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True})
+        _delta = DeltaModel(input_file=p)
+
+        # make mocks
+        _delta.log_info = mock.MagicMock()
+        _delta.logger = mock.MagicMock()
+        _delta.init_output_file = mock.MagicMock()
+
+        # check checkpoint exists
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert hasattr(_delta, 'strata_counter')
+
+        # now mess up a field
+        _eta0 = np.copy(_delta.eta)
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+        assert np.all(_delta.eta == _rand_field)
+
+        # now resume from the checkpoint to restore the field
+        _delta.load_checkpoint()
+
+        # check that fields match
+        assert np.all(_delta.eta == _eta0)
+        assert hasattr(_delta, 'strata_counter')
+
+        # assertions on function calls
+        _strat_call = [mock.call('Loading stratigraphy arrays', verbosity=2)]
+        _delta.log_info.assert_has_calls(_strat_call, any_order=True)
+        _delta.logger.assert_not_called()
+        _delta.init_output_file.assert_not_called()
+        patched.assert_called()
+
+    @mock.patch('pyDeltaRCM.shared_tools.set_random_state')
+    def test_load_standard_grid_nostrata(self, patched, tmp_path):
+        """Test that a run can be resumed when there are outputs.
+        """
+        # create one delta, just to have a checkpoint file
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'save_strata': False,
+                                      'save_eta_grids': True})
+        _delta = DeltaModel(input_file=p)
+
+        # make mocks
+        _delta.log_info = mock.MagicMock()
+        _delta.logger = mock.MagicMock()
+        _delta.init_output_file = mock.MagicMock()
+
+        # check checkpoint exists
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert not hasattr(_delta, 'strata_counter')
+
+        # now mess up a field
+        _eta0 = np.copy(_delta.eta)
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+        assert np.all(_delta.eta == _rand_field)
+
+        # now resume from the checkpoint to restore the field
+        _delta.load_checkpoint()
+
+        # check that fields match
+        assert np.all(_delta.eta == _eta0)
+        assert not hasattr(_delta, 'strata_counter')
+
+        # assertions on function calls
+        _call = [mock.call('Renaming old NetCDF4 output file', verbosity=2)]
+        _delta.log_info.assert_has_calls(_call, any_order=True)
+        _delta.logger.assert_not_called()
+        _delta.init_output_file.assert_not_called()
+        patched.assert_called()
+
+    @mock.patch('pyDeltaRCM.shared_tools.set_random_state')
+    def test_load_wo_netcdf_not_expected(self, patched, tmp_path):
+        """
+        Test that a checkpoint can be loaded when the load does not expect
+        there to be any netcdf file.
+        """
+        # create one delta, just to have a checkpoint file
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'save_strata': False})
+        _delta = DeltaModel(input_file=p)
+
+        # make mocks
+        _delta.log_info = mock.MagicMock()
+        _delta.logger = mock.MagicMock()
+        _delta.init_output_file = mock.MagicMock()
+
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+        assert not os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert not hasattr(_delta, 'strata_counter')
+
+        # now mess up a field
+        _eta0 = np.copy(_delta.eta)
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+        assert np.all(_delta.eta == _rand_field)
+
+        # now resume from the checkpoint to restore the field
+        _delta.load_checkpoint()
+
+        # check that fields match
+        assert np.all(_delta.eta == _eta0)
+        assert not hasattr(_delta, 'strata_counter')
+
+        # assertions on function calls
+        _delta.log_info.assert_called()
+        _delta.logger.assert_not_called()
+        _delta.init_output_file.assert_not_called()
+        patched.assert_called()
+
+    @mock.patch('pyDeltaRCM.shared_tools.set_random_state')
+    def test_load_wo_netcdf_expected(self, patched, tmp_path):
+        """
+        Test that a checkpoint can be loaded when the load expects there to be
+        a netcdf file. This will create a new netcdf file and raise a
+        warning.
+        """
+        # define a yaml with NO outputs, but checkpoint
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_checkpoint': True,
+                                      'save_strata': False,
+                                      'save_eta_grids': True})
+        _delta = DeltaModel(input_file=p)
+
+        # make mocks
+        _delta.log_info = mock.MagicMock()
+        _delta.logger = mock.MagicMock()
+        _delta.init_output_file = mock.MagicMock()
+
+        # check that files exist, and then delete nc
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+        assert os.path.isfile(os.path.join(
+            _delta.prefix, 'checkpoint.npz'))
+        os.remove(os.path.join(
+            _delta.prefix, 'pyDeltaRCM_output.nc'))
+
+        # now mess up a field
+        _eta0 = np.copy(_delta.eta)
+        _rand_field = np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.eta = _rand_field
+        assert np.all(_delta.eta == _rand_field)
+
+        # now resume from the checkpoint to restore the field
+        with pytest.warns(UserWarning, match=r'NetCDF4 output *.'):
+            _delta.load_checkpoint()
+
+        # check that fields match
+        assert np.all(_delta.eta == _eta0)
+        assert not hasattr(_delta, 'strata_counter')
+
+        # assertions on function calls
+        _delta.log_info.assert_called()
+        _delta.logger.warning.assert_called()
+        _delta.init_output_file.assert_called()
+        patched.assert_called()
 
 
 class TestSettingConstants:

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -202,6 +202,9 @@ class TestLoadCheckpoint:
         _delta.logger = mock.MagicMock()
         _delta.init_output_file = mock.MagicMock()
 
+        # close the file so can be safely opened in load
+        _delta.output_netcdf.close()
+
         # check checkpoint exists
         assert os.path.isfile(os.path.join(
             _delta.prefix, 'checkpoint.npz'))
@@ -244,6 +247,9 @@ class TestLoadCheckpoint:
         _delta.log_info = mock.MagicMock()
         _delta.logger = mock.MagicMock()
         _delta.init_output_file = mock.MagicMock()
+
+        # close the file so can be safely opened in load
+        _delta.output_netcdf.close()
 
         # check checkpoint exists
         assert os.path.isfile(os.path.join(
@@ -332,6 +338,9 @@ class TestLoadCheckpoint:
         _delta.log_info = mock.MagicMock()
         _delta.logger = mock.MagicMock()
         _delta.init_output_file = mock.MagicMock()
+
+        # close the file so can be safely opened in load
+        _delta.output_netcdf.close()
 
         # check that files exist, and then delete nc
         assert os.path.isfile(os.path.join(

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -13,12 +13,9 @@ from pyDeltaRCM import shared_tools
 
 def create_temporary_file(tmp_path, file_name):
     d = tmp_path / 'configs'
-    try:
-        d.mkdir()
-    except Exception:
-        pass
+    d.mkdir(parents=True, exist_ok=True)
     p = d / file_name
-    f = open(p, "a")
+    f = open(p, "w")
     return p, f
 
 


### PR DESCRIPTION
This pull request adds a few different pathways to the saving/loading of checkpointing, to address issues raised in #146.

Now, pathways exist in saving and loading that allow for a full range of configurations to use checkpointing. For example, previosuly runs that did not have 1) strata or 2) any netcdf file would fail. Now, runs with one, either, or neither are able possible. There is also the ability to resume from a checkpoint file without the associated netcdf file also being present. In this scenario, a new output netcdf file is created.

Tests added.