### PR TITLE
Add a high-level input type "set" and refactor preprocessor

### DIFF
--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -100,7 +100,7 @@ The duration of a model run configured with the high-level API can be set up wit
 Using the high-level API, you can specify the duration to run the model by two mechanisms: 1) the number of timesteps to run the model, or 2) the duration of time to run the model.
 
 The former case is straightforward, insofar that the model determines the timestep duration and the high-level API simply iterates for the specified number of timestep iterations.
-To specify the number of timesteps to run the model, use the argument ``--timesteps`` at the command line (or ``timesteps:`` in the configuration YAML file).
+To specify the number of timesteps to run the model, use the argument ``--timesteps`` at the command line (or ``timesteps:`` in the configuration YAML file, or ``timesteps=`` with the Python :obj:`~pyDeltaRCM.Preprocessor`).
 
 .. code:: bash
     
@@ -111,8 +111,8 @@ In this case, the model run end condition is that the elapsed model time is *equ
 Importantly, this means that the duration of the model run is unlikely to exactly match the input condition, because the model timestep is unlikely to be a factor of the specified time.
 Again, refer to the complete description of model time :doc:`../info/modeltime` for more information.
 
-To specify the duration of time to run the model in *seconds*, simply use the argument ``--time`` at the command line (or ``time:`` in the configuration YAML file).
-It is also possible to specify the input run duration in units of years with the similarly named argument ``--time_years`` (``time_years:``).
+To specify the duration of time to run the model in *seconds*, simply use the argument ``--time`` at the command line (or ``time:`` in the configuration YAML file, or ``time=`` with the Python :obj:`~pyDeltaRCM.Preprocessor`).
+It is also possible to specify the input run duration in units of years with the similarly named argument ``--time_years`` (``time_years:``, ``time_years=``).
 
 .. code:: bash
     
@@ -126,7 +126,7 @@ would each run a simulation for :math:`(86400 * 365.25)` seconds, or 1 year.
     Do not specify both time arguments, or specify time arguments with the timesteps argument.
     In the case of multiple argument specification, precedence is given in the order `timesteps` > `time` > `time_years`.
 
-When specifying the time to run the simulation, an additional parameter determining the intermittency factor (:math:`I_f`) may be specified ``--If`` at the command line (or ``If:`` in the YAML configuration file).
+When specifying the time to run the simulation, an additional parameter determining the intermittency factor (:math:`I_f`) may be specified ``--If`` at the command line (``If:`` in the YAML configuration file, ``If=`` with the Python :obj:`~pyDeltaRCM.Preprocessor`).
 This argument will scale the specified time-to-model-time, such that the *scaled time* is equal to the input argument time.
 Specifying the :math:`I_f`  value is essential when using the model duration run specifications.
 See :doc:`../info/modeltime` for complete information on the scaling between model time and elapsed simulation time.
@@ -135,7 +135,7 @@ Running simulations in parallel
 -------------------------------
 
 The high-level API provides the ability to run simulations in parallel on Linux environments. 
-This option is only useful in the case where you are running multiple jobs with the :ref:`matrix expansion <matrix_expansion_tag>` or :ref:`ensemble expansion <ensemble_expansion_tag>` tools.
+This option is only useful in the case where you are running multiple jobs with the :ref:`matrix expansion <matrix_expansion_tag>`, :ref:`ensemble expansion <ensemble_expansion_tag>`, or :ref:`set expansion <set_expansion_tag>` tools.
 
 To run jobs in parallel simply specify the `--parallel` flag to the command line interface.
 Optionally, you can specify the number of simulations to run at once by following the flag with a number.
@@ -267,5 +267,25 @@ The ensemble expansion can be applied to configuration files that include a matr
 
 The above configuration file would produce 6 model runs, 3 with a basin depth (`h0`) of 1.0, and 3 with a basin depth of 2.0.
 
+.. _set_expansion_tag:
+
+Set expansion
+-------------
+
+Set expansion enables user-configured parameter sets to take advantage of the :obj:`~pyDeltaRCM.Preprocessor` infrastructure (such as the job output preparation and ability to run jobs in parallel), while also enabling flexible configurations for parameter sets than cannot be configured via `matrix` expansion.
+For example, to vary `Qw0` while holding `Qs0` fixed requires modifying both `C0_percent` and some water-discharge-controlling parameter *simultaneously*; i.e., this cannot be achieved with `matrix` expansion. 
+
+To use set expansion, add the `set` key to a configuration file, and define a *list* of *dictionaries* which set the parameters of each run to be completed.
+For example, to configure two model runs, the first with parameters ``u0: 1.0`` and ``h0: 1.0``, and the second with parameters ``u0: 1.2`` and ``h0: 1.2``:
+
+.. code:: yaml
+
+    set:
+      - {u0: 1.0, h0: 1.0}
+      - {u0: 1.2., h0: 1.2}
+
+
+All jobs in the `set` specification must have the exact same set of keys.
+Moreover, additional `ensemble` or `matrix` specifications are not supported with the `set` specification. 
 
 .. include:: subsidenceguide.rst

--- a/docs/source/reference/preprocessor/index.rst
+++ b/docs/source/reference/preprocessor/index.rst
@@ -24,5 +24,5 @@ Preprocessor function and utilities
 -----------------------------------
 
 .. autofunction:: preprocessor_wrapper
-.. autofunction:: write_yaml_config_to_file
 .. autofunction:: scale_relative_sea_level_rise_rate
+.. autofunction:: _write_yaml_config_to_file

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -68,7 +68,7 @@ class init_tools(abc.ABC):
 
         Parameters
         ----------
-        kwargs_dict :obj:`dict`, optional
+        kwargs_dict : :obj:`dict`, optional
 
             A dictionary with keys matching valid model parameter names that
             can be specified in a configuration YAML file. Keys given in this
@@ -77,9 +77,7 @@ class init_tools(abc.ABC):
 
         Returns
         -------
-
         """
-
         # This dictionary serves as a container to hold values for both the
         # user-specified file and the internal defaults.
         input_file_vars = dict()

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -285,20 +285,29 @@ class BasePreprocessor(abc.ABC):
 
         # determine the set
         _set = self.config_dict.pop('set')
-        jobs = len(_set)
-        dims = len(_set[0])
 
         # check that all sets are dictionaries
+        if not isinstance(_set, list):
+            raise TypeError(
+                'Set list must be type `list` but was {}.'.format(type(_set)))
         for i, d in enumerate(_set):  # check validity of keys, depth == 1
             if not isinstance(d, dict):
                 raise TypeError(
                     'Set must specify as a list of dictionaries')
+            for k in d.keys():  # check validity of keys, depth == 1
+                if ':' in k:
+                    raise ValueError(
+                        'Colon operator found in matrix expansion key.')
 
         # check that all sets have the same entries
         set0_set = set(_set[0].keys())
-        for s in range(1, jobs):
+        for s in range(1, len(_set)):
             if not (set0_set == set(_set[s].keys())):
                 raise ValueError('All keys in all sets must be identical.')
+
+        # extract dimensionality of set
+        jobs = len(_set)
+        dims = len(_set[0])
 
         if self.verbose > 0:
             print(('Set expansion:\n' +

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -662,6 +662,7 @@ class _BaseJob(abc.ABC):
             self._time_config = config_dict['timesteps']
 
             # compute the end time
+            print(config_dict['timesteps'])
             self._job_end_time = _curr_time + \
                 ((config_dict['timesteps'] * self.deltamodel._dt))
 
@@ -955,7 +956,21 @@ class PreprocessorCLI(BasePreprocessor):
         args = parser.parse_args()
         args_dict = vars(args)
 
-        # clean out the junk values in the dictionary
+        # convert arguments to valid types for preprocessor
+        if not (args_dict['timesteps'] is None):
+            args_dict['timesteps'] = int(args_dict['timesteps'])
+        else:
+            args_dict.pop('timesteps')
+        if not (args_dict['time'] is None):
+            args_dict['time'] = float(args_dict['time'])
+        else:
+            args_dict.pop('time')
+        if not (args_dict['time_years'] is None):
+            args_dict['time_years'] = float(args_dict['time_years'])
+        else:
+            args_dict.pop('time_years')
+
+        # set defaults as needed
         args_dict['parallel'] = args_dict['parallel'] or False
         args_dict['If'] = args_dict['If'] or 1.0
 

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -56,7 +56,7 @@ class BasePreprocessor(abc.ABC):
     def file_list(self):
         """File list.
 
-        A list of `Path`s to input YAML files for jobs constructed by the
+        A list of `Path` to input YAML files for jobs constructed by the
         preprocessor.
         """
         return self._file_list
@@ -65,7 +65,7 @@ class BasePreprocessor(abc.ABC):
     def config_list(self):
         """Configuration list.
 
-        A list of `dict`s containing the input configurations for jobs
+        A list of `dict` containing the input configurations for jobs
         constructed by the preprocessor.
         """
         return self._config_list

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,14 +1,6 @@
 
 import pytest
 
-import os
-# import shutil
-# import locale
-# import numpy as np
-# import subprocess
-import glob
-import netCDF4
-# import time
 import platform
 
 import unittest.mock as mock
@@ -37,10 +29,9 @@ class TestPreprocessorSingleJobSetups:
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.yaml_dict['timesteps'] == 50
-        assert not ('timesteps' in pp.cli_dict.keys())
-        assert not ('time' in pp.yaml_dict.keys())
-        assert not ('time' in pp.cli_dict.keys())
+        assert pp.config_dict['timesteps'] == 50
+        assert not ('time' in pp.config_dict.keys())
+        assert not ('time_years' in pp.config_dict.keys())
 
     def test_py_hlvl_time_yml_runjobs_sngle(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
@@ -50,10 +41,8 @@ class TestPreprocessorSingleJobSetups:
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.yaml_dict['time'] == 1000
-        assert not ('time' in pp.cli_dict.keys())
-        assert not ('timesteps' in pp.yaml_dict.keys())
-        assert not ('timesteps' in pp.cli_dict.keys())
+        assert pp.config_dict['time'] == 1000
+        assert not ('timesteps' in pp.config_dict.keys())
 
     def test_py_hlvl_time_If_yml_runjobs_sngle(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
@@ -64,9 +53,9 @@ class TestPreprocessorSingleJobSetups:
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.yaml_dict['time'] == 10000
-        assert pp.yaml_dict['If'] == 0.1
-        assert not ('time' in pp.cli_dict.keys())
+        assert pp.config_dict['time'] == 10000
+        assert pp.config_dict['If'] == 0.1
+        assert not ('timesteps' in pp.config_dict.keys())
 
     def test_py_hlvl_timeyears_yml_runjobs_sngle(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
@@ -76,10 +65,10 @@ class TestPreprocessorSingleJobSetups:
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.yaml_dict['time_years'] == pytest.approx(3.1688087e-05)
-        assert not ('If' in pp.yaml_dict.keys())
-        assert not ('time' in pp.yaml_dict.keys())
-        assert not ('time' in pp.cli_dict.keys())
+        assert pp.config_dict['time_years'] == pytest.approx(3.1688087e-05)
+        assert not ('If' in pp.config_dict.keys())
+        assert not ('time' in pp.config_dict.keys())
+        assert not ('timesteps' in pp.config_dict.keys())
 
     def test_py_hlvl_timeyears_If_yml_runjobs_sngle(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
@@ -90,14 +79,14 @@ class TestPreprocessorSingleJobSetups:
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.yaml_dict['time_years'] == pytest.approx(.00031688087814)
-        assert pp.yaml_dict['If'] == 0.1
-        assert not ('time' in pp.yaml_dict.keys())
-        assert not ('time' in pp.cli_dict.keys())
+        assert pp.config_dict['time_years'] == pytest.approx(.00031688087814)
+        assert pp.config_dict['If'] == 0.1
+        assert not ('time' in pp.config_dict.keys())
+        assert not ('timesteps' in pp.config_dict.keys())
 
     def test_py_hlvl_timesteps_and_yaml_argument(self, tmp_path):
         """
-        test calling the python hook command line feature with a config file.
+        Test that timesteps can come from cli, but others from yaml
         """
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_eta_figs': True})
@@ -107,9 +96,49 @@ class TestPreprocessorSingleJobSetups:
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.cli_dict['timesteps'] == 2
-        assert (pp.yaml_dict['save_eta_figs'] is True)
-        assert not ('timesteps' in pp.yaml_dict.keys())
+        assert pp.config_dict['timesteps'] == 2
+        assert (pp.config_dict['save_eta_figs'] is True)
+        assert not ('time' in pp.config_dict.keys())
+
+    def test_py_hlvl_timesteps_yaml_and_cli(self, tmp_path):
+        """
+        Test preference for command line argument
+        """
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_eta_figs': True,
+                                      'timesteps': 20})
+        pp = preprocessor.Preprocessor(input_file=p, timesteps=13)
+
+        assert type(pp.file_list) is list
+        assert len(pp.file_list) == 1
+        assert pp._is_completed is False
+
+        assert pp.config_dict['timesteps'] == 13
+        assert (pp.config_dict['save_eta_figs'] is True)
+        assert not ('time' in pp.config_dict.keys())
+
+    def test_py_hlvl_timesteps_and_time_yaml_and_cli(self, tmp_path):
+        """
+        Test that preference is given to command line arguments
+
+        note that time and timesteps both persist, precedence for these args
+        is determined at runtime of run_jobs()
+        """
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_eta_figs': True,
+                                      'timesteps': 20,
+                                      'time': 1000})
+        pp = preprocessor.Preprocessor(input_file=p, timesteps=13, time=13000)
+
+        assert type(pp.file_list) is list
+        assert len(pp.file_list) == 1
+        assert pp._is_completed is False
+
+        assert pp.config_dict['timesteps'] == 13
+        assert pp.config_dict['time'] == 13000
+        assert (pp.config_dict['save_eta_figs'] is True)
+        assert ('time' in pp.config_dict.keys())
+        assert ('timesteps' in pp.config_dict.keys())
 
 
 class TestPreprocessorMatrixJobsSetups:
@@ -129,12 +158,11 @@ class TestPreprocessorMatrixJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._is_completed is False
 
-        f_bedload_list = pp.matrix_table[:, 1]
+        f_bedload_list = pp._matrix_table[:, 1]
 
         assert sum([j == 0.2 for j in f_bedload_list]) == 1
         assert sum([j == 0.6 for j in f_bedload_list]) == 1
-        assert pp.cli_dict['timesteps'] == 3
-        assert not ('timesteps' in pp.yaml_dict.keys())
+        assert pp.config_dict['timesteps'] == 3
 
     def test_py_hlvl_mtrx_1list_tsteps_cfg(self, tmp_path):
         file_name = 'user_parameters.yaml'
@@ -152,12 +180,11 @@ class TestPreprocessorMatrixJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._is_completed is False
 
-        f_bedload_list = pp.matrix_table[:, 1]
+        f_bedload_list = pp._matrix_table[:, 1]
 
         assert sum([j == 0.2 for j in f_bedload_list]) == 1
         assert sum([j == 0.6 for j in f_bedload_list]) == 1
-        assert pp.yaml_dict['timesteps'] == 3
-        assert not ('timesteps' in pp.cli_dict.keys())
+        assert pp.config_dict['timesteps'] == 3
 
     def test_py_hlvl_mtrx_2list(self, tmp_path):
         file_name = 'user_parameters.yaml'
@@ -174,8 +201,8 @@ class TestPreprocessorMatrixJobsSetups:
         assert len(pp.file_list) == 9
         assert pp._is_completed is False
 
-        f_bedload_list = pp.matrix_table[:, 1]
-        u0_list = pp.matrix_table[:, 2]
+        f_bedload_list = pp._matrix_table[:, 1]
+        u0_list = pp._matrix_table[:, 2]
 
         assert sum([j == 0.2 for j in f_bedload_list]) == 3
         assert sum([j == 0.5 for j in f_bedload_list]) == 3
@@ -184,7 +211,7 @@ class TestPreprocessorMatrixJobsSetups:
         assert sum([j == 1.5 for j in u0_list]) == 3
         assert sum([j == 2.0 for j in u0_list]) == 3
 
-        comb_list = pp.matrix_table[:, 1:].tolist()
+        comb_list = pp._matrix_table[:, 1:].tolist()
         assert [0.2, 2.0] in comb_list
         assert [0.5, 1.0] in comb_list
         assert not ([0.5, 0.2] in comb_list)
@@ -202,7 +229,7 @@ class TestPreprocessorMatrixJobsSetups:
         # will convert everything to scientific notation
         pp = preprocessor.Preprocessor(input_file=p)
 
-        SLR_list = pp.matrix_table[:, 2]
+        SLR_list = pp._matrix_table[:, 2]
         assert sum([j == 4e-5 for j in SLR_list]) == 3
         assert sum([j == 0.000001 for j in SLR_list]) == 3
 
@@ -233,7 +260,7 @@ class TestPreprocessorMatrixJobsSetups:
         assert pp._has_matrix is True
 
         # verify the directory exists
-        assert pp.jobs_root == str(tmp_path / 'test')
+        assert pp._jobs_root == str(tmp_path / 'test')
         assert (tmp_path / 'test').is_dir()
 
         # try to create another preprocessor at same directory
@@ -343,6 +370,7 @@ class TestPreprocessorEnsembleJobsSetups:
         pp = preprocessor.Preprocessor(input_file=p)
         # assertions for job creation
         assert pp._has_matrix is True
+        assert pp._has_ensemble is True
         assert type(pp.file_list) is list
         assert len(pp.file_list) == 2
 
@@ -424,7 +452,7 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 1
         assert pp._has_matrix is False
 
-        assert pp.yaml_dict['parallel'] is True
+        assert pp.config_dict['parallel'] is True
 
     def test_py_hlvl_parallel_boolean_yaml(self, tmp_path):
         file_name = 'user_parameters.yaml'
@@ -439,8 +467,7 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._has_matrix is True
 
-        assert pp.yaml_dict['parallel'] is True
-        assert not ('parallel' in pp.cli_dict.keys())
+        assert pp.config_dict['parallel'] is True
 
     def test_py_hlvl_parallel_boolean_cli(self, tmp_path):
         file_name = 'user_parameters.yaml'
@@ -454,8 +481,7 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._has_matrix is True
 
-        assert pp.cli_dict['parallel'] is True
-        assert not ('parallel' in pp.yaml_dict.keys())
+        assert pp.config_dict['parallel'] is True
 
     def test_py_hlvl_parallel_integer_yaml(self, tmp_path):
         file_name = 'user_parameters.yaml'
@@ -470,8 +496,7 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._has_matrix is True
 
-        assert pp.yaml_dict['parallel'] == 2
-        assert not ('parallel' in pp.cli_dict.keys())
+        assert pp.config_dict['parallel'] == 2
 
     def test_py_hlvl_parallel_integer_cli(self, tmp_path):
         file_name = 'user_parameters.yaml'
@@ -486,8 +511,7 @@ class TestPreprocessorParallelJobsSetups:
         assert pp._has_matrix is True
         assert pp._is_completed is False
 
-        assert pp.cli_dict['parallel'] == 2
-        assert not ('parallel' in pp.yaml_dict.keys())
+        assert pp.config_dict['parallel'] == 2
 
 
 class TestPreprocessorRunJobs:
@@ -521,7 +545,8 @@ class TestPreprocessorRunJobs:
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         pp = preprocessor.Preprocessor(p)
 
-        pp.file_list = [*pp.file_list] * 2
+        pp._file_list = [*pp.file_list] * 2
+        pp._config_list = [*pp.config_list] * 2
 
         # patch jobs
         with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
@@ -541,7 +566,8 @@ class TestPreprocessorRunJobs:
         pp = preprocessor.Preprocessor(p, parallel=True)
 
         # expand the list to include multiples
-        pp.file_list = [*pp.file_list] * 5
+        pp._file_list = [*pp.file_list] * 5
+        pp._config_list = [*pp.config_list] * 5
 
         # patch jobs and semaphore to check number of processes called
         with mock.patch('pyDeltaRCM.preprocessor._ParallelJob') as ptch, \
@@ -566,7 +592,8 @@ class TestPreprocessorRunJobs:
         pp = preprocessor.Preprocessor(p, parallel=2)
 
         # expand the list to include multiples
-        pp.file_list = [*pp.file_list] * 5
+        pp._file_list = [*pp.file_list] * 5
+        pp._config_list = [*pp.config_list] * 5
 
         # patch jobs and semaphore to check number of processes called
         with mock.patch('pyDeltaRCM.preprocessor._ParallelJob') as ptch, \
@@ -635,15 +662,15 @@ class TestBaseJob:
                            match=r'You must specify a run duration *.'):
             _ = preprocessor._BaseJob(
                 i=0, input_file=p,
-                cli_dict={}, yaml_dict={})
+                config_dict={})
 
     def test_timeargs_precedence_tstepsovertime(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
 
         basej = preprocessor._BaseJob(
             i=0, input_file=p,
-            cli_dict={}, yaml_dict={'time': 10000,
-                                    'timesteps': 2})
+            config_dict={'time': 10000,
+                         'timesteps': 2})
 
         assert isinstance(basej.deltamodel, DeltaModel)
         assert basej._job_end_time == basej.deltamodel._dt * 2
@@ -654,8 +681,8 @@ class TestBaseJob:
 
         basej = preprocessor._BaseJob(
             i=0, input_file=p,
-            cli_dict={}, yaml_dict={'time_years': 10000,
-                                    'timesteps': 2})
+            config_dict={'time_years': 10000,
+                         'timesteps': 2})
 
         assert isinstance(basej.deltamodel, DeltaModel)
         assert basej._job_end_time == basej.deltamodel._dt * 2
@@ -667,8 +694,8 @@ class TestBaseJob:
 
         basej = preprocessor._BaseJob(
             i=0, input_file=p,
-            cli_dict={}, yaml_dict={'time_years': 10000,
-                                    'time': 900})
+            config_dict={'time_years': 10000,
+                         'time': 900})
 
         assert isinstance(basej.deltamodel, DeltaModel)
         assert basej._job_end_time == 900
@@ -683,7 +710,7 @@ class TestSerialJob:
 
         sj = preprocessor._SerialJob(
             i=0, input_file=p,
-            cli_dict={}, yaml_dict={'timesteps': 10})
+            config_dict={'timesteps': 10})
 
         # modify the save interval to be twice dt
         sj.deltamodel._save_dt = 2 * sj.deltamodel._dt
@@ -722,7 +749,7 @@ class TestSerialJob:
 
         sj = preprocessor._SerialJob(
             i=99, input_file=p,
-            cli_dict={}, yaml_dict={'timesteps': 10})
+            config_dict={'timesteps': 10})
 
         # modify the save interval to be twice dt
         sj.deltamodel._save_dt = 2 * sj.deltamodel._dt
@@ -764,7 +791,7 @@ class TestSerialJob:
 
         sj = preprocessor._SerialJob(
             i=0, input_file=p,
-            cli_dict={}, yaml_dict={'timesteps': 10})
+            config_dict={'timesteps': 10})
 
         # modify the save interval to be twice dt
         sj.deltamodel._save_dt = 2 * sj.deltamodel._dt
@@ -812,7 +839,7 @@ class TestParallelJob:
 
         pj = preprocessor._ParallelJob(
             i=0, queue=Q, sema=S, input_file=p,
-            cli_dict={}, yaml_dict={'timesteps': 10})
+            config_dict={'timesteps': 10})
 
         # modify the save interval to be twice dt
         pj.deltamodel._save_dt = 2 * pj.deltamodel._dt
@@ -855,7 +882,7 @@ class TestParallelJob:
 
         pj = preprocessor._ParallelJob(
             i=99, queue=Q, sema=S, input_file=p,
-            cli_dict={}, yaml_dict={'timesteps': 10})
+            config_dict={'timesteps': 10})
 
         # modify the save interval to be twice dt
         pj.deltamodel._save_dt = 2 * pj.deltamodel._dt
@@ -904,7 +931,7 @@ class TestParallelJob:
 
         pj = preprocessor._ParallelJob(
             i=0, queue=Q, sema=S, input_file=p,
-            cli_dict={}, yaml_dict={'timesteps': 10})
+            config_dict={'timesteps': 10})
 
         # modify the save interval to be twice dt
         pj.deltamodel._save_dt = 2 * pj.deltamodel._dt

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -32,6 +32,15 @@ def write_matrix_to_file(f, keys, lists):
             f.write('    ' + '- ' + str(lists[i][j]) + '\n')
 
 
+def write_set_to_file(f, set_list):
+    f.write('set' + ': ' + '\n')
+    for i, _set in enumerate(set_list):
+        f.write('  - {')
+        for j, (k, v) in enumerate(_set.items()):
+            f.write(k + ': ' + str(v) + ', ')
+        f.write('}' + '\n')
+
+
 def yaml_from_dict(tmp_path, file_name, _dict=None):
     p, f = create_temporary_file(tmp_path, file_name)
     if (_dict is None):


### PR DESCRIPTION
# summary 

This PR implements a new configuration option for the high level `Preprocessor`, and completes significant refactoring of the `Preprocessor` infrastructure.

# set expansion

I believe this addition will now cover just about all configurations.
The new configuration option is titled `set` configuration and looks like 
```yaml
set:
  - {u0: 1.0, h0: 21.0}
  - {u0: 22., h0: 0.3333}
```
where each item in the list specifies a set of parameters to set for one job; e.g., the above config would set up two jobs.
All jobs in the set must have the exact same keys.
Note that current implementation does not allow ensemble specifications. It may be possible to set this up, but it wasn't trivial at present, because the ensemble expansion uses the matrix expansion internally, and that cannot work with `set` configs.

## need example

The need for this type of configuration is for jobs where a user wants to construct a matrix of jobs that hold fixed some variable that is not explicitly an input parameter in the model configuration. For example, to vary `Qw0` while holding `Qs0` fixed requires modifying both `C0_percent` and some water-discharge-controlling parameter _simultaneously_; i.e., this cannot be achieved with `matrix` expansion. This user (hint, I'm the user) may want to use the job output and parallel simulation infrastructure of the `Preprocessor`, but cannot easily do so. Now, the user can specify the set directly (based on their own computations to fix derived model parameters as needed) and then use the `Preprocessor` as a multi-job handler.


# refactoring

In the process of implementing this I realized the `Preprocessor` was an unreadable disaster. I have refactored the code substantially. For example:
* config inputs (`yaml` and `cli`) are now combined very early in the `Preprocessor`, such that there is only one `self.config_dict` to track for options in the `Preprocessor` setup.
* job run time is still determined by the `_Job` classes based on `time` `timestep` and `time_years` options, but the `_Job`s no longer require complex property setters, since the `Preprocessor` handles cleaning the inputs.
* I have renamed and re-ordered methods in the code to make the sequence of the `Preprocessor` more intuitive and clear. Additionally, I have added many comments and docstrings.


TODO:
 - [x] example(s) in documentation
 - [x] convert to ready after #147 