### PR TITLE
Better handling of `ensemble: 1` and matrix keys with length == 1

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -249,6 +249,14 @@ class BasePreprocessor(abc.ABC):
         if not isinstance(_ensemble, int):
             raise TypeError('Invalid ensemble type, must be an integer.')
 
+        if _ensemble == 1:
+            # there's nothing to do here
+            warnings.warn(UserWarning(
+                    'Ensemble was set to 1. '
+                    'Remove this key from configuration.'))
+            self._has_ensemble = False
+            return
+
         # if matrix does not exist, then it must be created
         if 'matrix' not in self.config_dict.keys():
             _matrix = {}
@@ -376,9 +384,9 @@ class BasePreprocessor(abc.ABC):
                 'You cannot specify "out_dir" as a matrix expansion key.')
         for k in _matrix.keys():  # check validity of keys, depth == 1
             if len(_matrix[k]) == 1:
-                raise ValueError(
+                warnings.warn(UserWarning(
                     'Length of matrix key "%s" was 1, '
-                    'relocate to fixed configuration.' % str(k))
+                    'remove this key from matrix configuration.' % str(k)))
             for v in _matrix[k]:
                 if isinstance(v, list):
                     raise ValueError(

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -277,8 +277,8 @@ class TestPreprocessorMatrixJobsSetups:
                                        ['f_bedload', 'u0'],
                                        [[0.2], [0.5, 0.6, 1.25]])
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'Length of matrix key "f_bedload" was 1,'):
+        with pytest.warns(UserWarning,
+                          match=r'Length of matrix key "f_bedload" was 1,'):
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_mtrx_bad_listinlist(self, tmp_path):
@@ -449,6 +449,21 @@ class TestPreprocessorEnsembleJobsSetups:
         assert pp._has_ensemble is True
         assert type(pp.file_list) is list
         assert len(pp.file_list) == 2
+
+    def test_py_hlvl_ensemble_1(self, tmp_path):
+        file_name = 'user_parameters.yaml'
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, 'ensemble', 1)
+        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        f.close()
+        with pytest.warns(UserWarning,
+                          match=r'Ensemble was set to 1. *.'):
+            pp = preprocessor.Preprocessor(input_file=p)
+
+        # check that keys were reset and config set correctly
+        assert pp._has_ensemble is False
+        assert pp._has_matrix is False
+        assert len(pp.file_list) == 1
 
     def test_py_hlvl_ensemble_badtype(self, tmp_path):
         file_name = 'user_parameters.yaml'

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -279,7 +279,11 @@ class TestPreprocessorMatrixJobsSetups:
         f.close()
         with pytest.warns(UserWarning,
                           match=r'Length of matrix key "f_bedload" was 1,'):
-            _ = preprocessor.Preprocessor(input_file=p)
+            pp = preprocessor.Preprocessor(input_file=p)
+
+        # check job length
+        assert pp._has_matrix is True
+        assert len(pp.file_list) == 3
 
     def test_py_hlvl_mtrx_bad_listinlist(self, tmp_path):
         file_name = 'user_parameters.yaml'


### PR DESCRIPTION
I have changed the behavior of ensemble and matrix expansion here. Previously, both ensemble and matrix expansion would fail if configurations had items length unity. For example:

```
ensemble: 1
```
or 
```
matrix: 
  f_bedload: 
    - 0.2
  u0: 
    - 0.5
    - 0.6
    - 1.25
```
would result in an error message thrown (our error message). Now, these configurations lead to a warning, but the preprocessor will proceed with the run. In the ensemble case, the `ensemble` key is just stripped from the dictionary and we proceed as though it were a single job, with no specifications. In the matrix case, nothing had to change, it's just a warning now.

I've added tests for this behavior.

closes #149 