### PR TITLE
Refactor seq

### DIFF
--- a/docs/source/examples/variable_bedload.rst
+++ b/docs/source/examples/variable_bedload.rst
@@ -20,7 +20,7 @@ The following codes produce two runs (using `matrix` expansion from the Preproce
             self._changed = False
             self._changed_back = False
 
-        def hook_run_one_timestep(self):
+        def hook_solve_water_and_sediment_timestep(self):
             """Change the state depending on the _time.
             """
             # check if the state has been changed, and time to change it
@@ -85,8 +85,8 @@ Here, we will change the model time value directly, so that we can verify that t
         mdl_sandy._time = _time  # you should never do this
 
         # run the hooked method
-        mdl_muddy.hook_run_one_timestep()
-        mdl_sandy.hook_run_one_timestep()
+        mdl_muddy.hook_solve_water_and_sediment_timestep()
+        mdl_sandy.hook_solve_water_and_sediment_timestep()
 
         # grab the state of the `f_bedload` parameter
         fb_mdl_muddy[i] = mdl_muddy.f_bedload  # get the value

--- a/docs/source/examples/variable_velocity.rst
+++ b/docs/source/examples/variable_velocity.rst
@@ -76,7 +76,7 @@ We define a model subclass to handle the changing boundary condition:
             self._time_array, self._velocity_array = create_velocity_array(
                 end_time)  # use default shape parameters for the array
 
-        def hook_run_one_timestep(self):
+        def hook_solve_water_and_sediment_timestep(self):
             """Change the velocity."""
 
             # find the new velocity and set it to the model

--- a/docs/source/guides/advanced_configuration_guide.inc
+++ b/docs/source/guides/advanced_configuration_guide.inc
@@ -157,7 +157,7 @@ We then can initialize our new model type, and see that this model has all of th
 
 Hooks are methods in the model sequence that do nothing by default, but can be augmented to provide arbitrary desired behavior in the model.
 Hooks have been integrated throughout the model initialization and update sequences, to allow the users to achieve complex behavior at various stages of the model sequence.
-For example, ``hook_run_one_timestep`` is a hook which occurs immediately before the  model :obj:`run_one_timestep` method.
+For example, ``hook_solve_water_and_sediment_timestep`` is a hook which occurs immediately before the model :obj:`solve_water_and_sediment_timestep` method.
 
 To utilize the hooks, we simply define a method in our subclass with the name corresponding to the hook we want to augment to achieve the desired behavior.
 For example, to change the behavior of the subsidence field to vary randomly in magnitude on each iteration:

--- a/docs/source/info/hydrodynamics.rst
+++ b/docs/source/info/hydrodynamics.rst
@@ -81,12 +81,11 @@ The updated water surface is combined with the previous timestep's water surface
 
 .. plot:: water_tools/compute_free_surface_outputs.py
 
-With a new free surface computed, a few final operations prepare the surface for boundary condition updates and eventually being passed to the sediment routing operations.
+With a new free surface computed, a few final operations prepare the surface for boundary condition updates and eventually being passed to the sediment routing operations (inside :meth:`~water_tools.finalize_free_surface`).
 A non-linear smoothing operation is applied to the free surface, whereby wet cells are iteratively averaged with neighboring wet cells to yield an overall smoother surface.
 The smoothing is handled by :func:`_smooth_free_surface` and depends on the number of iterations (:attr:`~pyDeltaRCM.model.DeltaModel.Nsmooth`) and a weighting coefficient (:attr:`~pyDeltaRCM.model.DeltaModel.Csmooth`).
 
 .. plot:: water_tools/_smooth_free_surface.py
-
 
 Finally, a :meth:`~water_tools.flooding_correction` is applied to the domain.
 In this correction, all "dry" cells (a cell where the flow depth is less than the `dry_depth`) are checked for any neighboring cells where the water surface elevation (`stage`) is higher than the bed elevation of the dry cell.

--- a/docs/source/pyplots/water_tools/compute_free_surface_outputs.py
+++ b/docs/source/pyplots/water_tools/compute_free_surface_outputs.py
@@ -28,22 +28,22 @@ delta.run_water_iteration()
 delta.compute_free_surface()
 
 
-pidx = 60
+# pidx = 60
 
-sfc_visit, sfc_sum = pyDeltaRCM.water_tools._accumulate_free_surface_walks(
-    delta.free_surf_walk_inds, delta.free_surf_flag, delta.cell_type,
-    delta.uw, delta.ux, delta.uy, delta.depth,
-    delta._dx, delta._u0, delta.h0, delta._H_SL, delta._S0)
-
-
-Hnew = np.full_like(sfc_visit, np.nan)
-Hnew[sfc_visit > 0] = (sfc_sum[sfc_visit > 0] /
-                       sfc_visit[sfc_visit > 0])
+# sfc_visit, sfc_sum = pyDeltaRCM.water_tools._accumulate_free_surface_walks(
+#     delta.free_surf_walk_inds, delta.free_surf_flag, delta.cell_type,
+#     delta.uw, delta.ux, delta.uy, delta.depth,
+#     delta._dx, delta._u0, delta.h0, delta._H_SL, delta._S0)
 
 
-stage_new = delta.eta + delta.depth
-stage_new[sfc_visit > 0] = (sfc_sum[sfc_visit > 0] /
-                            sfc_visit[sfc_visit > 0])
+Hnew = np.full_like(delta.sfc_visit, np.nan)
+Hnew[delta.sfc_visit > 0] = (delta.sfc_sum[delta.sfc_visit > 0] /
+                             delta.sfc_visit[delta.sfc_visit > 0])
+
+
+# stage_new = delta.eta + delta.depth
+# stage_new[delta.sfc_visit > 0] = (delta.sfc_sum[delta.sfc_visit > 0] /
+#                             delta.sfc_visit[delta.sfc_visit > 0])
 
 
 fig, ax = plt.subplots(2, 2, sharex=True, sharey=True, figsize=(9, 4))
@@ -57,9 +57,9 @@ pyDeltaRCM.debug_tools.plot_domain(
 
 pyDeltaRCM.debug_tools.plot_domain(
     Hnew, ax=ax[1, 0], grid=False,
-    label='H_new (m)')
+    label='computed Hnew (m)')
 pyDeltaRCM.debug_tools.plot_domain(
-    stage_new, ax=ax[1, 1], grid=False,
+    delta.Hnew, ax=ax[1, 1], grid=False,
     label='stage (m)')
 
 fig.show()

--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -12,11 +12,12 @@ A complete list of hooks in the model follows:
     :obj:`~hook_tools.hook_import_files`, :obj:`~hook_tools.hook_run_one_timestep`
     :obj:`~hook_tools.hook_process_input_to_model`, :obj:`~hook_tools.hook_apply_subsidence`
     :obj:`~hook_tools.hook_create_other_variables`, :obj:`~hook_tools.hook_finalize_timestep`
-    :obj:`~hook_tools.hook_create_domain`, :obj:`~hook_tools.hook_init_water_iteration`
-    :obj:`~hook_tools.hook_load_checkpoint`, :obj:`~hook_tools.hook_run_water_iteration`
-    :obj:`~hook_tools.hook_output_data`, :obj:`~hook_tools.hook_compute_free_surface`
-    :obj:`~hook_tools.hook_output_checkpoint`, :obj:`~hook_tools.hook_finalize_water_iteration`
-    :obj:`~hook_tools.hook_init_output_file`, :obj:`~hook_tools.hook_route_sediment`
+    :obj:`~hook_tools.hook_create_domain`, :obj:`~hook_tools.hook_route_water`
+    :obj:`~hook_tools.hook_load_checkpoint`, :obj:`~hook_tools.hook_init_water_iteration`
+    :obj:`~hook_tools.hook_output_data`, :obj:`~hook_tools.hook_run_water_iteration`
+    :obj:`~hook_tools.hook_output_checkpoint`, :obj:`~hook_tools.hook_compute_free_surface`
+    :obj:`~hook_tools.hook_init_output_file`, :obj:`~hook_tools.hook_finalize_water_iteration`
+    , :obj:`~hook_tools.hook_route_sediment`
     , :obj:`~hook_tools.hook_route_all_sand_parcels`
     , :obj:`~hook_tools.hook_topo_diffusion`
     , :obj:`~hook_tools.hook_route_all_mud_parcels`

--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -9,7 +9,7 @@ A complete list of hooks in the model follows:
     :header: "Initializing", "Updating"
     :widths: 40, 40
 
-    :obj:`~hook_tools.hook_import_files`, :obj:`~hook_tools.hook_run_one_timestep`
+    :obj:`~hook_tools.hook_import_files`, :obj:`~hook_tools.hook_solve_water_and_sediment_timestep`
     :obj:`~hook_tools.hook_process_input_to_model`, :obj:`~hook_tools.hook_apply_subsidence`
     :obj:`~hook_tools.hook_create_other_variables`, :obj:`~hook_tools.hook_finalize_timestep`
     :obj:`~hook_tools.hook_create_domain`, :obj:`~hook_tools.hook_route_water`

--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -16,7 +16,7 @@ A complete list of hooks in the model follows:
     :obj:`~hook_tools.hook_load_checkpoint`, :obj:`~hook_tools.hook_run_water_iteration`
     :obj:`~hook_tools.hook_output_data`, :obj:`~hook_tools.hook_compute_free_surface`
     :obj:`~hook_tools.hook_output_checkpoint`, :obj:`~hook_tools.hook_finalize_water_iteration`
-    :obj:`~hook_tools.hook_init_output_file`, :obj:`~hook_tools.hook_sed_route`
+    :obj:`~hook_tools.hook_init_output_file`, :obj:`~hook_tools.hook_route_sediment`
     , :obj:`~hook_tools.hook_route_all_sand_parcels`
     , :obj:`~hook_tools.hook_topo_diffusion`
     , :obj:`~hook_tools.hook_route_all_mud_parcels`

--- a/docs/source/reference/water_tools/index.rst
+++ b/docs/source/reference/water_tools/index.rst
@@ -7,15 +7,15 @@ water_tools
 .. currentmodule:: pyDeltaRCM.water_tools
 
 
-The :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep` routine manages the water routing.
-During :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep`, water iteration is repeated a total of :obj:`~pyDeltaRCM.model.DeltaModel.itermax` times.
+The :obj:`~pyDeltaRCM.water_tools.water_tools.route_water` routine manages the water routing.
+During :obj:`~pyDeltaRCM.water_tools.water_tools.route_water`, water iteration is repeated a total of :obj:`~pyDeltaRCM.model.DeltaModel.itermax` times.
 During each of these iterations of the water routing, the following methods are called *in order*:
 
 .. autosummary::
 
-  water_tools.init_water_iteration
-	water_tools.run_water_iteration
-	water_tools.compute_free_surface
+    water_tools.init_water_iteration
+    water_tools.run_water_iteration
+    water_tools.compute_free_surface
 	water_tools.finalize_water_iteration
 
 

--- a/pyDeltaRCM/_version.py
+++ b/pyDeltaRCM/_version.py
@@ -4,4 +4,4 @@ def __version__():
     Private version declaration, gets assigned to pyDeltaRCM.__version__
     during import
     """
-    return '1.3.0'
+    return '1.3.1'

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -106,6 +106,14 @@ class hook_tools(abc.ABC):
         """
         pass
 
+    def hook_route_water(self):
+        """Hook :obj:`~pyDeltaRCM.water_tools.water_tools.route_water`.
+
+        Called immediately before
+        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.route_water`.
+        """
+        pass
+
     def hook_init_water_iteration(self):
         """Hook :obj:`~pyDeltaRCM.water_tools.water_tools.init_water_iteration`.
 

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -146,6 +146,14 @@ class hook_tools(abc.ABC):
         """
         pass
 
+    def hook_init_sediment_iteration(self):
+        """Hook :obj:`~pyDeltaRCM.sed_tools.sed_tools.init_sediment_iteration`.
+
+        Called immediately before
+        :obj:`~pyDeltaRCM.sed_tools.sed_tools.init_sediment_iteration`.
+        """
+        pass
+
     def hook_route_all_sand_parcels(self):
         """Hook :obj:`~pyDeltaRCM.sed_tools.sed_tools.route_all_sand_parcels`.
 

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -19,7 +19,8 @@ class hook_tools(abc.ABC):
 
         This helper method is early in the `DeltaModel` `__init__` routine.
         """
-        _deprecated_list = {'hook_sed_route': 'hook_route_sediment'}
+        _deprecated_list = {'hook_sed_route': 'hook_route_sediment',
+                            'hook_run_one_timestep': 'hook_solve_water_and_sediment_timestep'}
         for old_hook, new_hook in _deprecated_list.items():
             if hasattr(self, old_hook):
                 raise AttributeError(
@@ -66,11 +67,11 @@ class hook_tools(abc.ABC):
         """
         pass
 
-    def hook_run_one_timestep(self):
-        """Hook :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep`.
+    def hook_solve_water_and_sediment_timestep(self):
+        """Hook :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep`.
 
         Called immediately before
-        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep`.
+        :obj:`~pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep`.
         """
         pass
 

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -8,6 +8,24 @@ class hook_tools(abc.ABC):
     </guides/user_guide>`.
     """
 
+    def _check_deprecated_hooks(self):
+        """Check for any old hooks that are defined.
+
+        Sometimes hook names need to be deprecated, due to changing underlying
+        model mechanics or anything else. This may mean that an old hook is
+        *no longer called*, but there is no way to warn the user about this.
+        Therefore, we enforce that no old hooks may be used as method names of
+        subclassing models.
+
+        This helper method is early in the `DeltaModel` `__init__` routine.
+        """
+        _deprecated_list = {'hook_sed_route': 'hook_route_sediment'}
+        for old_hook, new_hook in _deprecated_list.items():
+            if hasattr(self, old_hook):
+                raise AttributeError(
+                    f'`{old_hook}` is deprecated, '
+                    f'and has been replaced with `{new_hook}`.')
+
     def hook_import_files(self):
         """Hook :obj:`~pyDeltaRCM.init_tools.init_tools.import_files`.
 
@@ -120,11 +138,11 @@ class hook_tools(abc.ABC):
         """
         pass
 
-    def hook_sed_route(self):
-        """Hook :obj:`~pyDeltaRCM.sed_tools.sed_tools.sed_route`.
+    def hook_route_sediment(self):
+        """Hook :obj:`~pyDeltaRCM.sed_tools.sed_tools.route_sediment`.
 
         Called immediately before
-        :obj:`~pyDeltaRCM.sed_tools.sed_tools.sed_route`.
+        :obj:`~pyDeltaRCM.sed_tools.sed_tools.route_sediment`.
         """
         pass
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -73,7 +73,6 @@ class init_tools(abc.ABC):
         self.log_info('Platform: {}'.format(platform.platform()),
                       verbosity=0)  # log the os
 
-
     def import_files(self, kwargs_dict={}):
         """Import the input files.
 
@@ -464,8 +463,10 @@ class init_tools(abc.ABC):
 
         Fills with default variables.
 
-        .. warning:: Overwrites an existing netcdf file with the same name if
-        :attr:`pyDeltaRCM.model.DeltaModel.clobber_netcdf` is True
+        .. warning::
+
+            Overwrites an existing netcdf file with the same name if
+            :attr:`~pyDeltaRCM.model.DeltaModel.clobber_netcdf` is `True`.
 
         """
         _msg = 'Initializing output NetCDF4 file'

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -40,31 +40,11 @@ class iteration_tools(abc.ABC):
         # start the model operations
         self.eta0 = np.copy(self.eta)  # copy
 
-        #   water iterations
-        _msg = 'Beginning water iteration'
-        self.log_info(_msg, verbosity=2)
-        for iteration in range(self._itermax):
+        # water iterations
+        self.hook_route_water()
+        self.route_water()
 
-            # initialize the relevant fields and parcel trackers
-            self.hook_init_water_iteration()
-            self.init_water_iteration()
-
-            # run the actual iteration of the parcels
-            self.hook_run_water_iteration()
-            self.run_water_iteration()
-
-            # accumulate the routed water parcels into free surface
-            self.hook_compute_free_surface()
-            self.compute_free_surface()
-
-            # clean up the water surface and apply boundary conditions
-            self.hook_finalize_water_iteration(iteration)
-            self.finalize_water_iteration(iteration)
-
-        #  sediment iteration
-        _msg = 'Beginning sediment iteration'
-        self.log_info(_msg, verbosity=2)
-
+        # sediment iteration
         self.hook_route_sediment()
         self.route_sediment()
 

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -23,13 +23,11 @@ class iteration_tools(abc.ABC):
     these operations largely occur when saving and updating the model.
     """
 
-    def run_one_timestep(self):
-        """Run the timestep once.
+    def solve_water_and_sediment_timestep(self):
+        """Run water and sediment operations for one timestep.
 
         The first operation called by :meth:`update`, this method iterates the
         water surface calculation and sediment parcel routing routines.
-
-        .. note:: Will print the current time to stdout, if ``verbose > 0``.
 
         Parameters
         ----------
@@ -47,6 +45,17 @@ class iteration_tools(abc.ABC):
         # sediment iteration
         self.hook_route_sediment()
         self.route_sediment()
+
+    def run_one_timestep(self):
+        """Deprecated, since v1.3.1. Use :obj:`solve_water_and_sediment_timestep`."""
+        _msg = ('`run_one_timestep` and `hook_run_one_timestep` are '
+                'deprecated and have been replaced with '
+                '`solve_water_and_sediment_timestep`. '
+                'Running `solve_water_and_sediment_timestep` now, but '
+                'this will be removed in future release.')
+        self.logger.warning(_msg)
+        warnings.warn(UserWarning(_msg))
+        self.solve_water_and_sediment_timestep()
 
     def apply_subsidence(self):
         """Apply subsidence pattern.

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -65,8 +65,8 @@ class iteration_tools(abc.ABC):
         _msg = 'Beginning sediment iteration'
         self.log_info(_msg, verbosity=2)
 
-        self.hook_sed_route()
-        self.sed_route()
+        self.hook_route_sediment()
+        self.route_sediment()
 
     def apply_subsidence(self):
         """Apply subsidence pattern.

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -84,6 +84,9 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         _src_dir = os.path.realpath(os.path.dirname(__file__))
         self.default_file = os.path.join(_src_dir, 'default.yml')
 
+        # check for any deprecated hooks
+        self._check_deprecated_hooks()
+
         # import the input file
         self.hook_import_files()  # user hook
         self.import_files(kwargs)

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -140,15 +140,16 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         self.log_model_time()
 
     def update(self):
-        """Run the model for one full instance.
+        """Run the model for one full timestep.
 
         This method handles the input/output from the model, orchestrating the
-        various morphodynamic and basin-scale processes, and incrementing the
-        model time-tracking attributes. This method calls, in sequence:
+        various morphodynamic and basin-scale processes (from sub-methods),
+        and incrementing the model time-tracking attributes. This method
+        calls, in sequence:
 
             * the routine to run one timestep (i.e., water surface estimation
               and sediment routing;
-              :meth:`~pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep`)
+              :meth:`~pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep`)
             * the basin subsidence update;
               (:meth:`~pyDeltaRCM.iteration_tools.iteration_tools.apply_subsidence`)
             * the timestep finalization routine (applying boundary conditions);
@@ -181,8 +182,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             raise RuntimeError('Cannot update model, model already finalized!')
 
         # update the model, i.e., the actual model morphodynamics
-        self.hook_run_one_timestep()
-        self.run_one_timestep()
+        self.hook_solve_water_and_sediment_timestep()
+        self.solve_water_and_sediment_timestep()
 
         self.hook_apply_subsidence()
         self.apply_subsidence()

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -26,6 +26,9 @@ class sed_tools(abc.ABC):
             * :obj:`topo_diffusion`
             * :obj:`route_all_mud_parcels`
         """
+        _msg = 'Beginning sediment iteration'
+        self.log_info(_msg, verbosity=2)
+
         # initialize the relevant fields and parcel trackers
         self.hook_init_sediment_iteration()
         self.init_sediment_iteration()

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -50,11 +50,12 @@ class sed_tools(abc.ABC):
 
     def sed_route(self):
         """Deprecated, since v1.3.1. Use :obj:`route_sediment`."""
-        warnings.warn(UserWarning(
-            '`sed_route` and `hook_sed_route` are deprecated and '
-            'have been replaced with `route_sediment`. '
-            'Running `route_sediment` now, but '
-            'this will be removed in future release.'))
+        _msg = ('`sed_route` and `hook_sed_route` are deprecated and '
+                'have been replaced with `route_sediment`. '
+                'Running `route_sediment` now, but '
+                'this will be removed in future release.')
+        self.logger.warning(_msg)
+        warnings.warn(UserWarning(_msg))
         self.route_sediment()
 
     def init_sediment_iteration(self):

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -6,6 +6,8 @@ from numba.experimental import jitclass
 from scipy import ndimage
 import abc
 
+import warnings
+
 from . import shared_tools
 
 # tools for sediment routing algorithms and deposition/erosion
@@ -13,7 +15,7 @@ from . import shared_tools
 
 class sed_tools(abc.ABC):
 
-    def sed_route(self):
+    def route_sediment(self):
         """Sediment routing main method.
 
         This is the main method for sediment routing in the model. It is
@@ -39,6 +41,14 @@ class sed_tools(abc.ABC):
         self.log_info(_msg, verbosity=2)
         self.hook_route_all_mud_parcels()
         self.route_all_mud_parcels()
+
+    def sed_route(self):
+        warnings.warn(UserWarning(
+            '`sed_route` and `hook_sed_route` are deprecated and '
+            'have been replaced with `route_sediment`. '
+            'Running `route_sediment` now, but '
+            'this will be removed in future release.'))
+        self.route_sediment()
 
     def route_all_sand_parcels(self):
         """Route sand parcels; topo diffusion.

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -10,6 +10,39 @@ from . import shared_tools
 
 class water_tools(abc.ABC):
 
+    def route_water(self):
+        """Water routing main method.
+
+        This is the main method for water routing in the model. It is
+        called once per `update()` call.
+
+        Internally, this method calls:
+            * :obj:`init_water_iteration`
+            * :obj:`run_water_iteration`
+            * :obj:`compute_free_surface`
+            * :obj:`finalize_water_iteration`
+        """
+        _msg = 'Beginning water iteration'
+        self.log_info(_msg, verbosity=2)
+
+        for iteration in range(self._itermax):
+
+            # initialize the relevant fields and parcel trackers
+            self.hook_init_water_iteration()
+            self.init_water_iteration()
+
+            # run the actual iteration of the parcels
+            self.hook_run_water_iteration()
+            self.run_water_iteration()
+
+            # accumulate the routed water parcels into free surface
+            self.hook_compute_free_surface()
+            self.compute_free_surface()
+
+            # clean up the water surface and apply boundary conditions
+            self.hook_finalize_water_iteration(iteration)
+            self.finalize_water_iteration(iteration)
+
     def init_water_iteration(self):
         """Init the water iteration routine.
         """

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -209,9 +209,18 @@ class water_tools(abc.ABC):
         The output from :obj:`_accumulate_free_surface_walks` is then used to
         calculate a new stage surface (``H_new``) based only on the water
         parcel paths and expected water surface elevations, approximately as
-        ``H_new = sfc_sum / sfc_visit``. Finally, the updated water surface is
+        ``Hnew = sfc_sum / sfc_visit`` ("computed Hnew" in figure below)
+
+        Following this step, a correction is applied forcing the new free
+        surface to be below sea level and above or equal to the land surface
+        elevation over the model domain ("stage" in figure below). This
+        surface `Hnew` is used in the following operation
+        :obj:`finalize_free_surface`.
+
+        Finally, the updated water surface is
         combined with the previous timestep's water surface and an
-        underrelaxation coefficient :obj:`_omega_sfc`.
+        underrelaxation coefficient
+        :obj:`~pyDeltaRCM.model.DeltaModel.omega_sfc`.
 
         .. plot:: water_tools/compute_free_surface_outputs.py
 
@@ -234,7 +243,48 @@ class water_tools(abc.ABC):
             self.uw, self.ux, self.uy, self.depth,
             self._dx, self._u0, self.h0, self._H_SL, self._S0)
 
+        # begin from the previous stage
+        Hnew = self.eta + self.depth
+
+        # find average water surface elevation for a cell from accumulation
+        Hnew[self.sfc_visit > 0] = (self.sfc_sum[self.sfc_visit > 0] /
+                                    self.sfc_visit[self.sfc_visit > 0])
+
+        # water surface height not under sea level
+        Hnew[Hnew < self._H_SL] = self._H_SL
+
+        # water surface height not below bed elevation
+        Hnew[Hnew < self.eta] = self.eta[Hnew < self.eta]
+
+        # set to model field
+        self.Hnew = Hnew
+
+        # finalize the free surface (combine and smooth)
         self.finalize_free_surface()
+
+    def finalize_free_surface(self):
+        """Finalize the water free surface.
+
+        This method occurs after the initial computation of the free surface,
+        and creates the new free surface by smoothing the newly computed free
+        surface with a jitted function (:obj:`_smooth_free_surface`), and then
+        combining the old surface and new smoothed surface with
+        underrelaxation. Finally, a :obj:`flooding_correction` is applied.
+        """
+        _msg = 'Smoothing and finalizing free surface'
+        self.log_info(_msg, verbosity=2)
+
+        # smooth newly calculated free surface
+        Hsmth = _smooth_free_surface(
+            self.Hnew, self.cell_type, self._Nsmooth, self._Csmooth)
+
+        # combine new smoothed and previous free surf with underrelaxation
+        if self._time_iter > 0:
+            self.stage = (((1 - self._omega_sfc) * self.stage) +
+                          (self._omega_sfc * Hsmth))
+
+        # apply a flooding correction
+        self.flooding_correction()
 
     def finalize_water_iteration(self, iteration):
         """Finish updating flow fields.
@@ -358,43 +408,6 @@ class water_tools(abc.ABC):
         # inds[self.free_surf_flag == 2] = 0
         boundary = (self.cell_type.flat[inds] == -1)
         return boundary
-
-    def finalize_free_surface(self):
-        """Finalize the water free surface.
-
-        This method occurs after the initial computation of the free surface,
-        by accumulating the directed walks of all water parcels. In this
-        method, thresholding is applied to correct for sea level, and a the
-        free surface is smoothed by a jitted function
-        (:obj:`_smooth_free_surface`).
-        """
-        _msg = 'Smoothing and finalizing free surface'
-        self.log_info(_msg, verbosity=2)
-
-        # begin from the previous stage
-        Hnew = self.eta + self.depth
-
-        # find average water surface elevation for a cell from accumulation
-        Hnew[self.sfc_visit > 0] = (self.sfc_sum[self.sfc_visit > 0] /
-                                    self.sfc_visit[self.sfc_visit > 0])
-
-        # water surface height not under sea level
-        Hnew[Hnew < self._H_SL] = self._H_SL
-
-        # water surface height not below bed elevation
-        Hnew[Hnew < self.eta] = self.eta[Hnew < self.eta]
-
-        # smooth newly calculated free surface
-        Hsmth = _smooth_free_surface(
-            Hnew, self.cell_type, self._Nsmooth, self._Csmooth)
-
-        # combine new smoothed and previous free surf with underrelaxation
-        if self._time_iter > 0:
-            self.stage = (((1 - self._omega_sfc) * self.stage) +
-                          (self._omega_sfc * Hsmth))
-
-        # apply a flooding correction
-        self.flooding_correction()
 
     def update_flow_field(self, iteration):
         """Update water discharge.

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -17,15 +17,15 @@ from .. import utilities
 
 
 @mock.patch(
-    'pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep',
-    new=utilities.FastIteratingDeltaModel.run_one_timestep)
+    'pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep',
+    new=utilities.FastIteratingDeltaModel.solve_water_and_sediment_timestep)
 class TestCheckpointingIntegrations:
     """
     The above patch implements an augmented DeltaModel from `utilities`. In
-    this modified DeltaModel, the `run_one_timestep` operations (i.e., the
-    time consuming part of the model) is replaced with an updating random
-    field. This guarantees that the random-repeatedness of checkpointing is
-    validated, but it is much faster and easier to isolate
+    this modified DeltaModel, the `solve_water_and_sediment_timestep`
+    operations (i.e., the time consuming part of the model) is replaced with
+    an updating random field. This guarantees that the random-repeatedness of
+    checkpointing is validated, but it is much faster and easier to isolate
     checkpointing-related issues from model issues.
     """
 
@@ -531,8 +531,8 @@ class TestCheckpointingCreatingLoading:
         assert np.all(_delta.eta == _rand_field)
 
     @mock.patch(
-        'pyDeltaRCM.iteration_tools.iteration_tools.run_one_timestep',
-        new=utilities.FastIteratingDeltaModel.run_one_timestep)
+        'pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep',
+        new=utilities.FastIteratingDeltaModel.solve_water_and_sediment_timestep)
     @pytest.mark.skipif(
         platform.system() != 'Linux',
         reason='Parallel support only on Linux OS.')

--- a/tests/integration/test_timing_triggers.py
+++ b/tests/integration/test_timing_triggers.py
@@ -22,7 +22,7 @@ class TestTimingOutputData:
         _delta._checkpoint_dt = 2 * _delta._dt
 
         # mock top-level methods, verify call was made to each
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_info = mock.MagicMock()
@@ -39,7 +39,7 @@ class TestTimingOutputData:
         _delta.update()
 
         # assert calls
-        assert _delta.run_one_timestep.call_count == 1
+        assert _delta.solve_water_and_sediment_timestep.call_count == 1
         assert _delta.apply_subsidence.call_count == 1
         assert _delta.finalize_timestep.call_count == 1
         assert _delta.log_model_time.call_count == 1
@@ -56,7 +56,7 @@ class TestTimingOutputData:
         _delta.update()
 
         # assert calls
-        assert _delta.run_one_timestep.call_count == 2
+        assert _delta.solve_water_and_sediment_timestep.call_count == 2
         assert _delta.apply_subsidence.call_count == 2
         assert _delta.finalize_timestep.call_count == 2
         assert _delta.log_model_time.call_count == 2
@@ -73,7 +73,7 @@ class TestTimingOutputData:
         _delta.update()
 
         # assert calls
-        assert _delta.run_one_timestep.call_count == 3
+        assert _delta.solve_water_and_sediment_timestep.call_count == 3
         assert _delta.apply_subsidence.call_count == 3
         assert _delta.finalize_timestep.call_count == 3
         assert _delta.log_model_time.call_count == 3
@@ -97,7 +97,7 @@ class TestTimingOutputData:
         _delta._save_any_grids = True  # override from settings
 
         # mock top-level methods, verify call was made to each
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -149,7 +149,7 @@ class TestTimingOutputData:
         _delta._save_any_grids = True  # override from settings
 
         # mock top-level methods, verify call was made to each
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -193,7 +193,7 @@ class TestTimingOutputData:
         _delta._save_any_grids = True  # override from settings
 
         # mock top-level methods, verify call was made to each
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -234,7 +234,7 @@ class TestTimingOutputData:
         _delta._save_any_grids = True  # override from settings
 
         # mock top-level methods, verify call was made to each
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -317,7 +317,7 @@ class TestTimingOutputData:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -334,7 +334,7 @@ class TestTimingOutputData:
             _delta.update()
 
         assert _delta.time_iter == 2.0
-        _delta.run_one_timestep.call_count == 2
+        _delta.solve_water_and_sediment_timestep.call_count == 2
 
         # check for output eta files
         exp_path_nc = os.path.join(
@@ -357,7 +357,7 @@ class TestTimingOutputData:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -391,7 +391,7 @@ class TestTimingOutputData:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -405,7 +405,7 @@ class TestTimingOutputData:
             _delta.update()
 
         assert _delta.time_iter == 2.0
-        _delta.run_one_timestep.call_count == 2
+        _delta.solve_water_and_sediment_timestep.call_count == 2
 
         _delta.finalize()
 
@@ -424,7 +424,7 @@ class TestTimingOutputData:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -438,7 +438,7 @@ class TestTimingOutputData:
             _delta.update()
 
         assert _delta.time_iter == 2.0
-        _delta.run_one_timestep.call_count == 2
+        _delta.solve_water_and_sediment_timestep.call_count == 2
 
         _delta.finalize()
 
@@ -459,7 +459,7 @@ class TestTimingOutputData:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -473,7 +473,7 @@ class TestTimingOutputData:
             _delta.update()
 
         assert _delta.time_iter == 6.0
-        _delta.run_one_timestep.call_count == 6
+        _delta.solve_water_and_sediment_timestep.call_count == 6
 
         _delta.finalize()
         ds = netCDF4.Dataset(exp_path_nc, "r", format="NETCDF4")

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -26,7 +26,7 @@ class TestRunOneTimestep:
         delta.run_water_iteration = mock.MagicMock()
         delta.compute_free_surface = mock.MagicMock()
         delta.finalize_water_iteration = mock.MagicMock()
-        delta.sed_route = mock.MagicMock()
+        delta.route_sediment = mock.MagicMock()
 
         # run the timestep
         delta.run_one_timestep()
@@ -40,7 +40,7 @@ class TestRunOneTimestep:
         delta.finalize_water_iteration.assert_has_calls(
             _calls, any_order=False)
         assert delta.finalize_water_iteration.call_count == 3
-        assert (delta.sed_route.called is True)
+        assert (delta.route_sediment.called is True)
         assert (delta._is_finalized is False)
 
     def test_run_one_timestep_itermax_10(self, tmp_path):
@@ -55,7 +55,7 @@ class TestRunOneTimestep:
         delta.run_water_iteration = mock.MagicMock()
         delta.compute_free_surface = mock.MagicMock()
         delta.finalize_water_iteration = mock.MagicMock()
-        delta.sed_route = mock.MagicMock()
+        delta.route_sediment = mock.MagicMock()
 
         # run the timestep
         delta.run_one_timestep()
@@ -69,7 +69,7 @@ class TestRunOneTimestep:
         delta.finalize_water_iteration.assert_has_calls(
             _calls, any_order=False)
         assert delta.finalize_water_iteration.call_count == 10
-        assert (delta.sed_route.called is True)
+        assert (delta.route_sediment.called is True)
         assert (delta._is_finalized is False)
 
 

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -13,9 +13,9 @@ from pyDeltaRCM.model import DeltaModel
 from . import utilities
 
 
-class TestRunOneTimestep:
+class TestSolveWaterAndSedimentTimestep:
 
-    def test_run_one_timestep_defaults(self, tmp_path):
+    def test_solve_water_and_sediment_timestep_defaults(self, tmp_path):
         # create a delta with default settings
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         delta = DeltaModel(input_file=p)
@@ -29,7 +29,7 @@ class TestRunOneTimestep:
         delta.route_sediment = mock.MagicMock()
 
         # run the timestep
-        delta.run_one_timestep()
+        delta.solve_water_and_sediment_timestep()
 
         # assert that methods are called
         assert delta.init_water_iteration.called is True
@@ -43,7 +43,7 @@ class TestRunOneTimestep:
         assert (delta.route_sediment.called is True)
         assert (delta._is_finalized is False)
 
-    def test_run_one_timestep_itermax_10(self, tmp_path):
+    def test_solve_water_and_sediment_timestep_itermax_10(self, tmp_path):
         # create a delta with different itermax
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'itermax': 10})
@@ -58,7 +58,7 @@ class TestRunOneTimestep:
         delta.route_sediment = mock.MagicMock()
 
         # run the timestep
-        delta.run_one_timestep()
+        delta.solve_water_and_sediment_timestep()
 
         # assert that methods are called
         assert delta.init_water_iteration.called is True
@@ -108,7 +108,7 @@ class TestApplyingSubsidence:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
 
         assert _delta.dt == 25000
         assert _delta.subsidence_rate == 1e-8
@@ -133,7 +133,7 @@ class TestApplyingSubsidence:
         _delta = DeltaModel(input_file=p)
 
         # mock the timestep computations
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
 
         assert _delta.dt == 25000
         assert _delta.subsidence_rate == 1e-8
@@ -153,7 +153,7 @@ class TestApplyingSubsidence:
                       pytest.approx(-_delta.h0 - 0.00025))
         _delta.output_netcdf.close()
 
-        _delta.run_one_timestep.call_count == 2
+        _delta.solve_water_and_sediment_timestep.call_count == 2
 
     def test_subsidence_changed_with_timestep(self, tmp_path):
         # create a delta with subsidence parameters

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -72,6 +72,22 @@ class TestSolveWaterAndSedimentTimestep:
         assert (delta.route_sediment.called is True)
         assert (delta._is_finalized is False)
 
+    def test_run_one_timestep_deprecated(self, tmp_path):
+        # create a delta with default settings
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _delta = DeltaModel(input_file=p)
+
+        # mock top-level methods
+        _delta.logger = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
+
+        # check warning raised
+        with pytest.warns(UserWarning):
+            _delta.run_one_timestep()
+
+        # and logged
+        assert (_delta.logger.warning.called is True)
+
 
 class TestFinalizeTimestep:
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -354,7 +354,7 @@ class TestUpdate:
         _delta = DeltaModel(input_file=p)
 
         # mock top-level methods, verify call was made to each
-        _delta.run_one_timestep = mock.MagicMock()
+        _delta.solve_water_and_sediment_timestep = mock.MagicMock()
         _delta.apply_subsidence = mock.MagicMock()
         _delta.finalize_timestep = mock.MagicMock()
         _delta.log_model_time = mock.MagicMock()
@@ -366,7 +366,7 @@ class TestUpdate:
         _delta.update()
 
         # assert calls
-        assert _delta.run_one_timestep.call_count == 1
+        assert _delta.solve_water_and_sediment_timestep.call_count == 1
         assert _delta.apply_subsidence.call_count == 1
         assert _delta.finalize_timestep.call_count == 1
         assert _delta.log_model_time.call_count == 1
@@ -382,7 +382,7 @@ class TestUpdate:
         _delta.update()
 
         # assert calls
-        assert _delta.run_one_timestep.call_count == 2
+        assert _delta.solve_water_and_sediment_timestep.call_count == 2
         assert _delta.apply_subsidence.call_count == 2
         assert _delta.finalize_timestep.call_count == 2
         assert _delta.log_model_time.call_count == 2

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -325,6 +325,27 @@ class Test__init__:
             _ = DeltaModel(input_file=p)
 
 
+class TestDeprecatedHooks:
+
+    class HookDeltaModel(DeltaModel):
+        """Dummy class to add old hook."""
+
+        def hook_sed_route(self):
+            """Old hook"""
+            pass
+
+    def test_if_hook_raise_error(self, tmp_path):
+        """Deprecated hooks cannot be implemented and will raise an error."""
+
+        # create a delta with default settings
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        with pytest.raises(AttributeError):
+            _ = self.HookDeltaModel(input_file=p)
+
+        # check that regular model still works though
+        _ = DeltaModel(input_file=p)
+
+
 class TestUpdate:
 
     def test_update(self, tmp_path):

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -853,7 +853,7 @@ class TestSerialJob:
         sj.deltamodel._checkpoint_dt = 2 * sj.deltamodel._dt
 
         # mock top-level methods, verify call was made to each
-        sj.deltamodel.run_one_timestep = mock.MagicMock()
+        sj.deltamodel.solve_water_and_sediment_timestep = mock.MagicMock()
         sj.deltamodel.apply_subsidence = mock.MagicMock()
         sj.deltamodel.finalize_timestep = mock.MagicMock()
         sj.deltamodel.log_model_time = mock.MagicMock()
@@ -868,7 +868,7 @@ class TestSerialJob:
         # assertions
         assert sj.deltamodel._time_iter == 10
         assert sj.deltamodel.output_data.call_count == 10
-        assert sj.deltamodel.run_one_timestep.call_count == 10
+        assert sj.deltamodel.solve_water_and_sediment_timestep.call_count == 10
         assert sj.deltamodel.apply_subsidence.call_count == 10
         assert sj.deltamodel.finalize_timestep.call_count == 10
         assert sj.deltamodel.log_model_time.call_count == 10
@@ -892,7 +892,7 @@ class TestSerialJob:
         sj.deltamodel._checkpoint_dt = 2 * sj.deltamodel._dt
 
         # mock top-level methods, verify call was made to each
-        sj.deltamodel.run_one_timestep = mock.MagicMock()
+        sj.deltamodel.solve_water_and_sediment_timestep = mock.MagicMock()
         sj.deltamodel.apply_subsidence = mock.MagicMock()
         sj.deltamodel.finalize_timestep = mock.MagicMock()
         sj.deltamodel.log_model_time = mock.MagicMock()
@@ -907,7 +907,7 @@ class TestSerialJob:
 
         # assertions
         assert sj.deltamodel._time_iter == 1
-        assert sj.deltamodel.run_one_timestep.call_count == 1
+        assert sj.deltamodel.solve_water_and_sediment_timestep.call_count == 1
         assert sj.deltamodel.apply_subsidence.call_count == 1
         assert sj.deltamodel.finalize_timestep.call_count == 1
         assert sj.deltamodel.log_model_time.call_count == 1
@@ -934,7 +934,7 @@ class TestSerialJob:
         sj.deltamodel._checkpoint_dt = 2 * sj.deltamodel._dt
 
         # mock top-level methods, verify call was made to each
-        sj.deltamodel.run_one_timestep = mock.MagicMock()
+        sj.deltamodel.solve_water_and_sediment_timestep = mock.MagicMock()
         sj.deltamodel.apply_subsidence = mock.MagicMock()
         sj.deltamodel.finalize_timestep = mock.MagicMock()
         sj.deltamodel.log_model_time = mock.MagicMock()
@@ -949,7 +949,7 @@ class TestSerialJob:
 
         # assertions
         assert sj.deltamodel._time_iter == 10
-        assert sj.deltamodel.run_one_timestep.call_count == 10
+        assert sj.deltamodel.solve_water_and_sediment_timestep.call_count == 10
         assert sj.deltamodel.apply_subsidence.call_count == 10
         assert sj.deltamodel.finalize_timestep.call_count == 10
         assert sj.deltamodel.log_model_time.call_count == 10
@@ -982,7 +982,7 @@ class TestParallelJob:
         pj.deltamodel._checkpoint_dt = 2 * pj.deltamodel._dt
 
         # mock top-level methods, verify call was made to each
-        pj.deltamodel.run_one_timestep = mock.MagicMock()
+        pj.deltamodel.solve_water_and_sediment_timestep = mock.MagicMock()
         pj.deltamodel.apply_subsidence = mock.MagicMock()
         pj.deltamodel.finalize_timestep = mock.MagicMock()
         pj.deltamodel.log_model_time = mock.MagicMock()
@@ -996,7 +996,7 @@ class TestParallelJob:
 
         # assertions
         assert pj.deltamodel._time_iter == 10
-        assert pj.deltamodel.run_one_timestep.call_count == 10
+        assert pj.deltamodel.solve_water_and_sediment_timestep.call_count == 10
         assert pj.deltamodel.apply_subsidence.call_count == 10
         assert pj.deltamodel.finalize_timestep.call_count == 10
         assert pj.deltamodel.log_model_time.call_count == 10
@@ -1025,7 +1025,7 @@ class TestParallelJob:
         pj.deltamodel._checkpoint_dt = 2 * pj.deltamodel._dt
 
         # mock top-level methods, verify call was made to each
-        pj.deltamodel.run_one_timestep = mock.MagicMock()
+        pj.deltamodel.solve_water_and_sediment_timestep = mock.MagicMock()
         pj.deltamodel.apply_subsidence = mock.MagicMock()
         pj.deltamodel.finalize_timestep = mock.MagicMock()
         pj.deltamodel.log_model_time = mock.MagicMock(
@@ -1040,7 +1040,7 @@ class TestParallelJob:
 
         # assertions
         assert pj.deltamodel._time_iter == 1
-        assert pj.deltamodel.run_one_timestep.call_count == 1
+        assert pj.deltamodel.solve_water_and_sediment_timestep.call_count == 1
         assert pj.deltamodel.apply_subsidence.call_count == 1
         assert pj.deltamodel.finalize_timestep.call_count == 1
         assert pj.deltamodel.log_model_time.call_count == 1
@@ -1074,7 +1074,7 @@ class TestParallelJob:
         pj.deltamodel._checkpoint_dt = 2 * pj.deltamodel._dt
 
         # mock top-level methods, verify call was made to each
-        pj.deltamodel.run_one_timestep = mock.MagicMock()
+        pj.deltamodel.solve_water_and_sediment_timestep = mock.MagicMock()
         pj.deltamodel.apply_subsidence = mock.MagicMock()
         pj.deltamodel.finalize_timestep = mock.MagicMock()
         pj.deltamodel.log_model_time = mock.MagicMock()
@@ -1089,7 +1089,7 @@ class TestParallelJob:
 
         # assertions
         assert pj.deltamodel._time_iter == 10
-        assert pj.deltamodel.run_one_timestep.call_count == 10
+        assert pj.deltamodel.solve_water_and_sediment_timestep.call_count == 10
         assert pj.deltamodel.apply_subsidence.call_count == 10
         assert pj.deltamodel.finalize_timestep.call_count == 10
         assert pj.deltamodel.log_model_time.call_count == 10

--- a/tests/test_sed_tools.py
+++ b/tests/test_sed_tools.py
@@ -23,6 +23,7 @@ class TestSedimentRoute:
 
         # mock top-level methods
         _delta.log_info = mock.MagicMock()
+        _delta.init_sediment_iteration = mock.MagicMock()
         _delta.route_all_sand_parcels = mock.MagicMock()
         _delta.topo_diffusion = mock.MagicMock()
         _delta.route_all_mud_parcels = mock.MagicMock()
@@ -30,14 +31,9 @@ class TestSedimentRoute:
         # run the method
         _delta.route_sediment()
 
-        # assertions
-        assert np.all(_delta.pad_depth[1:-1, 1:-1] == _delta.depth)
-        assert np.all(_delta.qs == 0)
-        assert np.all(_delta.Vp_dep_sand == 0)
-        assert np.all(_delta.Vp_dep_mud == 0)
-
         # methods called
         assert (_delta.log_info.call_count == 3)
+        assert (_delta.init_sediment_iteration.called is True)
         assert (_delta.route_all_sand_parcels.called is True)
         assert (_delta.topo_diffusion.called is True)
         assert (_delta.route_all_mud_parcels.called is True)
@@ -53,6 +49,23 @@ class TestSedimentRoute:
 
         with pytest.warns(UserWarning):
             _delta.sed_route()
+
+
+class TestInitSedimentIteration:
+
+    def test_fields_cleared(self, tmp_path):
+        # create a delta with default settings
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _delta = DeltaModel(input_file=p)
+
+        # call the method
+        _delta.init_sediment_iteration()
+
+        # assertions
+        assert np.all(_delta.pad_depth[1:-1, 1:-1] == _delta.depth)
+        assert np.all(_delta.qs == 0)
+        assert np.all(_delta.Vp_dep_sand == 0)
+        assert np.all(_delta.Vp_dep_mud == 0)
 
 
 class TestRouteAllSandParcels:

--- a/tests/test_sed_tools.py
+++ b/tests/test_sed_tools.py
@@ -2,15 +2,16 @@
 
 import numpy as np
 
+import pytest
 import unittest.mock as mock
 
 from pyDeltaRCM.model import DeltaModel
 from . import utilities
 
 
-class TestSedRoute:
+class TestSedimentRoute:
 
-    def test_sed_route(self, tmp_path):
+    def test_route_sediment(self, tmp_path):
         # create a delta with default settings
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _delta = DeltaModel(input_file=p)
@@ -27,7 +28,7 @@ class TestSedRoute:
         _delta.route_all_mud_parcels = mock.MagicMock()
 
         # run the method
-        _delta.sed_route()
+        _delta.route_sediment()
 
         # assertions
         assert np.all(_delta.pad_depth[1:-1, 1:-1] == _delta.depth)
@@ -40,6 +41,18 @@ class TestSedRoute:
         assert (_delta.route_all_sand_parcels.called is True)
         assert (_delta.topo_diffusion.called is True)
         assert (_delta.route_all_mud_parcels.called is True)
+
+    def test_sed_route_deprecated(self, tmp_path):
+        # create a delta with default settings
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _delta = DeltaModel(input_file=p)
+
+        # mock top-level methods
+        _delta.log_info = mock.MagicMock()
+        _delta.route_sediment = mock.MagicMock()
+
+        with pytest.warns(UserWarning):
+            _delta.sed_route()
 
 
 class TestRouteAllSandParcels:

--- a/tests/test_sed_tools.py
+++ b/tests/test_sed_tools.py
@@ -16,11 +16,6 @@ class TestSedimentRoute:
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _delta = DeltaModel(input_file=p)
 
-        # alter field for initial values going into function
-        _delta.qs += np.random.uniform(0, 1, size=_delta.eta.shape)
-        _delta.Vp_dep_sand += np.random.uniform(0, 1, size=_delta.eta.shape)
-        _delta.Vp_dep_mud += np.random.uniform(0, 1, size=_delta.eta.shape)
-
         # mock top-level methods
         _delta.log_info = mock.MagicMock()
         _delta.init_sediment_iteration = mock.MagicMock()
@@ -42,6 +37,11 @@ class TestSedimentRoute:
         # create a delta with default settings
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _delta = DeltaModel(input_file=p)
+
+        # alter field for initial values going into function
+        _delta.qs += np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.Vp_dep_sand += np.random.uniform(0, 1, size=_delta.eta.shape)
+        _delta.Vp_dep_mud += np.random.uniform(0, 1, size=_delta.eta.shape)
 
         # mock top-level methods
         _delta.log_info = mock.MagicMock()

--- a/tests/test_water_tools.py
+++ b/tests/test_water_tools.py
@@ -14,7 +14,7 @@ from pyDeltaRCM import water_tools
 
 class TestWaterRoute:
 
-    def test_route_sediment(self, tmp_path):
+    def test_route_water(self, tmp_path):
         # create a delta with default settings
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _delta = DeltaModel(input_file=p)

--- a/tests/test_water_tools.py
+++ b/tests/test_water_tools.py
@@ -12,6 +12,31 @@ from . import utilities
 from pyDeltaRCM import water_tools
 
 
+class TestWaterRoute:
+
+    def test_route_sediment(self, tmp_path):
+        # create a delta with default settings
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _delta = DeltaModel(input_file=p)
+
+        # mock top-level methods
+        _delta.log_info = mock.MagicMock()
+        _delta.init_water_iteration = mock.MagicMock()
+        _delta.run_water_iteration = mock.MagicMock()
+        _delta.compute_free_surface = mock.MagicMock()
+        _delta.finalize_water_iteration = mock.MagicMock()
+
+        # run the method
+        _delta.route_water()
+
+        # methods called
+        assert (_delta.log_info.called is True)
+        assert (_delta.init_water_iteration.call_count == _delta._itermax)
+        assert (_delta.run_water_iteration.call_count == _delta._itermax)
+        assert (_delta.compute_free_surface.call_count == _delta._itermax)
+        assert (_delta.finalize_water_iteration.call_count == _delta._itermax)
+
+
 class TestWaterRoutingWeights:
 
     def test_get_weight_at_cell(self):

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -100,11 +100,11 @@ class FastIteratingDeltaModel:
     This class is useful in patching the DeltaModel for timing tests. The
     patched DeltaModel uses the random number generation internally, so it
     will verify functionality in any checkpointing scenarios, and overwriting
-    only the `run_one_timestep` method removes most of the jitting compilation
+    only the `solve_water_and_sediment_timestep` method removes most of the jitting compilation
     time and much of the actual computation time.
     """
 
-    def run_one_timestep(self):
+    def solve_water_and_sediment_timestep(self):
         """PATCH"""
 
         def _get_random_field(shp):


### PR DESCRIPTION
# summary

This PR is pure refactoring. The goal was to make only non-breaking changes, which was mostly honored. The exception was with respect to method names and model hooks (see below).

# highlight changes

* Rearranged some components of `compute_free_surface` and `finalize_free_surface` to actually separate at the point of computation vs finalization. All docs and tests were updated accordingly. 
* `run_one_timestep` has been renamed to `solve_water_and_sediment_timestep`. This makes the method name fall in line with the underlying modular design of `route_water` and `route_sediment`, which can be swapped out for non-routing-based solvers. These two methods are still orchestrated by `solve_water_and_sediment_timestep`. This change required many small changes to names in docs and tests, but the change was simple. Note, this is a breaking change with respect to the `hook_run_one_timestep`, which is now replaced with `hook_solve_water_and_sediment_timestep`.
* water routing is now wrapped into a single method `route_water` called from `solve_water_and_sediment_timestep` (formerly `run_one_timestep`), so that it matches the API for sediment routing (`route_sediment`, formerly `sed_route`).
* sediment routing method has been renamed `route_sediment` to be more descriptive, and now matches the water API (`route_water`).
*  sediment routing now has a separate method for initialization `init_sediment_routing`, matching the water routing API.
* across all of these changes, hooks, tests, pyplots, and documentation have been updated

# hook deprecation

This PR introduces a necessary evil, I think, regarding hooks. When a hook is deprecated due to it's parent method being deprecated (e.g., `hook_run_one_timestep`), there is no way to let a user of a subclass know that this hook is no longer being called. So, the best I could come up with is to add deprecated hooks to a "forbidden list", and then raise an error that the implemented hook is no longer available, and supply the new name to use.