### PR TITLE
Refactor figure saving, hooks for custom netCDF fields

### DIFF
--- a/docs/source/examples/custom_saving.rst
+++ b/docs/source/examples/custom_saving.rst
@@ -1,0 +1,74 @@
+Saving custom fields to the output file
+=======================================
+
+Given the flexibility of the pyDeltaRCM model to modifications via hooks and subclassing, it is necessary that the variables saved to the output netCDF file are similarly customizable.
+Fortunately, the use of subclasses and hooks itself enables flexible setting of gridded variables to be saved as figures, as well as customization of the fields saved to the netCDF file as both variables, and as metadata.
+
+To customize the figures and variables that are saved, the hook ``hook_init_output_file`` should be used to subclass the pyDeltaRCM model.
+
+When adding a model attribute to the list of grids to save as figures, be sure to append the actual *attribute name* to the list of figures to save.
+For example, ``self._save_fig_list.append('active_layer')`` will properly indicate that figures of the active layer should be saved, however ``self._save_fig_list.append('activelayer')`` will not work because the name of the model attribute is ``active_layer`` not ``activelayer``.
+
+When adding variables or metadata to be initialized and subsequently saved in the output netCDF, the key-value pair relationship is as follows.
+The key added to ``self._save_var_list`` is the name of the variable as it will be recorded in the netCDF file, this *does not* have to correspond to the name of an attribute in the model.
+To add a variable to the metadata, a key must be added to ``self._save_var_list['meta']``.
+The expected value for a given key is a list containing strings indicating the model attribute to be saved, its units, the variable type, and lastly the variable dimensions (e.g., ``['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]`` for the active layer).
+
+An example of using the hook and creating a model subclass to customize the figures, gridded variables, and metadata being saved is provided below.
+
+.. plot::
+    :context: reset
+    :include-source:
+
+    class CustomSaveModel(pyDeltaRCM.DeltaModel):
+        """A subclass of DeltaModel to save custom figures and variables.
+
+        This subclass modifies the list of variables and figures used to
+        initialize the netCDF file and save figures and grids before the
+        output file is setup and initial conditions are plotted.
+        """
+        def __init__(self, input_file=None, **kwargs):
+
+             # inherit base DeltaModel methods
+            super().__init__(input_file, **kwargs)
+
+        def hook_init_output_file(self):
+            """Add non-standard grids, figures and metadata to be saved."""
+            # save a figure of the active layer each save_dt
+            self._save_fig_list.append('active_layer')
+
+            # save the active layer grid each save_dt w/ a short name
+            self._save_var_list['actlay'] = ['active_layer', 'fraction', 'f4',
+                                             ('total_time', 'length', 'width')]
+            # save number of water parcels w/ a long name
+            self._save_var_list['meta']['water_parcels'] = ['Np_water',
+                                                            'parcels',
+                                                            'i8', ()]
+
+Next, we instantiate the model class.
+
+.. code::
+
+    mdl = CustomSaveModel()
+
+
+.. plot::
+    :context:
+
+    with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+        mdl = CustomSaveModel(out_dir=output_dir)
+
+
+This subclass has added the active layer as a figure and a grid to be saved, as well as the number of water parcels as metadata to be saved.
+For simplicity we will just check that the appropriate parameters were added to the save figure and save variable lists, however please feel free to give this example a try on your local machine and examine the output figures and netCDF file.
+
+.. doctest::
+
+    >>> 'active_layer' in mdl._save_fig_list
+    True
+
+    >>> print(mdl._save_fig_list)
+    ['active_layer']
+
+    >>> print(mdl._save_var_list)
+    {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'ACT_lay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}

--- a/docs/source/examples/custom_saving.rst
+++ b/docs/source/examples/custom_saving.rst
@@ -63,7 +63,19 @@ This subclass has added the active layer as a figure and a grid to be saved, as 
 For simplicity we will just check that the appropriate parameters were added to the save figure and save variable lists, however please feel free to give this example a try on your local machine and examine the output figures and netCDF file.
 
 .. doctest::
+    :context:
 
+    >>> 'active_layer' in mdl._save_fig_list
+    True
+
+    >>> print(mdl._save_fig_list)
+    ['active_layer']
+
+    >>> print(mdl._save_var_list)
+    {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'ACT_lay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}
+
+.. code::
+    
     >>> 'active_layer' in mdl._save_fig_list
     True
 

--- a/docs/source/examples/custom_saving.rst
+++ b/docs/source/examples/custom_saving.rst
@@ -79,7 +79,7 @@ For simplicity we will just check that the appropriate parameters were added to 
     True
 
     >>> print(mdl._save_fig_list)
-    ['active_layer']
+    {'active_layer': ['active_layer']}
 
     >>> print(mdl._save_var_list)
     {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'ACT_lay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}
@@ -90,7 +90,7 @@ For simplicity we will just check that the appropriate parameters were added to 
     True
 
     >>> print(mdl._save_fig_list)
-    ['active_layer']
+    {'active_layer': ['active_layer']}
 
     >>> print(mdl._save_var_list)
     {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'ACT_lay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -31,3 +31,11 @@ Modifying behavior of the Preprocessor
 --------------------------------------
 
 * none
+
+Modifying variables saved in the output file
+--------------------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   custom_saving

--- a/docs/source/guides/user_guide.rst
+++ b/docs/source/guides/user_guide.rst
@@ -39,7 +39,7 @@ The "low-level" API consists of creating a model instance from a YAML configurat
 
 
 
-.. _high_level_api: 
+.. _high_level_api:
 
 High-level model API
 ====================
@@ -107,11 +107,11 @@ The former case is straightforward, insofar that the model determines the timest
 To specify the number of timesteps to run the model, use the argument ``--timesteps`` at the command line (or ``timesteps:`` in the configuration YAML file, or ``timesteps=`` with the Python :obj:`~pyDeltaRCM.Preprocessor`).
 
 .. code:: bash
-    
+
     pyDeltaRCM --config model_configuration.yml --timesteps 5000
 
 The second case is more complicated, because the time specification is converted to model time according to a set of additional parameters.
-In this case, the model run end condition is that the elapsed model time is *equal to or greater than* the specified input time. 
+In this case, the model run end condition is that the elapsed model time is *equal to or greater than* the specified input time.
 Importantly, this means that the duration of the model run is unlikely to exactly match the input condition, because the model timestep is unlikely to be a factor of the specified time.
 Again, refer to the complete description of model time :doc:`../info/modeltime` for more information.
 
@@ -119,7 +119,7 @@ To specify the duration of time to run the model in *seconds*, simply use the ar
 It is also possible to specify the input run duration in units of years with the similarly named argument ``--time_years`` (``time_years:``, ``time_years=``).
 
 .. code:: bash
-    
+
     pyDeltaRCM --config model_configuration.yml --time 31557600
     pyDeltaRCM --config model_configuration.yml --time_years 1
 
@@ -138,14 +138,14 @@ See :doc:`../info/modeltime` for complete information on the scaling between mod
 Running simulations in parallel
 -------------------------------
 
-The high-level API provides the ability to run simulations in parallel on Linux environments. 
+The high-level API provides the ability to run simulations in parallel on Linux environments.
 This option is only useful in the case where you are running multiple jobs with the :ref:`matrix expansion <matrix_expansion_tag>`, :ref:`ensemble expansion <ensemble_expansion_tag>`, or :ref:`set expansion <set_expansion_tag>` tools.
 
 To run jobs in parallel simply specify the `--parallel` flag to the command line interface.
 Optionally, you can specify the number of simulations to run at once by following the flag with a number.
 
 .. code:: bash
-    
+
     pyDeltaRCM --config model_configuration.yml --timesteps 5000 --parallel
     pyDeltaRCM --config model_configuration.yml --timesteps 5000 --parallel 6
 
@@ -166,7 +166,7 @@ The simplest case to use the low-level API is to do
     >>> delta.finalize()
 
 However, you can also inspect/modify the :obj:`~pyDeltaRCM.DeltaModel.update` method, and change the order of operations, or add operations, as desired.
-If you are working with the low-level API, you can optionally pass any valid key in the YAML configuration file as a keyword argument during model instantiation. 
+If you are working with the low-level API, you can optionally pass any valid key in the YAML configuration file as a keyword argument during model instantiation.
 For example:
 
 .. code::
@@ -206,3 +206,4 @@ Examples:
 
     * :doc:`/examples/slight_slope`
     * :doc:`/examples/subsidence_region`
+    * :doc:`/examples/custom_saving`

--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -16,7 +16,7 @@ A complete list of hooks in the model follows:
     :obj:`~hook_tools.hook_load_checkpoint`, :obj:`~hook_tools.hook_run_water_iteration`
     :obj:`~hook_tools.hook_output_data`, :obj:`~hook_tools.hook_compute_free_surface`
     :obj:`~hook_tools.hook_output_checkpoint`, :obj:`~hook_tools.hook_finalize_water_iteration`
-    , :obj:`~hook_tools.hook_sed_route`
+    :obj:`~hook_tools.hook_init_output_file`, :obj:`~hook_tools.hook_sed_route`
     , :obj:`~hook_tools.hook_route_all_sand_parcels`
     , :obj:`~hook_tools.hook_topo_diffusion`
     , :obj:`~hook_tools.hook_route_all_mud_parcels`

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -160,46 +160,26 @@ class hook_tools(abc.ABC):
         """
         pass
 
-    def hook_init_grids(self):
-        """
-        Hook within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`.
+    def hook_init_output_file(self):
+        """Hook :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`.
 
-        Called within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`
-        after establishment of the output netCDF4 file and its dimensions.
-        But before creation of standard grids in the netCDF file. Look at the
-        function :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file` for
-        guidance on how to write this hook to set up additional netCDF grids.
-        """
-        pass
+        Called immediately before
+        :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`.
 
-    def hook_init_metadata(self):
-        """
-        Hook within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`.
+        Expected format for entries to the `meta` dictionary nested within the
+        `self._save_var_list` dictionary:
 
-        Called within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`
-        after creation of the netCDF4 metadata group, 'meta'.
-        But before assignment of standard metadata variables. Look at the
-        function :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file` for
-        guidance on how to write this hook to set up additional metadata.
-        """
-        pass
+        ```
+        self._save_var_list['meta']['new_meta_name'] = ['varname', 'units',
+                                                        'type', (dimensions)]
+        ```
 
-    def hook_save_grids(self, save_idx):
-        """
-        Hook within :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`.
+        Expected format for time varying grid entries as keys within the
+        `self._save_var_list` dictionary:
 
-        Called within
-        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`
-        before standard grids are saved to the netCDF file.
-        """
-        pass
-
-    def hook_save_metadata(self, save_idx):
-        """
-        Hook within :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`.
-
-        Called within
-        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`
-        before the standard time-varying metadata is saved to the group.
+        ```
+        self._save_var_list['new_grid_name'] = ['varname', 'units', 'type',
+                                                (dimensions)]
+        ```
         """
         pass

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -159,3 +159,47 @@ class hook_tools(abc.ABC):
         :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.compute_sand_frac`.
         """
         pass
+
+    def hook_init_grids(self):
+        """
+        Hook within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`.
+
+        Called within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`
+        after establishment of the output netCDF4 file and its dimensions.
+        But before creation of standard grids in the netCDF file. Look at the
+        function :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file` for
+        guidance on how to write this hook to set up additional netCDF grids.
+        """
+        pass
+
+    def hook_init_metadata(self):
+        """
+        Hook within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`.
+
+        Called within :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file`
+        after creation of the netCDF4 metadata group, 'meta'.
+        But before assignment of standard metadata variables. Look at the
+        function :obj:`~pyDeltaRCM.init_tools.init_tools.init_output_file` for
+        guidance on how to write this hook to set up additional metadata.
+        """
+        pass
+
+    def hook_save_grids(self, save_idx):
+        """
+        Hook within :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`.
+
+        Called within
+        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`
+        before standard grids are saved to the netCDF file.
+        """
+        pass
+
+    def hook_save_metadata(self, save_idx):
+        """
+        Hook within :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`.
+
+        Called within
+        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.save_grids_and_figs`
+        before the standard time-varying metadata is saved to the group.
+        """
+        pass

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -319,13 +319,6 @@ class init_tools(abc.ABC):
                                 self._save_sandfrac_grids or
                                 self._save_discharge_components or
                                 self._save_velocity_components)
-        self._save_any_figs = (self._save_eta_figs or
-                               self._save_depth_figs or
-                               self._save_stage_figs or
-                               self._save_discharge_figs or
-                               self._save_velocity_figs or
-                               self._save_sedflux_figs or
-                               self._save_sandfrac_figs)
         if self._save_any_grids:  # always save metadata if saving grids
             self._save_metadata = True
         self._is_finalized = False

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -36,7 +36,7 @@ class init_tools(abc.ABC):
             os.makedirs(self.prefix_abspath)
             assert os.path.isdir(self.prefix_abspath)  # validate dir created
 
-        self._save_fig_list = []  # list of figure variables to save
+        self._save_fig_list = dict()  # dict of figure variables to save
         self._save_var_list = dict()  # dict of variables to save
         self._save_var_list['meta'] = dict()  # set up meta dict
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -496,6 +496,9 @@ class init_tools(abc.ABC):
             x[:] = self.x
             y[:] = self.y
 
+            # hook to set up additional variables as output grids
+            self.hook_init_grids()
+
             # set up variables for output data grids
             if self.save_eta_grids:
                 eta = self.output_netcdf.createVariable(
@@ -549,6 +552,8 @@ class init_tools(abc.ABC):
                 _v[:] = varvalue
 
             self.output_netcdf.createGroup('meta')
+            # hook to add custom metadata
+            self.hook_init_metadata()
             # fixed metadata
             _create_meta_variable('L0', self.L0, 'cells', vartype='i8')
             _create_meta_variable('N0', self.N0, 'cells', vartype='i8')

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -22,7 +22,7 @@ from . import sed_tools
 class init_tools(abc.ABC):
 
     def init_output_infrastructure(self):
-        """Initialize the output infrastructure (i.e., folder).
+        """Initialize the output infrastructure (folder and save lists).
 
         This method is the first called in the initialization of the
         `DeltaModel`, after the configuration variables have been imported.
@@ -35,6 +35,10 @@ class init_tools(abc.ABC):
         if not os.path.exists(self.prefix_abspath):
             os.makedirs(self.prefix_abspath)
             assert os.path.isdir(self.prefix_abspath)  # validate dir created
+
+        self._save_fig_list = []  # list of figure variables to save
+        self._save_var_list = dict()  # dict of variables to save
+        self._save_var_list['meta'] = dict()  # set up meta dict
 
     def init_logger(self):
         """Initialize a logger.
@@ -453,6 +457,36 @@ class init_tools(abc.ABC):
         _msg = 'Initializing output NetCDF4 file'
         self.log_info(_msg, verbosity=1)
 
+        # set standard/default metadata values in the dict structure
+        if self._save_metadata:
+            # fixed metadata
+            self._save_var_list['meta']['L0'] = ['L0', 'cells', 'i8', ()]
+            self._save_var_list['meta']['N0'] = ['N0', 'cells', 'i8', ()]
+            self._save_var_list['meta']['CTR'] = ['CTR', 'cells', 'i8', ()]
+            self._save_var_list['meta']['dx'] = ['dx', 'meters', 'f4', ()]
+            self._save_var_list['meta']['h0'] = ['h0', 'meters', 'f4', ()]
+            self._save_var_list['meta']['cell_type'] = ['cell_type',
+                                                        'type', 'i8',
+                                                        ('length', 'width')]
+            # subsidence metadata
+            if self._toggle_subsidence:
+                self._save_var_list['meta']['start_subsidence'] = [
+                    'start_subsidence', 'seconds', 'i8', ()
+                ]
+                self._save_var_list['meta']['sigma'] = [
+                    'sigma', 'meters per timestep', 'f4',
+                    ('length', 'width')
+                ]
+            # time-varying metadata
+            self._save_var_list['meta']['H_SL'] = [None, 'meters', 'f4',
+                                                   ('total_time')]
+            self._save_var_list['meta']['f_bedload'] = [None, 'fraction',
+                                                        'f4', ('total_time')]
+            self._save_var_list['meta']['C0_percent'] = [None, 'percent',
+                                                         'f4', ('total_time')]
+            self._save_var_list['meta']['u0'] = [None, 'meters per second',
+                                                 'f4', ('total_time')]
+
         if (self._save_metadata or
                 self._save_any_grids):
 
@@ -496,52 +530,19 @@ class init_tools(abc.ABC):
             x[:] = self.x
             y[:] = self.y
 
-            # hook to set up additional variables as output grids
-            self.hook_init_grids()
-
             # set up variables for output data grids
-            if self.save_eta_grids:
-                eta = self.output_netcdf.createVariable(
-                    'eta', 'f4', ('total_time', 'length', 'width'))
-                eta.units = 'meters'
-            if self.save_stage_grids:
-                stage = self.output_netcdf.createVariable(
-                    'stage', 'f4', ('total_time', 'length', 'width'))
-                stage.units = 'meters'
-            if self.save_depth_grids:
-                depth = self.output_netcdf.createVariable(
-                    'depth', 'f4', ('total_time', 'length', 'width'))
-                depth.units = 'meters'
-            if self.save_discharge_grids:
-                discharge = self.output_netcdf.createVariable(
-                    'discharge', 'f4', ('total_time', 'length', 'width'))
-                discharge.units = 'cubic meters per second'
-            if self.save_velocity_grids:
-                velocity = self.output_netcdf.createVariable(
-                    'velocity', 'f4', ('total_time', 'length', 'width'))
-                velocity.units = 'meters per second'
-            if self.save_sedflux_grids:
-                sedflux = self.output_netcdf.createVariable(
-                    'sedflux', 'f4', ('total_time', 'length', 'width'))
-                sedflux.units = 'cubic meters per second'
-            if self.save_sandfrac_grids:
-                sandfrac = self.output_netcdf.createVariable(
-                    'sandfrac', 'f4', ('total_time', 'length', 'width'))
-                sandfrac.units = 'fraction'
-            if self.save_discharge_components:
-                discharge_x = self.output_netcdf.createVariable(
-                    'discharge_x', 'f4', ('total_time', 'length', 'width'))
-                discharge_x.units = 'cubic meters per second'
-                discharge_y = self.output_netcdf.createVariable(
-                    'discharge_y', 'f4', ('total_time', 'length', 'width'))
-                discharge_y.units = 'cubic meters per second'
-            if self.save_velocity_components:
-                velocity_x = self.output_netcdf.createVariable(
-                    'velocity_x', 'f4', ('total_time', 'length', 'width'))
-                velocity_x.units = 'meters per second'
-                velocity_y = self.output_netcdf.createVariable(
-                    'velocity_y', 'f4', ('total_time', 'length', 'width'))
-                velocity_y.units = 'meters per second'
+            def _create_grid_variable(varname, varunits,
+                                      vartype='f4', vardims=()):
+                _v = self.output_netcdf.createVariable(
+                    varname, vartype, vardims)
+                _v.units = varunits
+
+            _var_list = list(self._save_var_list.keys())
+            _var_list.remove('meta')
+            for _val in _var_list:
+                _create_grid_variable(_val, self._save_var_list[_val][1],
+                                      self._save_var_list[_val][2],
+                                      self._save_var_list[_val][3])
 
             # set up metadata group and populate variables
             def _create_meta_variable(varname, varvalue, varunits,
@@ -552,34 +553,21 @@ class init_tools(abc.ABC):
                 _v[:] = varvalue
 
             self.output_netcdf.createGroup('meta')
-            # hook to add custom metadata
-            self.hook_init_metadata()
-            # fixed metadata
-            _create_meta_variable('L0', self.L0, 'cells', vartype='i8')
-            _create_meta_variable('N0', self.N0, 'cells', vartype='i8')
-            _create_meta_variable('CTR', self.CTR, 'cells', vartype='i8')
-            _create_meta_variable('dx', self.dx, 'meters')
-            _create_meta_variable('h0', self.h0, 'meters')
-            _create_meta_variable('cell_type', self.cell_type, 'type',
-                                  vartype='i8', vardims=('length', 'width'))
-            # subsidence metadata
-            if self._toggle_subsidence:
-                _create_meta_variable('start_subsidence',
-                                      self.start_subsidence, 'seconds',
-                                      vartype='i8')
-                _create_meta_variable('sigma', self.sigma,
-                                      'meters per timestep',
-                                      vardims=('length', 'width'))
-
-            # time-varying metadata
-            _create_meta_variable('H_SL', None, 'meters',
-                                  vardims=('total_time'))
-            _create_meta_variable('f_bedload', None, 'fraction',
-                                  vardims=('total_time'))
-            _create_meta_variable('C0_percent', None, 'percent',
-                                  vardims=('total_time'))
-            _create_meta_variable('u0', None, 'meters per second',
-                                  vardims=('total_time'))
+            for _val in self._save_var_list['meta'].keys():
+                # time-varying initialize w/ None value, fixed use attribute
+                if (self._save_var_list['meta'][_val][0] is None):
+                    _create_meta_variable(
+                        _val, self._save_var_list['meta'][_val][0],
+                        self._save_var_list['meta'][_val][1],
+                        self._save_var_list['meta'][_val][2],
+                        self._save_var_list['meta'][_val][3])
+                else:
+                    _create_meta_variable(
+                        _val, getattr(self,
+                                      self._save_var_list['meta'][_val][0]),
+                        self._save_var_list['meta'][_val][1],
+                        self._save_var_list['meta'][_val][2],
+                        self._save_var_list['meta'][_val][3])
 
             _msg = 'Output netCDF file created'
             self.log_info(_msg, verbosity=2)

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -311,36 +311,12 @@ class iteration_tools(abc.ABC):
             _msg = 'Saving grids'
             self.log_info(_msg, verbosity=2)
 
-            self.hook_save_grids(save_idx)  # hook to let you save custom grids
-
-            if self._save_eta_grids:
-                self.save_grids('eta', self.eta, save_idx)
-
-            if self._save_depth_grids:
-                self.save_grids('depth', self.depth, save_idx)
-
-            if self._save_stage_grids:
-                self.save_grids('stage', self.stage, save_idx)
-
-            if self._save_discharge_grids:
-                self.save_grids('discharge', self.qw, save_idx)
-
-            if self._save_velocity_grids:
-                self.save_grids('velocity', self.uw, save_idx)
-
-            if self._save_sedflux_grids:
-                self.save_grids('sedflux', self.qs, save_idx)
-
-            if self._save_sandfrac_grids:
-                self.save_grids('sandfrac', self.sand_frac, save_idx)
-
-            if self._save_discharge_components:
-                self.save_grids('discharge_x', self.qx, save_idx)
-                self.save_grids('discharge_y', self.qy, save_idx)
-
-            if self._save_velocity_components:
-                self.save_grids('velocity_x', self.ux, save_idx)
-                self.save_grids('velocity_y', self.uy, save_idx)
+            _var_list = list(self._save_var_list.keys())
+            _var_list.remove('meta')
+            for _val in _var_list:
+                self.save_grids(_val, getattr(self,
+                                              self._save_var_list[_val][0]),
+                                save_idx)
 
         # ------------------ metadata ------------------
         if self._save_metadata:
@@ -348,13 +324,11 @@ class iteration_tools(abc.ABC):
             _msg = 'Saving metadata'
             self.log_info(_msg, verbosity=2)
 
-            self.hook_save_metadata(save_idx)  # hook to save custom metadata
-
-            self.output_netcdf['meta']['H_SL'][save_idx] = self._H_SL
-            self.output_netcdf['meta']['f_bedload'][save_idx] = self._f_bedload
-            self.output_netcdf['meta']['C0_percent'][save_idx] = \
-                self._C0_percent
-            self.output_netcdf['meta']['u0'][save_idx] = self._u0
+            for _val in self._save_var_list['meta'].keys():
+                # use knowledge of time-varying values to save them
+                if (self._save_var_list['meta'][_val][0] is None):
+                    self.output_netcdf['meta'][_val][save_idx] = \
+                        getattr(self, _val)
 
         # -------------------- sync --------------------
         if (self._save_metadata or self._save_any_grids):

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -274,52 +274,36 @@ class iteration_tools(abc.ABC):
             self.output_netcdf.variables['time'][save_idx] = self._time
 
         # ------------------ Figures ------------------
-        if self._save_any_figs:
+        if len(self._save_fig_list) > 0:
 
             _msg = 'Saving figures'
             self.log_info(_msg, verbosity=2)
 
-            if self._save_eta_figs:
-                _fe = self.make_figure('eta', self._time)
-                self.save_figure(_fe, directory=self.prefix,
-                                 filename_root='eta_',
-                                 timestep=self.save_iter)
-
-            if self._save_stage_figs:
-                _fs = self.make_figure('stage', self._time)
-                self.save_figure(_fs, directory=self.prefix,
-                                 filename_root='stage_',
-                                 timestep=self.save_iter)
-
-            if self._save_depth_figs:
-                _fh = self.make_figure('depth', self._time)
-                self.save_figure(_fh, directory=self.prefix,
-                                 filename_root='depth_',
-                                 timestep=self.save_iter)
-
-            if self._save_discharge_figs:
-                _fq = self.make_figure('qw', self._time)
-                self.save_figure(_fq, directory=self.prefix,
-                                 filename_root='discharge_',
-                                 timestep=self.save_iter)
-
-            if self._save_velocity_figs:
-                _fu = self.make_figure('uw', self._time)
-                self.save_figure(_fu, directory=self.prefix,
-                                 filename_root='velocity_',
-                                 timestep=self.save_iter)
-
-            if self._save_sedflux_figs:
-                _fu = self.make_figure('qs', self._time)
-                self.save_figure(_fu, directory=self.prefix,
-                                 filename_root='sedflux_',
-                                 timestep=self.save_iter)
-
-            if self._save_sandfrac_figs:
-                _ff = self.make_figure('sand_frac', self._time)
-                self.save_figure(_ff, directory=self.prefix,
-                                 filename_root='sandfrac_',
-                                 timestep=self.save_iter)
+            for f in self._save_fig_list:
+                _attr = getattr(self, f)
+                if isinstance(_attr, np.ndarray):
+                    if _attr.shape == (self.L, self.W):
+                        _fig = self.make_figure(f, self._time)
+                        self.save_figure(_fig, directory=self.prefix,
+                                         filename_root=f+'_',
+                                         timestep=self.save_iter)
+                    else:
+                        raise AttributeError('Attribute "{_k}" is not of the '
+                                             'right shape to be saved as a '
+                                             'figure using the built-in '
+                                             'methods. Expected a shape of '
+                                             '"{_expshp}", but it has a shape '
+                                             'of "{_wasshp}". Consider making '
+                                             'a custom plotting utility to '
+                                             'visualize this attribute.'
+                                             .format(_k=f,
+                                                     _expshp=(self.L, self.W),
+                                                     _wasshp=_attr.shape))
+                else:
+                    raise AttributeError('Only plotting of np.ndarray-type '
+                                         'attributes is natively supported. '
+                                         'Input "{_k}" was of type "{_wt}".'
+                                         .format(_k=f, _wt=type(_attr)))
 
         # ------------------ grids ------------------
         if self._save_any_grids:

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -279,11 +279,12 @@ class iteration_tools(abc.ABC):
             _msg = 'Saving figures'
             self.log_info(_msg, verbosity=2)
 
-            for f in self._save_fig_list:
-                _attr = getattr(self, f)
+            for f in self._save_fig_list.keys():
+                _attr = getattr(self, self._save_fig_list[f][0])
                 if isinstance(_attr, np.ndarray):
                     if _attr.shape == (self.L, self.W):
-                        _fig = self.make_figure(f, self._time)
+                        _fig = self.make_figure(self._save_fig_list[f][0],
+                                                self._time)
                         self.save_figure(_fig, directory=self.prefix,
                                          filename_root=f+'_',
                                          timestep=self.save_iter)
@@ -352,7 +353,6 @@ class iteration_tools(abc.ABC):
         fig : :obj:`matplotlib.figure`
             The created figure object.
         """
-
         _data = getattr(self, var)
 
         fig, ax = plt.subplots()
@@ -366,7 +366,7 @@ class iteration_tools(abc.ABC):
         cb.ax.tick_params(labelsize=7)
         ax.use_sticky_edges = False
         ax.margins(y=0.2)
-        ax.set_title(var+'\ntime: '+str(timestep), fontsize=10)
+        ax.set_title(str(var)+'\ntime: '+str(timestep), fontsize=10)
 
         return fig
 

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -311,6 +311,8 @@ class iteration_tools(abc.ABC):
             _msg = 'Saving grids'
             self.log_info(_msg, verbosity=2)
 
+            self.hook_save_grids(save_idx)  # hook to let you save custom grids
+
             if self._save_eta_grids:
                 self.save_grids('eta', self.eta, save_idx)
 
@@ -345,6 +347,8 @@ class iteration_tools(abc.ABC):
 
             _msg = 'Saving metadata'
             self.log_info(_msg, verbosity=2)
+
+            self.hook_save_metadata(save_idx)  # hook to save custom metadata
 
             self.output_netcdf['meta']['H_SL'][save_idx] = self._H_SL
             self.output_netcdf['meta']['f_bedload'][save_idx] = self._f_bedload

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -608,10 +608,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_eta_figs.setter
     def save_eta_figs(self, save_eta_figs):
-        if (save_eta_figs is True) and ('eta' not in self._save_fig_list):
-            self._save_fig_list.append('eta')
-        elif (save_eta_figs is False) and ('eta' in self._save_fig_list):
-            self._save_fig_list.remove('eta')
+        if (save_eta_figs is True) and \
+          ('eta' not in self._save_fig_list.keys()):
+            self._save_fig_list['eta'] = ['eta']
+        elif (save_eta_figs is False) and \
+          ('eta' in self._save_fig_list.keys()):
+            del self._save_fig_list['eta']
         self._save_eta_figs = save_eta_figs
 
     @property
@@ -623,10 +625,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_stage_figs.setter
     def save_stage_figs(self, save_stage_figs):
-        if (save_stage_figs is True) and ('stage' not in self._save_fig_list):
-            self._save_fig_list.append('stage')
-        elif (save_stage_figs is False) and ('stage' in self._save_fig_list):
-            self._save_fig_list.remove('stage')
+        if (save_stage_figs is True) and \
+          ('stage' not in self._save_fig_list.keys()):
+            self._save_fig_list['stage'] = ['stage']
+        elif (save_stage_figs is False) and \
+          ('stage' in self._save_fig_list.keys()):
+            del self._save_fig_list['stage']
         self._save_stage_figs = save_stage_figs
 
     @property
@@ -638,10 +642,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_depth_figs.setter
     def save_depth_figs(self, save_depth_figs):
-        if (save_depth_figs is True) and ('depth' not in self._save_fig_list):
-            self._save_fig_list.append('depth')
-        elif (save_depth_figs is False) and ('depth' in self._save_fig_list):
-            self._save_fig_list.remove('depth')
+        if (save_depth_figs is True) and \
+          ('depth' not in self._save_fig_list.keys()):
+            self._save_fig_list['depth'] = ['depth']
+        elif (save_depth_figs is False) and \
+          ('depth' in self._save_fig_list.keys()):
+            del self._save_fig_list['depth']
         self._save_depth_figs = save_depth_figs
 
     @property
@@ -653,10 +659,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_discharge_figs.setter
     def save_discharge_figs(self, save_discharge_figs):
-        if (save_discharge_figs is True) and ('qw' not in self._save_fig_list):
-            self._save_fig_list.append('qw')
-        elif (save_discharge_figs is False) and ('qw' in self._save_fig_list):
-            self._save_fig_list.remove('qw')
+        if (save_discharge_figs is True) and \
+          ('discharge' not in self._save_fig_list.keys()):
+            self._save_fig_list['discharge'] = ['qw']
+        elif (save_discharge_figs is False) and \
+          ('discharge' in self._save_fig_list):
+            del self._save_fig_list['discharge']
         self._save_discharge_figs = save_discharge_figs
 
     @property
@@ -668,10 +676,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_velocity_figs.setter
     def save_velocity_figs(self, save_velocity_figs):
-        if (save_velocity_figs is True) and ('uw' not in self._save_fig_list):
-            self._save_fig_list.append('uw')
-        elif (save_velocity_figs is False) and ('uw' in self._save_fig_list):
-            self._save_fig_list.remove('uw')
+        if (save_velocity_figs is True) and \
+          ('velocity' not in self._save_fig_list.keys()):
+            self._save_fig_list['velocity'] = ['uw']
+        elif (save_velocity_figs is False) and \
+          ('velocity' in self._save_fig_list.keys()):
+            del self._save_fig_list['sedflux']
         self._save_velocity_figs = save_velocity_figs
 
     @property
@@ -683,10 +693,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_sedflux_figs.setter
     def save_sedflux_figs(self, save_sedflux_figs):
-        if (save_sedflux_figs is True) and ('qs' not in self._save_fig_list):
-            self._save_fig_list.append('qs')
-        elif (save_sedflux_figs is False) and ('qs' in self._save_fig_list):
-            self._save_fig_list.remove('qs')
+        if (save_sedflux_figs is True) and \
+          ('sedflux' not in self._save_fig_list.keys()):
+            self._save_fig_list['sedflux'] = ['qs']
+        elif (save_sedflux_figs is False) and \
+          ('sedflux' in self._save_fig_list):
+            del self._save_fig_list['sedflux']
         self._save_sedflux_figs = save_sedflux_figs
 
     @property
@@ -700,11 +712,11 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @save_sandfrac_figs.setter
     def save_sandfrac_figs(self, save_sandfrac_figs):
         if (save_sandfrac_figs is True) and \
-          ('sand_frac' not in self._save_fig_list):
-            self._save_fig_list.append('sand_frac')
+          ('sandfrac' not in self._save_fig_list.keys()):
+            self._save_fig_list['sandfrac'] = ['sand_frac']
         elif (save_sandfrac_figs is False) and \
-          ('sand_frac' in self._save_fig_list):
-            self._save_fig_list.remove('sand_frac')
+          ('sandfrac' in self._save_fig_list):
+            del self._save_fig_list['sandfrac']
         self._save_sandfrac_figs = save_sandfrac_figs
 
     @property

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -76,7 +76,6 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._save_time_since_data = float("inf")  # force save on t==0
         self._save_iter = int(0)
         self._save_time_since_checkpoint = float("inf")  # force save on t==0
-        self._save_fig_list = []  # establish list of figure variables to save
 
         self.input_file = input_file
         _src_dir = os.path.realpath(os.path.dirname(__file__))
@@ -120,6 +119,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         else:
             # initialize the output file
             if not defer_output:
+                self.hook_init_output_file()
                 self.init_output_file()
 
                 # record initial conditions
@@ -756,6 +756,13 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_eta_grids.setter
     def save_eta_grids(self, save_eta_grids):
+        if (save_eta_grids is True) and \
+          ('eta' not in self._save_var_list.keys()):
+            self._save_var_list['eta'] = ['eta', 'meters', 'f4',
+                                          ('total_time', 'length', 'width')]
+        elif (save_eta_grids is False) and \
+          ('eta' in self._save_var_list.keys()):
+            del self._save_var_list['eta']
         self._save_eta_grids = save_eta_grids
 
     @property
@@ -767,6 +774,13 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_stage_grids.setter
     def save_stage_grids(self, save_stage_grids):
+        if (save_stage_grids is True) and \
+          ('stage' not in self._save_var_list.keys()):
+            self._save_var_list['stage'] = ['stage', 'meters', 'f4',
+                                            ('total_time', 'length', 'width')]
+        elif (save_stage_grids is False) and \
+          ('stage' in self._save_var_list.keys()):
+            del self._save_var_list['stage']
         self._save_stage_grids = save_stage_grids
 
     @property
@@ -778,6 +792,13 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_depth_grids.setter
     def save_depth_grids(self, save_depth_grids):
+        if (save_depth_grids is True) and \
+          ('depth' not in self._save_var_list.keys()):
+            self._save_var_list['depth'] = ['depth', 'meters', 'f4',
+                                            ('total_time', 'length', 'width')]
+        elif (save_depth_grids is False) and \
+          ('depth' in self._save_var_list.keys()):
+            del self._save_var_list['depth']
         self._save_depth_grids = save_depth_grids
 
     @property
@@ -789,6 +810,16 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_discharge_grids.setter
     def save_discharge_grids(self, save_discharge_grids):
+        if (save_discharge_grids is True) and \
+          ('discharge' not in self._save_var_list.keys()):
+            self._save_var_list['discharge'] = ['qw',
+                                                'cubic meters per second',
+                                                'f4',
+                                                ('total_time', 'length',
+                                                 'width')]
+        elif (save_discharge_grids is False) and \
+          ('discharge' in self._save_var_list.keys()):
+            del self._save_var_list['discharge']
         self._save_discharge_grids = save_discharge_grids
 
     @property
@@ -800,6 +831,14 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_velocity_grids.setter
     def save_velocity_grids(self, save_velocity_grids):
+        if (save_velocity_grids is True) and \
+          ('velocity' not in self._save_var_list.keys()):
+            self._save_var_list['velocity'] = ['uw', 'meters per second', 'f4',
+                                               ('total_time', 'length',
+                                                'width')]
+        elif (save_velocity_grids is False) and \
+          ('velocity' in self._save_var_list.keys()):
+            del self._save_var_list['velocity']
         self._save_velocity_grids = save_velocity_grids
 
     @property
@@ -811,6 +850,15 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_sedflux_grids.setter
     def save_sedflux_grids(self, save_sedflux_grids):
+        if (save_sedflux_grids is True) and \
+          ('sedflux' not in self._save_var_list.keys()):
+            self._save_var_list['sedflux'] = ['qs', 'cubic meters per second',
+                                              'f4',
+                                              ('total_time', 'length',
+                                               'width')]
+        elif (save_sedflux_grids is False) and \
+          ('sedflux' in self._save_var_list.keys()):
+            del self._save_var_list['sedflux']
         self._save_sedflux_grids = save_sedflux_grids
 
     @property
@@ -823,6 +871,14 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_sandfrac_grids.setter
     def save_sandfrac_grids(self, save_sandfrac_grids):
+        if (save_sandfrac_grids is True) and \
+          ('sandfrac' not in self._save_var_list.keys()):
+            self._save_var_list['sandfrac'] = ['sand_frac', 'fraction', 'f4',
+                                               ('total_time', 'length',
+                                                'width')]
+        elif (save_sandfrac_grids is False) and \
+          ('sandfrac' in self._save_var_list.keys()):
+            del self._save_var_list['sandfrac']
         self._save_sandfrac_grids = save_sandfrac_grids
 
     @property
@@ -834,6 +890,20 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_discharge_components.setter
     def save_discharge_components(self, save_discharge_components):
+        if (save_discharge_components is True):
+            if ('discharge_x' not in self._save_var_list.keys()):
+                self._save_var_list['discharge_x'] = [
+                    'qx', 'cubic meters per second', 'f4',
+                    ('total_time', 'length', 'width')]
+            if ('discharge_y' not in self._save_var_list.keys()):
+                self._save_var_list['discharge_y'] = [
+                    'qy', 'cubic meters per second', 'f4',
+                    ('total_time', 'length', 'width')]
+        elif (save_discharge_components is False):
+            if ('discharge_x' in self._save_var_list.keys()):
+                del self._save_var_list['discharge_x']
+            if ('discharge_y' in self._save_var_list.keys()):
+                del self._save_var_list['discharge_y']
         self._save_discharge_components = save_discharge_components
 
     @property
@@ -845,6 +915,20 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_velocity_components.setter
     def save_velocity_components(self, save_velocity_components):
+        if (save_velocity_components is True):
+            if ('velocity_x' not in self._save_var_list.keys()):
+                self._save_var_list['velocity_x'] = [
+                    'ux', 'meters per second', 'f4',
+                    ('total_time', 'length', 'width')]
+            if ('velocity_y' not in self._save_var_list.keys()):
+                self._save_var_list['velocity_y'] = [
+                    'uy', 'meters per second', 'f4',
+                    ('total_time', 'length', 'width')]
+        elif (save_velocity_components is False):
+            if ('velocity_x' in self._save_var_list.keys()):
+                del self._save_var_list['velocity_x']
+            if ('velocity_y' in self._save_var_list.keys()):
+                del self._save_var_list['velocity_y']
         self._save_velocity_components = save_velocity_components
 
     @property

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -76,6 +76,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._save_time_since_data = float("inf")  # force save on t==0
         self._save_iter = int(0)
         self._save_time_since_checkpoint = float("inf")  # force save on t==0
+        self._save_fig_list = []  # establish list of figure variables to save
 
         self.input_file = input_file
         _src_dir = os.path.realpath(os.path.dirname(__file__))
@@ -607,6 +608,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_eta_figs.setter
     def save_eta_figs(self, save_eta_figs):
+        if (save_eta_figs is True) and ('eta' not in self._save_fig_list):
+            self._save_fig_list.append('eta')
+        elif (save_eta_figs is False) and ('eta' in self._save_fig_list):
+            self._save_fig_list.remove('eta')
         self._save_eta_figs = save_eta_figs
 
     @property
@@ -618,6 +623,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_stage_figs.setter
     def save_stage_figs(self, save_stage_figs):
+        if (save_stage_figs is True) and ('stage' not in self._save_fig_list):
+            self._save_fig_list.append('stage')
+        elif (save_stage_figs is False) and ('stage' in self._save_fig_list):
+            self._save_fig_list.remove('stage')
         self._save_stage_figs = save_stage_figs
 
     @property
@@ -629,6 +638,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_depth_figs.setter
     def save_depth_figs(self, save_depth_figs):
+        if (save_depth_figs is True) and ('depth' not in self._save_fig_list):
+            self._save_fig_list.append('depth')
+        elif (save_depth_figs is False) and ('depth' in self._save_fig_list):
+            self._save_fig_list.remove('depth')
         self._save_depth_figs = save_depth_figs
 
     @property
@@ -640,6 +653,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_discharge_figs.setter
     def save_discharge_figs(self, save_discharge_figs):
+        if (save_discharge_figs is True) and ('qw' not in self._save_fig_list):
+            self._save_fig_list.append('qw')
+        elif (save_discharge_figs is False) and ('qw' in self._save_fig_list):
+            self._save_fig_list.remove('qw')
         self._save_discharge_figs = save_discharge_figs
 
     @property
@@ -651,6 +668,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_velocity_figs.setter
     def save_velocity_figs(self, save_velocity_figs):
+        if (save_velocity_figs is True) and ('uw' not in self._save_fig_list):
+            self._save_fig_list.append('uw')
+        elif (save_velocity_figs is False) and ('uw' in self._save_fig_list):
+            self._save_fig_list.remove('uw')
         self._save_velocity_figs = save_velocity_figs
 
     @property
@@ -662,6 +683,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_sedflux_figs.setter
     def save_sedflux_figs(self, save_sedflux_figs):
+        if (save_sedflux_figs is True) and ('qs' not in self._save_fig_list):
+            self._save_fig_list.append('qs')
+        elif (save_sedflux_figs is False) and ('qs' in self._save_fig_list):
+            self._save_fig_list.remove('qs')
         self._save_sedflux_figs = save_sedflux_figs
 
     @property
@@ -674,6 +699,12 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
     @save_sandfrac_figs.setter
     def save_sandfrac_figs(self, save_sandfrac_figs):
+        if (save_sandfrac_figs is True) and \
+          ('sand_frac' not in self._save_fig_list):
+            self._save_fig_list.append('sand_frac')
+        elif (save_sandfrac_figs is False) and \
+          ('sand_frac' in self._save_fig_list):
+            self._save_fig_list.remove('sand_frac')
         self._save_sandfrac_figs = save_sandfrac_figs
 
     @property

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -454,56 +454,56 @@ class TestSettingParametersFromYAMLFile:
                                      {'save_eta_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_depth_grids(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_depth_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_stage_grids(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_stage_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_discharge_grids(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_discharge_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_velocity_grids(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_velocity_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_sedflux_grids(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_sedflux_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_sandfrac_grids(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_sandfrac_grids': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
 
     def test_save_discharge_components(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_discharge_components': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
         assert _delta._save_discharge_components is True
 
     def test_save_velocity_components(self, tmp_path):
@@ -511,63 +511,63 @@ class TestSettingParametersFromYAMLFile:
                                      {'save_velocity_components': True})
         _delta = DeltaModel(input_file=p)
         assert _delta._save_any_grids is True
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
         assert _delta._save_velocity_components is True
 
     def test_save_eta_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_eta_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_depth_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_depth_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_stage_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_stage_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_discharge_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_discharge_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_velocity_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_velocity_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_sedflux_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_sedflux_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_sandfrac_figs(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_sandfrac_figs': True})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is True
+        assert len(_delta._save_fig_list) > 0
         assert _delta._save_any_grids is False
 
     def test_save_figs_sequential(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_figs_sequential': False})
         _delta = DeltaModel(input_file=p)
-        assert _delta._save_any_figs is False
+        assert len(_delta._save_fig_list) == 0
         assert _delta._save_any_grids is False
         assert _delta._save_figs_sequential is False
 

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -283,7 +283,7 @@ class TestSaveGridsAndFigs:
         _delta.save_figure.call_count == 0
         _delta.save_grids.call_count == 0
 
-        assert (_delta._save_any_figs is True)
+        assert (len(_delta._save_fig_list) > 0)
         assert (_delta._save_eta_figs is True)
 
         # update the delta a few times

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -272,6 +272,26 @@ class Test__init__:
         with pytest.raises(ValueError):
             _ = DeltaModel(input_file=p)
 
+    def test_badtype_figure_saving(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _model = DeltaModel(input_file=p, defer_output=True)
+        # add request to plot invalid attribute
+        _model._save_fig_list.append('beta')
+        # try to finish init
+        _model.init_output_file()
+        with pytest.raises(AttributeError):
+            _model.output_data()
+
+    def test_badshape_figure_saving(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _model = DeltaModel(input_file=p, defer_output=True)
+        # add request to plot attribute w/ invalid shape
+        _model._save_fig_list.append('inlet')
+        # try to finish init
+        _model.init_output_file()
+        with pytest.raises(AttributeError):
+            _model.output_data()
+
 
 class TestUpdate:
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -276,7 +276,7 @@ class Test__init__:
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _model = DeltaModel(input_file=p, defer_output=True)
         # add request to plot invalid attribute
-        _model._save_fig_list.append('beta')
+        _model._save_fig_list['beta'] = ['beta']
         # try to finish init
         _model.init_output_file()
         with pytest.raises(AttributeError):
@@ -286,7 +286,7 @@ class Test__init__:
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _model = DeltaModel(input_file=p, defer_output=True)
         # add request to plot attribute w/ invalid shape
-        _model._save_fig_list.append('inlet')
+        _model._save_fig_list['inlet'] = ['inlet']
         # try to finish init
         _model.init_output_file()
         with pytest.raises(AttributeError):


### PR DESCRIPTION
## Refactors figure/metadata/grid saving

This PR refactors the saving of figures, model variables, and metadata so that they are more flexible. To do this, two new model attributes are initialized during the output infrastructure initialization (`init_output_infrastructure`), `self._save_fig_list` and `self._save_var_list`, and a hook to customize the standard figures/variables being saved is provided in the form of `hook_init_output_file` that is called before the netCDF file is initialized. 

- `self._save_fig_list` holds string values indicating the grid variables for which figures should be made and saved every `save_dt` interval. There is some type and shape checking to ensure that only figures of shape `L x W` can be saved in this manner, and other string values will throw an error.
- `self._save_var_list` is actually a dictionary that holds both variable names to save, and a dictionary "meta" containing the metadata to save. Adding values to be saved is as simple as adding a dictionary entry in which the key-value is a string that becomes the name of the variable in the netCDF file with a corresponding list, `[model_attribute_name, units, type, (dimensions)]` for the non-standard model parameter being saved. 

An example of this behavior is shown via a simple model subclass below:

```
"""Non-standard saving model initialization."""

from pyDeltaRCM import DeltaModel


class SaveModel(DeltaModel):
    """Subclass to demo saving special figs/grids/data via hooks."""

    def __init__(self, input_file=None, **kwargs):
        """Add custom init to save figures of a nonstandard grid."""
        # inherit base DeltaModel methods
        super().__init__(input_file, **kwargs)

    def hook_init_output_file(self):
        """Add non-standard grids, figures and metadata to be saved."""
        # save a figure of the active layer each save_dt
        self._save_fig_list.append('active_layer')
        # save the active layer grid each save_dt w/ wacky name
        self._save_var_list['ACT_lay'] = ['active_layer', 'fraction', 'f4',
                                          ('total_time', 'length', 'width')]
        # save number of water parcels w/ a cool name too
        self._save_var_list['meta']['water_parcels'] = ['Np_water', 'parcels',
                                                        'i8', ()]


# implement and run this model
model = SaveModel(input_file='base_run.yaml')
for _ in range(0, 50):
    model.update()

model.finalize()
```

before merge need to:

- [x] update list of hooks in docs to include new ones added by this pr
- [x] consider adding the above subclass or something similar to documentation as an example?

This PR aims to close #153.