### PR TITLE
Fix checkpoint metadata handling

### DIFF
--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -472,33 +472,7 @@ class init_tools(abc.ABC):
 
         # set standard/default metadata values in the dict structure
         if self._save_metadata:
-            # fixed metadata
-            self._save_var_list['meta']['L0'] = ['L0', 'cells', 'i8', ()]
-            self._save_var_list['meta']['N0'] = ['N0', 'cells', 'i8', ()]
-            self._save_var_list['meta']['CTR'] = ['CTR', 'cells', 'i8', ()]
-            self._save_var_list['meta']['dx'] = ['dx', 'meters', 'f4', ()]
-            self._save_var_list['meta']['h0'] = ['h0', 'meters', 'f4', ()]
-            self._save_var_list['meta']['cell_type'] = ['cell_type',
-                                                        'type', 'i8',
-                                                        ('length', 'width')]
-            # subsidence metadata
-            if self._toggle_subsidence:
-                self._save_var_list['meta']['start_subsidence'] = [
-                    'start_subsidence', 'seconds', 'i8', ()
-                ]
-                self._save_var_list['meta']['sigma'] = [
-                    'sigma', 'meters per timestep', 'f4',
-                    ('length', 'width')
-                ]
-            # time-varying metadata
-            self._save_var_list['meta']['H_SL'] = [None, 'meters', 'f4',
-                                                   ('total_time')]
-            self._save_var_list['meta']['f_bedload'] = [None, 'fraction',
-                                                        'f4', ('total_time')]
-            self._save_var_list['meta']['C0_percent'] = [None, 'percent',
-                                                         'f4', ('total_time')]
-            self._save_var_list['meta']['u0'] = [None, 'meters per second',
-                                                 'f4', ('total_time')]
+            self.init_metadata_list()
 
         if (self._save_metadata or
                 self._save_any_grids):
@@ -607,6 +581,39 @@ class init_tools(abc.ABC):
             self.subsidence_mask[:self.L0, :] = False
 
             self.sigma = self.subsidence_mask * self._subsidence_rate * self.dt
+
+    def init_metadata_list(self):
+        """Populate the list of metadata information.
+
+        Sets up the dictionary object for the standard metadata.
+        """
+        # fixed metadata
+        self._save_var_list['meta']['L0'] = ['L0', 'cells', 'i8', ()]
+        self._save_var_list['meta']['N0'] = ['N0', 'cells', 'i8', ()]
+        self._save_var_list['meta']['CTR'] = ['CTR', 'cells', 'i8', ()]
+        self._save_var_list['meta']['dx'] = ['dx', 'meters', 'f4', ()]
+        self._save_var_list['meta']['h0'] = ['h0', 'meters', 'f4', ()]
+        self._save_var_list['meta']['cell_type'] = ['cell_type',
+                                                    'type', 'i8',
+                                                    ('length', 'width')]
+        # subsidence metadata
+        if self._toggle_subsidence:
+            self._save_var_list['meta']['start_subsidence'] = [
+                'start_subsidence', 'seconds', 'i8', ()
+            ]
+            self._save_var_list['meta']['sigma'] = [
+                'sigma', 'meters per timestep', 'f4',
+                ('length', 'width')
+            ]
+        # time-varying metadata
+        self._save_var_list['meta']['H_SL'] = [None, 'meters', 'f4',
+                                               ('total_time')]
+        self._save_var_list['meta']['f_bedload'] = [None, 'fraction',
+                                                    'f4', ('total_time')]
+        self._save_var_list['meta']['C0_percent'] = [None, 'percent',
+                                                     'f4', ('total_time')]
+        self._save_var_list['meta']['u0'] = [None, 'meters per second',
+                                             'f4', ('total_time')]
 
     def load_checkpoint(self, defer_output=False):
         """Load the checkpoint from the .npz file.
@@ -722,6 +729,10 @@ class init_tools(abc.ABC):
                 # write dims / attributes / variables to new netCDF file
                 _msg = 'Creating NetCDF4 output file'
                 self.log_info(_msg, verbosity=2)
+
+                # populate default metadata list
+                if self._save_metadata:
+                    self.init_metadata_list()
 
                 # copy data from old netCDF4 into new one
                 with Dataset(_tmp_name) as src, Dataset(file_path, 'w',

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -169,6 +169,7 @@ class TestCheckpointingIntegrations:
         assert 'sandfrac' in out_vars
 
         # check attributes of variables
+        import pdb; pdb.set_trace()
         assert output['time'][0].tolist() == 0.0
         assert output['time'][-1] == resumeModel.time
         assert output['time'][-1].tolist() == resumeModel._dt * \
@@ -178,6 +179,17 @@ class TestCheckpointingIntegrations:
         assert output['depth'][-1].shape == resumeModel.eta.shape
         assert output['discharge'][-1].shape == resumeModel.eta.shape
         assert output['sandfrac'][-1].shape == resumeModel.eta.shape
+        # check the metadata
+        assert output['meta']['L0'][:] == resumeModel.L0
+        assert output['meta']['N0'][:] == resumeModel.N0
+        assert output['meta']['CTR'][:] == resumeModel.CTR
+        assert output['meta']['dx'][:] == resumeModel.dx
+        assert output['meta']['h0'][:] == resumeModel.h0
+        assert np.all(output['meta']['cell_type'][:] == resumeModel.cell_type)
+        assert output['meta']['H_SL'][-1].data == resumeModel.H_SL
+        assert output['meta']['f_bedload'][-1].data == resumeModel.f_bedload
+        assert output['meta']['C0_percent'][-1].data == resumeModel.C0_percent
+        assert output['meta']['u0'][-1].data == resumeModel.u0
 
         # checkpoint interval aligns w/ timestep dt so these should match
         assert output['time'][-1].tolist() == resumeModel.time

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -169,7 +169,6 @@ class TestCheckpointingIntegrations:
         assert 'sandfrac' in out_vars
 
         # check attributes of variables
-        import pdb; pdb.set_trace()
         assert output['time'][0].tolist() == 0.0
         assert output['time'][-1] == resumeModel.time
         assert output['time'][-1].tolist() == resumeModel._dt * \

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -187,7 +187,8 @@ class TestCheckpointingIntegrations:
         assert np.all(output['meta']['cell_type'][:] == resumeModel.cell_type)
         assert output['meta']['H_SL'][-1].data == resumeModel.H_SL
         assert output['meta']['f_bedload'][-1].data == resumeModel.f_bedload
-        assert output['meta']['C0_percent'][-1].data == resumeModel.C0_percent
+        assert pytest.approx(float(output['meta']['C0_percent'][-1].data) ==
+                             resumeModel.C0_percent)
         assert output['meta']['u0'][-1].data == resumeModel.u0
 
         # checkpoint interval aligns w/ timestep dt so these should match


### PR DESCRIPTION
Band-aid for #194.

This problem in #194 was that the list (`self._save_var_list['meta']`) was not being properly re-created when a run was being resumed from a checkpoint. I think there could be a more elegant solution than what I have implemented here, but I also think our model initialization structure and pathways could be refactored to clean things up and add more hooks to cover different scenarios (many of which are likely related to initial conditions). 

This PR breaks out the metadata list creation from `init_output_file()` and puts it into its own function, `init_metadata_list()`. This new function is called during `init_output_file()`, but now it is also called during the loading of checkpoint data if metadata is supposed to be saved.

All that being said, I think we can close #194 as that particular issue has been resolved and this fix does work. Making this "cleaner" via a refactor broadly fits within #103 I think.