### PR TITLE
Bugfixes

### DIFF
--- a/docs/source/examples/custom_saving.rst
+++ b/docs/source/examples/custom_saving.rst
@@ -27,53 +27,54 @@ The expected value for a given key is a list containing strings indicating the m
 An example of using the hook and creating a model subclass to customize the figures, gridded variables, and metadata being saved is provided below.
 
 .. doctest::
-    :context: reset
-    :include-source:
 
-    class CustomSaveModel(pyDeltaRCM.DeltaModel):
-        """A subclass of DeltaModel to save custom figures and variables.
+    >>> import pyDeltaRCM
 
-        This subclass modifies the list of variables and figures used to
-        initialize the netCDF file and save figures and grids before the
-        output file is setup and initial conditions are plotted.
-        """
-        def __init__(self, input_file=None, **kwargs):
-
-             # inherit base DeltaModel methods
-            super().__init__(input_file, **kwargs)
-
-        def hook_init_output_file(self):
-            """Add non-standard grids, figures and metadata to be saved."""
-            # save a figure of the active layer each save_dt
-            self._save_fig_list['active_layer'] = ['active_layer']
-
-            # save the active layer grid each save_dt w/ a short name
-            self._save_var_list['actlay'] = ['active_layer', 'fraction', 'f4',
-                                             ('total_time', 'length', 'width')]
-            # save number of water parcels w/ a long name
-            self._save_var_list['meta']['water_parcels'] = ['Np_water',
-                                                            'parcels',
-                                                            'i8', ()]
+    >>> class CustomSaveModel(pyDeltaRCM.DeltaModel):
+    ...     """A subclass of DeltaModel to save custom figures and variables.
+    ...
+    ...     This subclass modifies the list of variables and figures used to
+    ...     initialize the netCDF file and save figures and grids before the
+    ...     output file is setup and initial conditions are plotted.
+    ...     """
+    ...     def __init__(self, input_file=None, **kwargs):
+    ...
+    ...         # inherit base DeltaModel methods
+    ...         super().__init__(input_file, **kwargs)
+    ...
+    ...     def hook_init_output_file(self):
+    ...         """Add non-standard grids, figures and metadata to be saved."""
+    ...         # save a figure of the active layer each save_dt
+    ...         self._save_fig_list['active_layer'] = ['active_layer']
+    ...
+    ...         # save the active layer grid each save_dt w/ a short name
+    ...         self._save_var_list['actlay'] = ['active_layer', 'fraction',
+    ...                                          'f4', ('total_time',
+    ...                                                 'length', 'width')]
+    ...
+    ...         # save number of water parcels w/ a long name
+    ...         self._save_var_list['meta']['water_parcels'] = ['Np_water',
+    ...                                                         'parcels',
+    ...                                                         'i8', ()]
 
 Next, we instantiate the model class.
 
 .. code::
 
-    mdl = CustomSaveModel()
+    >>> mdl = CustomSaveModel()
 
 
 .. doctest::
-    :context:
+    :hide:
 
-    with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
-        mdl = CustomSaveModel(out_dir=output_dir)
+    >>> with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    ...     mdl = CustomSaveModel(out_dir=output_dir)
 
 
 This subclass has added the active layer as a figure and a grid to be saved, as well as the number of water parcels as metadata to be saved.
 For simplicity we will just check that the appropriate parameters were added to the save figure and save variable lists, however please feel free to give this example a try on your local machine and examine the output figures and netCDF file.
 
 .. doctest::
-    :context:
 
     >>> 'active_layer' in mdl._save_fig_list
     True
@@ -82,15 +83,4 @@ For simplicity we will just check that the appropriate parameters were added to 
     {'active_layer': ['active_layer']}
 
     >>> print(mdl._save_var_list)
-    {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'ACT_lay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}
-
-.. code::
-
-    >>> 'active_layer' in mdl._save_fig_list
-    True
-
-    >>> print(mdl._save_fig_list)
-    {'active_layer': ['active_layer']}
-
-    >>> print(mdl._save_var_list)
-    {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'ACT_lay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}
+    {'meta': {'water_parcels': ['Np_water', 'parcels', 'i8', ()]}, 'actlay': ['active_layer', 'fraction', 'f4', ('total_time', 'length', 'width')]}

--- a/docs/source/reference/water_tools/index.rst
+++ b/docs/source/reference/water_tools/index.rst
@@ -13,7 +13,7 @@ During each of these iterations of the water routing, the following methods are 
 
 .. autosummary::
 
-    water_tools.init_water_iteration
+  water_tools.init_water_iteration
 	water_tools.run_water_iteration
 	water_tools.compute_free_surface
 	water_tools.finalize_water_iteration
@@ -22,7 +22,7 @@ During each of these iterations of the water routing, the following methods are 
 Public API methods attached to model
 ------------------------------------
 
-The following methods are defined in the ``water_tools`` class, of the ``pyDeltaRCM.water_tools`` module. 
+The following methods are defined in the ``water_tools`` class, of the ``pyDeltaRCM.water_tools`` module.
 
 .. autosummary::
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -187,7 +187,7 @@ class init_tools(abc.ABC):
         self.log_info(_msg, verbosity=0)
 
     def set_constants(self):
-
+        """Set the model constants."""
         _msg = 'Setting model constants'
         self.log_info(_msg, verbosity=1)
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -687,6 +687,17 @@ class init_tools(abc.ABC):
                 self._save_iter = int(0)
                 self.init_output_file()
             else:
+                # check if file is open in another process, if so throw error
+                try:
+                    _dataset = Dataset(file_path, 'r+', format='NETCDF')
+                    _dataset.close()  # if this worked then close it
+                except OSError:
+                    raise RuntimeError(
+                        'Could not open the NetCDF file for checkpointing. '
+                        'This could be because the file is corrupt, or open '
+                        'in another interpreter. Be sure to close any '
+                        'connections to the file before proceeding.')
+                # if not open elsewhere, then proceed
                 # rename the old netCDF4 file
                 _msg = 'Renaming old NetCDF4 output file'
                 self.log_info(_msg, verbosity=2)

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -896,7 +896,7 @@ class PreprocessorCLI(BasePreprocessor):
         cli_dict = self.process_arguments()
 
         # process the input file to a dictionary (or empty if none)
-        if 'config' in cli_dict.keys():
+        if cli_dict['config'] is not None:
             input_file = cli_dict['config']
             yaml_dict = self.open_input_file_to_dict(input_file)
             self._input_file = input_file  # fill field

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -509,7 +509,10 @@ class water_tools(abc.ABC):
 @njit
 def _get_weight_at_cell_water(ind, weight_sfc, weight_int, depth_nbrs, ct_nbrs,
                               dry_depth, gamma, theta):
+    """Compute water weights for a given cell.
 
+    This is a jitted function called by :func:`_get_water_weight_array`.
+    """
     # create a fixed set of bools
     dry = (depth_nbrs < dry_depth)
     wall = (ct_nbrs == -2)


### PR DESCRIPTION
### Just a bunch of bugfixes

1. Drops `:plot::` directives in the custom saving example and properly sets up the `:doctest::` directives... Closes #181 

2. Small change to preprocessor so the correct error is thrown when `pyDeltaRCM` is called from the command line without any arguments. Now the error message thrown if you call `>>> pyDeltaRCM` without any arguments is `ValueError: You must specify a run duration configuration in either the input YAML file or via input arguments.` Which is the one we want, so this closes #175 

3. Adds some small doc-strings so that all of our functions now have at least something in the doc-string (#3). 

4. <s>Adds integration test that attempts to cover behavior described in #100. Checkpoint netCDF file pathway has been refactored since that issue, and so I wasn't getting the same error in the integration test. Possibly because now the old netCDF is renamed (so the object isn't messed with), and a new netCDF file is created. Will leave the issue open until we're sure this is no longer a problem.</s>  So the issue is more nuanced than I originally thought. Linux/MacOS seem to be fine with multiple objects referencing a single `.nc` file so long as these references are in the same Python process which is why my new test does not throw any errors. Windows on the other hand will cough up a `PermissionError` if you try to access the same `.nc` file multiple times (which I actually think is better). The problem documented in #100 relates to different Python processes trying to access the same `.nc` file. So I've added the suggested check to try opening the file and raising a `RuntimeError` if it cannot be done. I've tested this locally and found that it works, however I haven't written a test that spins up a separate Python process to duplicate this behavior. Kind of a pain, but will leave the issue open until a proper test is written to confirm the expected error message behavior.