### PR TITLE
bugfix: save_iter on load_checkpoint without netcdf file

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -711,6 +711,7 @@ class init_tools(abc.ABC):
 
                 # create a new file
                 self.init_output_file()
+                self._save_iter = 0
 
                 # note we do not output data and a new checkpoint here!
 

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -363,6 +363,7 @@ class TestLoadCheckpoint:
         # check that fields match
         assert np.all(_delta.eta == _eta0)
         assert not hasattr(_delta, 'strata_counter')
+        assert _delta._save_iter == 0
 
         # assertions on function calls
         _delta.log_info.assert_called()


### PR DESCRIPTION
Missed a setting on #147, where we need to reset the `self._save_iter` to `0` when the netcdf file was not found during loading the checkpoint. Without resetting this, the new file has `0, ..., self._save_iter` blank slices of the output netcdf and then starts writing at that point.

This is a trivial fix.