### PR TITLE
Add a missing call to the init_output_file hook

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -685,6 +685,7 @@ class init_tools(abc.ABC):
                 # create a new file
                 # reset output file counters
                 self._save_iter = int(0)
+                self.hook_init_output_file()
                 self.init_output_file()
             else:
                 # rename the old netCDF4 file


### PR DESCRIPTION
Simple addition of a call to the hook (`hook_init_output_file`) resolves the issue of custom fields not being able to be added to resumed model runs.