### PR TITLE
working implementation for decoupled basin depth from inlet channel depth

### DIFF
--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -44,6 +44,8 @@ Model Domain Parameters
 
 :attr:`pyDeltaRCM.model.DeltaModel.h0`
 
+:attr:`pyDeltaRCM.model.DeltaModel.hb`
+
 :attr:`pyDeltaRCM.model.DeltaModel.H_SL`
 
 :attr:`pyDeltaRCM.model.DeltaModel.SLR`

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -37,6 +37,9 @@ N0_meters:
 h0:
   type: ['float', 'int']
   default: 5.0
+hb:
+  type: ['float', 'int', 'None']
+  default: null
 H_SL:
   type: ['float', 'int']
   default: 0.0

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -73,7 +73,6 @@ class init_tools(abc.ABC):
         self.log_info('Platform: {}'.format(platform.platform()),
                       verbosity=0)  # log the os
 
-
     def import_files(self, kwargs_dict={}):
         """Import the input files.
 
@@ -306,6 +305,9 @@ class init_tools(abc.ABC):
         self.Qs0 = self.Qw0 * self.C0  # sediment total input discharge
         self.Vp_sed = self.dVs / self._Np_sed  # volume of each sediment parcel
 
+        # determine the value for the basin depth
+        self._hb = self.hb or self.h0
+
         # max number of jumps for parcel
         if self.stepmax is None:
             self.stepmax = 2 * (self.L + self.W)
@@ -397,7 +399,7 @@ class init_tools(abc.ABC):
                          self._dx * self._S0)
         self.stage[self.cell_type == cell_ocean] = 0.
 
-        self.depth[self.cell_type == cell_ocean] = self.h0
+        self.depth[self.cell_type == cell_ocean] = self.hb
         self.depth[self.cell_type == cell_channel] = self.h0
 
         self.qx[self.cell_type == cell_channel] = self.qw0

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -601,6 +601,7 @@ class init_tools(abc.ABC):
         self._save_var_list['meta']['CTR'] = ['CTR', 'cells', 'i8', ()]
         self._save_var_list['meta']['dx'] = ['dx', 'meters', 'f4', ()]
         self._save_var_list['meta']['h0'] = ['h0', 'meters', 'f4', ()]
+        self._save_var_list['meta']['hb'] = ['hb', 'meters', 'f4', ()]
         self._save_var_list['meta']['cell_type'] = ['cell_type',
                                                     'type', 'i8',
                                                     ('length', 'width')]

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -441,6 +441,22 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self._h0 = h0
 
     @property
+    def hb(self):
+        """
+        hb is the basin depth in meters.
+
+        hb is the basin depth in meters. This parameter must be an *integer*
+        or *float*, or *None*. If no value is supplied for this parameter,
+        then the value of h0 is used to determine the basin depth (i.e., they
+        are the same).
+        """
+        return self._hb
+
+    @hb.setter
+    def hb(self, hb):
+        self._hb = hb
+
+    @property
     def H_SL(self):
         """
         H_SL sets the sea level elevation in meters.

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -1127,7 +1127,10 @@ def _write_yaml_config_to_file(_config, _path):
     """
     def _write_parameter_to_file(f, varname, varvalue):
         """Write each line, formatted."""
-        f.write(varname + ': ' + str(varvalue) + '\n')
+        if varvalue is None:
+            f.write(varname + ': ' + 'null' + '\n')
+        else:
+            f.write(varname + ': ' + str(varvalue) + '\n')
 
     f = open(_path, "a")
     for k in _config.keys():

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -403,6 +403,37 @@ class TestSettingParametersFromYAMLFile:
         _delta = DeltaModel(input_file=p)
         assert _delta.itermax == 6
 
+    def test_h0(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'h0': 7.5})
+        _delta = DeltaModel(input_file=p)
+        assert _delta.h0 == 7.5
+
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'h0': int(7)})
+        _delta = DeltaModel(input_file=p)
+        assert _delta.h0 == 7
+
+    def test_hb(self, tmp_path):
+        # take default from h0 if not given:
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'h0': 7.5})
+        _delta = DeltaModel(input_file=p)
+        assert _delta.h0 == 7.5
+        assert _delta.hb == 7.5
+
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'hb': 7.5})
+        _delta = DeltaModel(input_file=p)
+        assert _delta.h0 == 5
+        assert _delta.hb == 7.5
+
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'hb': int(7)})
+        _delta = DeltaModel(input_file=p)
+        assert _delta.h0 == 5
+        assert _delta.hb == 7
+
     def test_Nsmooth(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml', {'Nsmooth': 6})
         _delta = DeltaModel(input_file=p)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1156,6 +1156,94 @@ class TestParallelJob:
         pj.deltamodel.logger.exception.assert_called_once()
 
 
+class TestWriteYamlConfigToFile:
+
+    def test_write_single_int(self, tmp_path):
+        # set up what to write
+        file_path = tmp_path / 'output.yml'
+        yaml_dict = {'variable': 1}
+
+        # write the file
+        preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
+
+        with open(file_path) as f:
+            _returned = ' '.join(f.readlines())
+
+        assert _returned == 'variable: 1\n'
+
+    def test_write_single_float(self, tmp_path):
+        # set up what to write
+        file_path = tmp_path / 'output.yml'
+        yaml_dict = {'variable': 1.5}
+
+        # write the file
+        preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
+
+        with open(file_path) as f:
+            _returned = ' '.join(f.readlines())
+
+        assert _returned == 'variable: 1.5\n'
+
+    def test_write_single_string(self, tmp_path):
+        # set up what to write
+        file_path = tmp_path / 'output.yml'
+        yaml_dict = {'variable': 'a string'}
+
+        # write the file
+        preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
+
+        with open(file_path) as f:
+            _returned = ' '.join(f.readlines())
+
+        assert _returned == 'variable: a string\n'
+
+    def test_write_single_bool(self, tmp_path):
+        # set up what to write
+        file_path = tmp_path / 'output.yml'
+        yaml_dict = {'variable': False}
+
+        # write the file
+        preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
+
+        with open(file_path) as f:
+            _returned = ' '.join(f.readlines())
+
+        assert _returned == 'variable: False\n'
+
+    def test_write_single_null(self, tmp_path):
+        # set up what to write
+        file_path = tmp_path / 'output.yml'
+        yaml_dict = {'variable': None}
+
+        # write the file
+        preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
+
+        with open(file_path) as f:
+            _returned = ' '.join(f.readlines())
+
+        assert _returned == 'variable: null\n'
+
+    def test_write_multiple_one_each(self, tmp_path):
+        # set up what to write
+        file_path = tmp_path / 'output.yml'
+        yaml_dict = {'variable1': 1,
+                     'variable2': 2.2,
+                     'variable3': 'a string',
+                     'variable4': False,
+                     'variable5': None}
+
+        # write the file
+        preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
+
+        with open(file_path) as f:
+            _returned = ' '.join(f.readlines())
+        print(_returned)
+
+        assert _returned == ('variable1: 1\n variable2: 2.2\n '
+                             'variable3: a string\n variable4: False\n '
+                             'variable5: null\n')
+
+
 class TestPreprocessorImported:
 
     def test_Preprocessor_toplevelimport(self):


### PR DESCRIPTION
This pull request implements a sort-of undocumented feature of the original matlab implementation and concept that was described in the Liang 2016 paper. Decoupled basin depth from inlet depth [[link to code here]](https://github.com/DeltaRCM/DeltaRCM/blob/1561c5c9e9911c22382560143e055216be31acb1/DeltaRCM_BASE.m#L43). 

The actual implementation was really simple. Basically the ocean cells just take the value from `self.hb` instead of the value from `self.h0`. The default parameter for `hb` is None, which reverts to using the inlet channel depth for the basin depth; thus, this is a non-breaking change.

The appeal here is to be able to vary the basin depth across runs while holding the boundary conditions at the inlet fixed. This could kind of be achieved by manually constructing a `set` for expansion that fixed a determined boundary condition (e.g., Qs), but you always changed the basin depth too. This allows that basin depth to be decoupled.

```yaml
matrix:
  hb:
    - 5
    - 3
    - 7
```

![image](https://user-images.githubusercontent.com/8801322/115810067-e2d44380-a3b2-11eb-9bdd-acc7f91703da.png)


TODO:

- [x] tests
- [x] docs