### PR TITLE
Feature: implement ensemble expansion with set expansion

### DIFF
--- a/docs/source/guides/advanced_configuration_guide.inc
+++ b/docs/source/guides/advanced_configuration_guide.inc
@@ -95,8 +95,8 @@ The above configuration file would produce 6 model runs, 3 with a basin depth (`
 Set expansion
 -------------
 
-Set expansion enables user-configured parameter sets to take advantage of the :obj:`~pyDeltaRCM.Preprocessor` infrastructure (such as the job output preparation and ability to run jobs in parallel), while also enabling flexible configurations for parameter sets than cannot be configured via `matrix` expansion.
-For example, to vary `Qw0` while holding `Qs0` fixed requires modifying both `C0_percent` and some water-discharge-controlling parameter *simultaneously*; i.e., this cannot be achieved with `matrix` expansion. 
+Set expansion enables user-configured parameter sets to take advantage of the :obj:`~pyDeltaRCM.Preprocessor` infrastructure (such as the job output preparation and ability to run jobs in parallel), while also enabling flexible configurations for parameter sets that cannot be configured via `matrix` expansion.
+For example, to vary `Qw0` while holding `Qs0` fixed requires modifying both `C0_percent` and some water-discharge-controlling parameter *simultaneously*; this cannot be achieved with `matrix` expansion. 
 
 To use set expansion, add the `set` key to a configuration file, and define a *list* of *dictionaries* which set the parameters of each run to be completed.
 For example, to configure two model runs, the first with parameters ``u0: 1.0`` and ``h0: 1.0``, and the second with parameters ``u0: 1.2`` and ``h0: 1.2``:
@@ -109,7 +109,11 @@ For example, to configure two model runs, the first with parameters ``u0: 1.0`` 
 
 
 All jobs in the `set` specification must have the exact same set of keys.
-Moreover, additional `ensemble` or `matrix` specifications are not supported with the `set` specification. 
+
+.. note::
+    
+    Set expansion works with `ensemble` expansion, whereby each item in the `set` list is replicated `ensemble` number of times (with varied seed).
+    Note that, `matrix` specification is not supported with the `set` specification. 
 
 
 Customizing model operations with subclasses and hooks

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -270,12 +270,10 @@ class BasePreprocessor(abc.ABC):
 
             # here we augment each set by duplicating and add seed
             new_set = []  # new set list
-            for i in range(len(old_set)):
-                # extract the ith set
-                ith_old_set = old_set[i]
+            for ith_old_set in old_set:
 
                 # loop through the number of ensembles
-                for j in range(n_ensembles):
+                for _ in range(n_ensembles):
                     # make a copy of the ith
                     jth_new_set = ith_old_set.copy()
 


### PR DESCRIPTION
Previously we did not support specifying any other options along with the "set" specification in the preprocessor.

This PR implements ensemble support for set specification. This is achieved similarly to ensemble expansion for a matrix, where separate seeds are specified for each case. Here, however, we simply create a N copies of each set item, where `ensemble: N`, and a separate seed is specified for each replicate of each set.

Adds simple test to cover this case.