### PR TITLE
add an example with a chunk of time switched for the bedload

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -19,6 +19,7 @@ Modifying boundary conditions
    :maxdepth: 1
 
    subsidence_region
+   variable_bedload
 
 
 Modifying internal computations

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -20,6 +20,7 @@ Modifying boundary conditions
 
    subsidence_region
    variable_bedload
+   variable_velocity
 
 
 Modifying internal computations

--- a/docs/source/examples/variable_bedload.rst
+++ b/docs/source/examples/variable_bedload.rst
@@ -7,11 +7,13 @@ In this example, the time-varying behavior arises by managing two "switches", ``
 The following codes produce two runs (using `matrix` expansion from the Preprocessor), which has a baseline `f_bedload` value of either ``0.3`` or ``0.7``, and for a period in the middle of the run, the `f_bedload` values are mirrored by ``self.f_bedload = (1 - self.f_bedload)``, i.e., briefly switching the bedload values.
 
 
-.. code:: python
+.. plot::
+    :context: reset
+    :include-source:
 
     class VariableBedloadModel(pyDeltaRCM.DeltaModel):
 
-        def __init__(self, input_file, **kwargs):
+        def __init__(self, input_file=None, **kwargs):
 
             super().__init__(input_file, **kwargs)
 
@@ -39,6 +41,71 @@ The following codes produce two runs (using `matrix` expansion from the Preproce
                     f_bedload=self.f_bedload)
                 self.log_info(_msg, verbosity=0)
 
+
+.. rubric:: Checking on the state-change effect
+
+To demonstrate how this works, let's loop through time and check the model state.
+Here, we will change the model time value directly, so that we can verify that the model is working as intended, but you should never do this in practice.
+
+.. plot::
+    :context:
+
+    with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+        mdl_muddy = VariableBedloadModel(f_bedload=0.3,
+                                         out_dir=output_dir)
+        mdl_sandy = VariableBedloadModel(f_bedload=0.7)
+
+.. code:: python
+
+    mdl_muddy = VariableBedloadModel(f_bedload=0.3,
+                                     out_dir=output_dir)
+    mdl_sandy = VariableBedloadModel(f_bedload=0.7)
+
+.. important::
+
+    You should never modify the model time via ``self._time`` directly when working with the model.
+
+
+.. plot::
+    :context:
+    :include-source:
+
+    # create a figure
+    fig, ax = plt.subplots()
+
+    # set the "simulation" range
+    _times = np.linspace(0, 1e9, num=100)
+    fb_mdl_muddy = np.zeros_like(_times)
+    fb_mdl_sandy = np.zeros_like(_times)
+
+    # loop through time, change the model time and grab f_bedload values
+    for i, _time in enumerate(_times):
+        # change the model time directly
+        mdl_muddy._time = _time  # you should never do this
+        mdl_sandy._time = _time  # you should never do this
+
+        # run the hooked method
+        mdl_muddy.hook_run_one_timestep()
+        mdl_sandy.hook_run_one_timestep()
+
+        # grab the state of the `f_bedload` parameter
+        fb_mdl_muddy[i] = mdl_muddy.f_bedload  # get the value
+        fb_mdl_sandy[i] = mdl_sandy.f_bedload  # get the value
+
+    # add it to the plot
+    ax.plot(_times, fb_mdl_muddy, '-', c='saddlebrown', lw=2, label='muddy')
+    ax.plot(_times, fb_mdl_sandy, '--', c='goldenrod', lw=2, label='sandy')
+    ax.legend()
+
+    # clean up
+    ax.set_ylim(0, 1)
+    ax.set_ylabel('f_bedload')
+    ax.set_xlabel('model time (s)')
+
+    plt.show()
+
+
+.. rubric:: Running the model for real
 
 Given a yaml file (``variable_bedload.yaml``):
 

--- a/docs/source/examples/variable_bedload.rst
+++ b/docs/source/examples/variable_bedload.rst
@@ -1,0 +1,79 @@
+Time-varying bedload
+====================
+
+The following example demonstrates how to configure a subclassing model with a time-varying parameter.
+In this example, the time-varying behavior arises by managing two "switches", ``self._changed`` and ``self._changed_back``, which change the state of the :obj:`f_bedload` parameters at a predetermined time in the mode sequence.
+
+The following codes produce two runs (using `matrix` expansion from the Preprocessor), which has a baseline `f_bedload` value of either ``0.3`` or ``0.7``, and for a period in the middle of the run, the `f_bedload` values are mirrored by ``self.f_bedload = (1 - self.f_bedload)``, i.e., briefly switching the bedload values.
+
+
+.. code:: python
+
+    class VariableBedloadModel(pyDeltaRCM.DeltaModel):
+
+        def __init__(self, input_file, **kwargs):
+
+            super().__init__(input_file, **kwargs)
+
+            self._changed = False
+            self._changed_back = False
+
+        def hook_run_one_timestep(self):
+            """Change the state depending on the _time.
+            """
+            # check if the state has been changed, and time to change it
+            if (not self._changed) and (self._time > 459909090):
+                self.f_bedload = (1 - self.f_bedload)
+                self._changed = True
+
+                _msg = 'Bedload changed to {f_bedload}'.format(
+                    f_bedload=self.f_bedload)
+                self.log_info(_msg, verbosity=0)
+
+            # check if the state has been changed back, and time to change it back
+            if (not self._changed_back) and (self._time > 714545454):
+                self.f_bedload = (1 - self.f_bedload)
+                self._changed_back = True
+
+                _msg = 'Bedload changed back to {f_bedload}'.format(
+                    f_bedload=self.f_bedload)
+                self.log_info(_msg, verbosity=0)
+
+
+Given a yaml file (``variable_bedload.yaml``):
+
+.. code:: yaml
+
+    Length: 5000.
+    Width: 10000.
+    dx: 50
+    N0_meters: 500
+    C0_percent: 0.05
+    SLR: 1.5e-8
+    h0: 2
+    u0: 1.1
+    coeff_U_dep_mud: 0.5
+    parallel: True
+    
+    matrix:
+      f_bedload:
+        - 0.3
+        - 0.7
+
+
+and a script to run the code:
+
+.. code:: python
+    
+    if __name__ == '__main__':
+
+        # base yaml configuration
+        base_yaml = 'variable_bedload.yaml'
+
+        pp = pyDeltaRCM.Preprocessor(
+                base_yaml,
+                timesteps=12000)
+
+        # run the jobs
+        pp.run_jobs(DeltaModel=VariableBedloadModel)
+

--- a/docs/source/examples/variable_velocity.rst
+++ b/docs/source/examples/variable_velocity.rst
@@ -1,0 +1,107 @@
+Time-varying inlet velocity
+===========================
+
+It is straightforward to create models with time-varying boundary conditions. 
+In this example, we set up an array of values to use for the inlet flow velocity, depending on the time of the model (i.e., a timeseries).
+
+In implementation, because we don't know the timestep of the model before creating it, we interpolate the actual inlet flow velocity from the boundary condition timeseries.
+
+
+Define the boundary condition
+-----------------------------
+
+First, let's set up the boundary condition array we want to use.
+We'll set this up in a function, so that it can be called from the model subclass, as well as here for plotting.
+
+.. plot::
+    :context: reset
+    :include-source:
+
+    def create_velocity_array(end_time, a=1, b=5e4, h=3.2, k=2):
+        """Create velocity timeseries.
+        """
+        _time = np.linspace(0, end_time, num=1000)
+
+        _velocity = a * np.sin((_time - h)/b) + k
+        return _time, _velocity
+
+The function we define takes the `end_time` of the model run, as well as some shape parameters, and computes according to:
+
+.. math::
+
+    y = a \sin \left( \frac{ \left( t - h \right) }{ b } \right) + k
+
+where :math:`t` is the time array in seconds.
+We can inspect the result of this function, as it will be called in the model subclass below.
+
+.. plot::
+    :context:
+    :include-source:
+
+    end_time = 86400 * 100
+    _time_array, _velocity_array = create_velocity_array(
+                end_time)
+
+    # make a plot of the boundary condition
+    fig, ax = plt.subplots()
+    ax.plot(_time_array, _velocity_array)
+    ax.set_xlabel('time (seconds)')
+    ax.set_ylabel('inlet velocity (meters/second)')
+    plt.show()
+
+
+Define the model subclass
+-------------------------
+
+We define a model subclass to handle the changing boundary condition:
+
+.. plot::
+    :context: close-figs
+    :include-source:
+
+    class ChangingVelocityModel(pyDeltaRCM.DeltaModel):
+        """Model with changing flow velocity.
+
+        Create a model that changes the inlet flow velocity throughout the run.
+        In this example, the velocity is changed on each timestep, and the value
+        it is set to is interpolated from a **predetermined timeseries** of
+        velocities.
+        """
+        def __init__(self, input_file=None, end_time=86400, **kwargs):
+
+            # inherit from the base model
+            super().__init__(input_file, **kwargs)
+
+            # set up the attributes for interpolation
+            self._time_array, self._velocity_array = create_velocity_array(
+                end_time)  # use default shape parameters for the array
+
+        def hook_run_one_timestep(self):
+            """Change the velocity."""
+
+            # find the new velocity and set it to the model
+            self.u0 = np.interp(self._time, self._time_array, self._velocity_array)
+
+            # log the new value
+            _msg = 'Changed velocity value to {u0}'.format(
+                u0=self.u0)
+            self.log_info(_msg, verbosity=0)
+
+
+and then simply run with:
+
+.. plot::
+    :context:
+
+    # we create the model here, just to be sure it works (for good docs)
+    with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+        mdl = ChangingVelocityModel(
+            end_time=end_time,
+            out_dir=output_dir)
+
+.. code::
+
+    mdl = ChangingVelocityModel(end_time=end_time)
+
+    while mdl.time < end_time:
+        mdl.update()


### PR DESCRIPTION
The added documentation examples demonstrate how to use subclassing to impose a time-varying boundary condition. 

One example produces the following output. Unsure whether to include the png below, or just the code.

![image](https://user-images.githubusercontent.com/8801322/111079117-8550fb00-84c6-11eb-80c0-55f0f232ed61.png)
