### PR TITLE
update badge on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pyDeltaRCM
 **************
 
-.. image:: https://github.com/DeltaRCM/pyDeltaRCM/workflows/build/badge.svg
+.. image:: https://github.com/DeltaRCM/pyDeltaRCM/actions/workflows/build.yml/badge.svg
     :target: https://github.com/DeltaRCM/pyDeltaRCM/actions
 
 .. image:: https://badge.fury.io/py/pyDeltaRCM.svg


### PR DESCRIPTION
A while ago we changed the Github Actions workflow name (I think in #143?). This outdated the build badge on the README. 

This PR fixes it.