### PR TITLE
Bug saveiter

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -632,11 +632,42 @@ class init_tools(abc.ABC):
 
             self.sigma = self.subsidence_mask * self._sigma_max * self.dt
 
-    def load_checkpoint(self):
+    def load_checkpoint(self, defer_output=False):
         """Load the checkpoint from the .npz file.
 
         Uses the file at the path determined by `self.prefix` and a file named
-        `checkpoint.npz`.
+        `checkpoint.npz`. There are a few pathways for loading, which depend
+        on 1) the status of the :obj:`save_strata` option, 2) the status of
+        additional grid-saving options, 3) the presence of a netCDF output
+        file at the expected output location, and 4) the status of the
+        :obj:`defer_output` parameter passed to this method as an optional
+        argument.
+
+        As a standard user, you should not need to worry about any of these
+        pathways or options. However, if you are developing pyDeltaRCM or
+        customizing the model in any way that involves loadind from
+        checkpoints, you should be aware of these pathways.
+
+        For example, loading from checkpoint will succeed if no netCDF4 file
+        is found, where one is expected (e.g., because :obj:`_save_any_grids`
+        is `True`). In this case, a new output netcdf file will be created,
+        after a `UserWarning` is issued.
+
+        .. important::
+
+            If you are customing the model and intend to use checkpointing and
+            the :obj:`Preprocessor` parallel infrastructure, be sure that
+            parameter :obj:`defer_output` is `True` until the
+            :obj:`load_checkpoint: method can be called from the thread the
+            model will execute on. Failure to do so may result in unexpected
+            behavior with indexing in the output netCDF4 file.
+
+        Parameters
+        ----------
+        defer_output : :obj:`bool`, optional
+            Whether to defer any netCDF activities at present. Manipulating
+            this variable is critical for parallel operations. See note above.
+            Default is `False`.
         """
         _msg = 'Loading from checkpoint.'
         self.log_info(_msg, verbosity=0)
@@ -696,7 +727,8 @@ class init_tools(abc.ABC):
         shared_tools.set_random_state(rng_state)
 
         # handle the case with a netcdf file
-        if (self._save_any_grids or self._save_metadata or self._save_strata):
+        if ((self._save_any_grids or self._save_metadata or self._save_strata)
+                and not defer_output):
 
             # check if the file exists already
             #    if it does, it needs to be flushed of certain fields
@@ -713,11 +745,6 @@ class init_tools(abc.ABC):
                 # reset strata fields just loaded from checkpoint
                 if self.save_strata:
                     self.strata_counter = int(0)
-                    self.n_steps = int(max(1, 5 * int(self._save_dt / self.dt)))
-                    self.strata_sand_frac = lil_matrix(
-                        (self.L * self.W, self.n_steps), dtype=np.float32)
-                    self.strata_eta = lil_matrix(
-                        (self.L * self.W, self.n_steps), dtype=np.float32)
                 self.init_output_file()
 
                 # note we do not output data and a new checkpoint here!

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -708,10 +708,17 @@ class init_tools(abc.ABC):
                 warnings.warn(UserWarning(_msg))
 
                 # create a new file
-                self.init_output_file()
+                # reset output file counters
                 self._save_iter = int(0)
+                # reset strata fields just loaded from checkpoint
                 if self.save_strata:
                     self.strata_counter = int(0)
+                    self.n_steps = int(max(1, 5 * int(self._save_dt / self.dt)))
+                    self.strata_sand_frac = lil_matrix(
+                        (self.L * self.W, self.n_steps), dtype=np.float32)
+                    self.strata_eta = lil_matrix(
+                        (self.L * self.W, self.n_steps), dtype=np.float32)
+                self.init_output_file()
 
                 # note we do not output data and a new checkpoint here!
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -709,7 +709,9 @@ class init_tools(abc.ABC):
 
                 # create a new file
                 self.init_output_file()
-                self._save_iter = 0
+                self._save_iter = int(0)
+                if self.save_strata:
+                    self.strata_counter = int(0)
 
                 # note we do not output data and a new checkpoint here!
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -99,7 +99,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         # if resume flag set to True, load checkpoint, open netCDF4
         if self.resume_checkpoint:
             # load values from the checkpoint and don't init final features
-            self.load_checkpoint()
+            self.load_checkpoint(defer_output)
 
         else:
             # initialize the output file

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -807,7 +807,9 @@ class _ParallelJob(_BaseJob, multiprocessing.Process):
                 # initialize the output files (defer_output=True above)
                 # unless resuming from checkpoint, then load the checkpoint
                 if self.deltamodel.resume_checkpoint:
-                    self.deltamodel.load_checkpoint()
+                    # here we set defer output to false when loading the
+                    #   checkpoint on this thread
+                    self.deltamodel.load_checkpoint(defer_output=False)
                 else:
                     # infrastructure deferred, need to trigger manually
                     self.deltamodel.init_output_file()

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -662,7 +662,6 @@ class _BaseJob(abc.ABC):
             self._time_config = config_dict['timesteps']
 
             # compute the end time
-            print(config_dict['timesteps'])
             self._job_end_time = _curr_time + \
                 ((config_dict['timesteps'] * self.deltamodel._dt))
 


### PR DESCRIPTION
#150 did not correctly resolve the issue stated there. 


I failed to reset the values from stratrigaphy tracking, so that when the final netcdf was produced, there were N blank rows in the output arrays, where N is the number of arrays output during the run that produced the checkpoint file we are resuming from.

I have tested this pr with a short run, but am waiting for some long runs to finish so I can verify it is fixed.