### PR TITLE
fix handling of the cli arguments/defaults in the preprocessor.

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import argparse
 import abc
 import time
@@ -973,12 +974,10 @@ class PreprocessorCLI(BasePreprocessor):
 
         # set (or remove) defaults as needed
         if (args_dict['parallel'] is None):
-            # if not given
-            #   remove the key from cli spec
+            # if not given remove the key from cli spec
             args_dict.pop('parallel')
         if (args_dict['If'] is None):
-            # if not given
-            #   remove the key from cli spec
+            # if not given remove the key from cli spec
             args_dict.pop('If')
 
         return args_dict

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -971,9 +971,15 @@ class PreprocessorCLI(BasePreprocessor):
         else:
             args_dict.pop('time_years')
 
-        # set defaults as needed
-        args_dict['parallel'] = args_dict['parallel'] or False
-        args_dict['If'] = args_dict['If'] or 1.0
+        # set (or remove) defaults as needed
+        if (args_dict['parallel'] is None):
+            # if not given
+            #   remove the key from cli spec
+            args_dict.pop('parallel')
+        if (args_dict['If'] is None):
+            # if not given
+            #   remove the key from cli spec
+            args_dict.pop('If')
 
         return args_dict
 


### PR DESCRIPTION
fixes #154.

Problem was that the CLI input was overwriting the `parallel` flag specified in the YAML during the merging of the cli and yaml dictionaries.

I have fixed this by removing the `parallel` and `If` flags from the `cli_dict` if they are not explicitly specified at the cli.

There's not really any good way to test the cli though, which is how issues like this one continue to arise. We test the heck out the python preprocessor, which covers a lot of the same code that the CLI one uses, but doesn't capture the very initial parts like this one. Perhaps we can test the object directly in the same way we test the python one, while mocking the command line inputs somehow...