### PR TITLE
Overwrite 'n save

### DIFF
--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -110,6 +110,8 @@ Output Settings
 
 :attr:`pyDeltaRCM.model.DeltaModel.resume_checkpoint`
 
+:attr:`pyDeltaRCM.model.DeltaModel.clobber_netcdf`
+
 
 Reduced-Complexity Routing Parameters
 =====================================

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -175,3 +175,6 @@ stepmax:
 sand_frac_bc:
   type: ['float', 'int']
   default: 0
+clobber_netcdf:
+  type: 'bool'
+  default: False

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -451,7 +451,8 @@ class init_tools(abc.ABC):
 
         Fills with default variables.
 
-        .. warning:: Overwrites an existing netcdf file with the same name.
+        .. warning:: Overwrites an existing netcdf file with the same name if
+        :attr:`pyDeltaRCM.model.DeltaModel.clobber_netcdf` is True
 
         """
         _msg = 'Initializing output NetCDF4 file'
@@ -498,7 +499,12 @@ class init_tools(abc.ABC):
                 file=file_path)
             self.log_info(_msg, verbosity=2)
 
-            if os.path.exists(file_path):
+            if (os.path.exists(file_path)) and \
+                    (self._clobber_netcdf is False):
+                raise FileExistsError(
+                    'Existing NetCDF4 output file in target output location.')
+            elif (os.path.exists(file_path)) and \
+                    (self._clobber_netcdf is True):
                 _msg = 'Replacing existing netCDF file'
                 self.logger.warning(_msg)
                 warnings.warn(UserWarning(_msg))

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1217,6 +1217,23 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._stepmax = stepmax
 
     @property
+    def clobber_netcdf(self):
+        """
+        Allows overwriting (clobbering) of an existing netCDF output file.
+
+        Default behavior, clobber_netcdf: False, is for the model to raise an
+        error during initialization if a netCDF output file is found in the
+        location specified by :attr:`out_dir`. If the clobber_netcdf parameter
+        is instead set to True, then if there is an existing netCDF output file
+        in the target folder, it will be "clobbered" or overwritten.
+        """
+        return self._clobber_netcdf
+
+    @clobber_netcdf.setter
+    def clobber_netcdf(self, clobber_netcdf):
+        self._clobber_netcdf = clobber_netcdf
+
+    @property
     def time(self):
         """Elapsed model time in seconds.
         """

--- a/tests/integration/test_consistent_outputs.py
+++ b/tests/integration/test_consistent_outputs.py
@@ -124,14 +124,14 @@ class TestConsistentOutputsBetweenMerges:
         delta.finalize()
 
 
-class TestModelIsReprodicible:
+class TestModelIsReproducible:
 
     def test_same_result_two_models(self, tmp_path):
         """Test consistency of two models initialized from same yaml."""
-        p1 = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+        p1 = utilities.yaml_from_dict(tmp_path, 'input_1.yaml',
                                       {'out_dir': tmp_path / 'out_dir_1',
                                        'seed': 10, 'save_sandfrac_grids': True})
-        p2 = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+        p2 = utilities.yaml_from_dict(tmp_path, 'input_2.yaml',
                                       {'out_dir': tmp_path / 'out_dir_2',
                                        'seed': 10, 'save_sandfrac_grids': True})
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -304,17 +304,20 @@ class Test__init__:
                                      {'clobber_netcdf': True,
                                       'save_eta_grids': True})
         _model_1 = DeltaModel(input_file=p)
+        _model_1.output_netcdf.close()
         # assert that model could have clobbered a netcdf
         assert _model_1._clobber_netcdf is True
         # make a second model which clobbers, raising eyebrows (and warning)
         with pytest.warns(UserWarning):
             _model_2 = DeltaModel(input_file=p)
+        _model_2.output_netcdf.close()
         assert _model_2._clobber_netcdf is True
 
     def test_no_clobber_error(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'save_eta_grids': True})
         _model_1 = DeltaModel(input_file=p)
+        _model_1.output_netcdf.close()
         # assert that model could not have clobbered a netcdf
         assert _model_1._clobber_netcdf is False
         # make a second model which raises error

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -292,6 +292,35 @@ class Test__init__:
         with pytest.raises(AttributeError):
             _model.output_data()
 
+    def test_clobber_netcdf(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'clobber_netcdf': True})
+        _model = DeltaModel(input_file=p)
+        # assert that model could have clobbered a netcdf
+        assert _model._clobber_netcdf is True
+
+    def test_clobbering(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'clobber_netcdf': True,
+                                      'save_eta_grids': True})
+        _model_1 = DeltaModel(input_file=p)
+        # assert that model could have clobbered a netcdf
+        assert _model_1._clobber_netcdf is True
+        # make a second model which clobbers, raising eyebrows (and warning)
+        with pytest.warns(UserWarning):
+            _model_2 = DeltaModel(input_file=p)
+        assert _model_2._clobber_netcdf is True
+
+    def test_no_clobber_error(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_eta_grids': True})
+        _model_1 = DeltaModel(input_file=p)
+        # assert that model could not have clobbered a netcdf
+        assert _model_1._clobber_netcdf is False
+        # make a second model which raises error
+        with pytest.raises(FileExistsError):
+            _ = DeltaModel(input_file=p)
+
 
 class TestUpdate:
 

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -45,7 +45,7 @@ def yaml_from_dict(tmp_path, file_name, _dict=None):
     p, f = create_temporary_file(tmp_path, file_name)
     if (_dict is None):
         _dict = {'out_dir': tmp_path / 'out_dir'}
-    else:
+    elif ('out_dir' not in _dict.keys()):
         _dict['out_dir'] = tmp_path / 'out_dir'
 
     for k in _dict.keys():


### PR DESCRIPTION
## PR to modify overwriting <s>and checkpoint saving</s> behavior

PR does <s>2</s> 1 thing<s>s</s>.

1. Adds `clobber_netcdf` as a yaml parameter with default behavior set to False. This parameter controls whether or not an existing pyDeltaRCM output file will be overwritten if a new model is initialized with the same `out_dir`. Currently we overwrite the old file and spit out a warning. Proposed default behavior raises an error before overwriting an existing file, but existing behavior can still be had (maybe useful for prototyping or testing when the same model is being initialized a bunch) by setting `clobber_netcdf` to True. Closes #184.

Edited to just make clobbering an optional parameter. Didn't want to over-complicate saving logic.

<s>2. <s>Current checkpointing behavior requires `save_checkpoint` to be explicitly set to True in order to save any checkpointing information. My opinion is that if one bothers specifying `checkpoint_dt` as a number in the yaml, then `save_checkpoint` should automatically flip to True if it wasn't already. That is just my opinion, so feel free to disagree... this would close 185.</s> Changed this to cover really the two scenarios in "conflict". 
 
The first is when `save_checkpoint: False` and `checkpoint_dt = #`. This scenario may arise when the user actually intends for a checkpoint to be saved with `checkpoint_dt` but did not actually specify `save_checkpoint` and so it took on its default value of `False`. Proposed change does not change the value of parameters but provides a warning to the user to let them know that a `checkpoint_dt` value has been specified but checkpointing is turned off.

The second is when `save_checkpoint: True` and `checkpoint_dt` is not specified. In that case, the user wishes to save a checkpoint but has not specified the frequency at which they want to save it. When this happens, we revert to the previous behavior and set `checkpoint_dt = save_dt`, but now a warning is supplied to the user telling them that this is happening. Before we did this without notifying the user or recording it...</s>