### PR TITLE
Refactor initialization

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -18,6 +18,7 @@ Modifying boundary conditions
 .. toctree::
    :maxdepth: 1
 
+   updating_boundary_conditions
    subsidence_region
    variable_bedload
    variable_velocity

--- a/docs/source/examples/updating_boundary_conditions.rst
+++ b/docs/source/examples/updating_boundary_conditions.rst
@@ -1,0 +1,59 @@
+Updating model boundary conditions
+==================================
+
+In implementing custom model subclasses, it is common to want to change boundary conditions throughout the model run (see :doc:`variable_bedload`, :doc:`variable_velocity`).
+In some situations, we want to change a single variable, and see the effect of changing *only this variable*, in essence, pushing the model out of a dynamic equilibrium. 
+Another possibility is that we would want to change the boundary conditions of the inlet, *but maintain the dynamic equilibrium*.
+
+Let's create a `DeltaModel` class to demonstrate.
+
+.. code::
+
+    mdl = DeltaModel()
+
+
+.. doctest::
+    :hide:
+
+    >>> with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    ...     mdl = pyDeltaRCM.DeltaModel(out_dir=output_dir)
+
+Now, we can see that by the default settings, after initialization, the model flow velocity is 1.0 m/s, flow depth is 5 m, and so the unit water discharge is 5 m2/s.
+
+.. doctest::
+
+    >>> mdl.u0
+    1.0
+    >>> mdl.h0
+    5.0
+    >>> mdl.qw0
+    5.0
+
+If after some number of model iterations, we wanted to change the inlet flow velocity to be 2.0 m/s, we could simply set this value directly.
+
+.. doctest::
+
+    >>> mdl.u0 = 2.0
+
+But, now the model has been thrown out of equilibrium, where the unit water discharge no longer matches the product of the flow depth and flow velocity.
+
+.. doctest::
+
+    >>> mdl.u0
+    2.0
+    >>> mdl.h0
+    5.0
+    >>> mdl.qw0
+    5.0
+
+To remedy this, we need to use the :obj:`~pyDeltaRCM.init_tools.init_tools.create_boundary_conditions` method, which will reinitialize a number of fields, based on the current value of the inlet flow velocity.
+
+.. doctest::
+
+    >>> mdl.create_boundary_conditions()
+    >>> mdl.qw0
+    10.0
+
+.. important::
+
+    You are responsible for ensuring that boundary conditions are updated in the appropriate manner after changing certain model parameters. **You need to call the method to reinitialize boundary conditions yourself!**

--- a/docs/source/examples/variable_velocity.rst
+++ b/docs/source/examples/variable_velocity.rst
@@ -82,6 +82,9 @@ We define a model subclass to handle the changing boundary condition:
             # find the new velocity and set it to the model
             self.u0 = np.interp(self._time, self._time_array, self._velocity_array)
 
+            # update other boundary conditions using u0
+            self.create_boundary_conditions()
+
             # log the new value
             _msg = 'Changed velocity value to {u0}'.format(
                 u0=self.u0)
@@ -105,3 +108,8 @@ and then simply run with:
 
     while mdl.time < end_time:
         mdl.update()
+
+
+.. note::
+
+    For information on updating boundary conditions after changing certain model parameters see :doc:`updating_boundary_conditions`.

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -316,11 +316,12 @@ class init_tools(abc.ABC):
         there are several other parameters that depend on the value of the
         inlet flow velocity (e.g., `Qw0` and `Qs0`); of course, your
         scientific question may choose to leave these parameters as they are
-        too (in which case you should *not* re-run this method).
+        too (in which case you should *not* re-run this method). See
+        :doc:`/examples/updating_boundary_conditions` for more information.
 
         .. note::
 
-            This method is automatically called dor the "named" variables used
+            This method is automatically called for the "named" variables used
             by the BMI wrapper (e.g., `channel_flow_velocity`,
             `channel_width`, `channel_flow_depth`, and
             `influx_sediment_concentration`., so you do not need to call it

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -429,7 +429,7 @@ class init_tools(abc.ABC):
         self.sfc_sum = np.zeros_like(self.depth)
 
         # ---- domain ----
-        cell_land = 2
+        cell_land = -2
         cell_channel = 1
         cell_ocean = 0
         cell_edge = -1
@@ -471,7 +471,7 @@ class init_tools(abc.ABC):
 
         self.cell_type[bounds >= min(self.L - 5, self.W / 2 - 5)] = cell_edge
 
-        self.cell_type[:self.L0, :] = -cell_land
+        self.cell_type[:self.L0, :] = cell_land
         self.cell_type[:self.L0, channel_inds:y_channel_max] = cell_channel
 
         self.inlet = np.array(np.unique(np.where(self.cell_type == 1)[1]))

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1345,7 +1345,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @channel_flow_velocity.setter
     def channel_flow_velocity(self, new_u0):
         self.u0 = new_u0
-        self.create_other_variables()
+        self.create_boundary_conditions()
         self.init_sediment_routers()
 
     @property
@@ -1356,7 +1356,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @channel_width.setter
     def channel_width(self, new_N0_meters):
         self.N0_meters = new_N0_meters
-        self.create_other_variables()
+        self.create_boundary_conditions()
         self.init_sediment_routers()
         if self.channel_width != new_N0_meters:
             warnings.warn(UserWarning(
@@ -1372,7 +1372,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @channel_flow_depth.setter
     def channel_flow_depth(self, new_d):
         self.h0 = new_d
-        self.create_other_variables()
+        self.create_boundary_conditions()
         self.init_sediment_routers()
 
     @property
@@ -1410,7 +1410,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
     @influx_sediment_concentration.setter
     def influx_sediment_concentration(self, new_C0):
         self.C0_percent = new_C0 * 100
-        self.create_other_variables()
+        self.create_boundary_conditions()
         self.init_sediment_routers()
 
     @property

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -643,8 +643,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_eta_figs is True) and \
           ('eta' not in self._save_fig_list.keys()):
             self._save_fig_list['eta'] = ['eta']
-        elif (save_eta_figs is False) and \
-          ('eta' in self._save_fig_list.keys()):
+        elif ((save_eta_figs is False) and
+              ('eta' in self._save_fig_list.keys())):
             del self._save_fig_list['eta']
         self._save_eta_figs = save_eta_figs
 
@@ -660,8 +660,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_stage_figs is True) and \
           ('stage' not in self._save_fig_list.keys()):
             self._save_fig_list['stage'] = ['stage']
-        elif (save_stage_figs is False) and \
-          ('stage' in self._save_fig_list.keys()):
+        elif ((save_stage_figs is False) and
+              ('stage' in self._save_fig_list.keys())):
             del self._save_fig_list['stage']
         self._save_stage_figs = save_stage_figs
 
@@ -677,8 +677,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_depth_figs is True) and \
           ('depth' not in self._save_fig_list.keys()):
             self._save_fig_list['depth'] = ['depth']
-        elif (save_depth_figs is False) and \
-          ('depth' in self._save_fig_list.keys()):
+        elif ((save_depth_figs is False) and
+              ('depth' in self._save_fig_list.keys())):
             del self._save_fig_list['depth']
         self._save_depth_figs = save_depth_figs
 
@@ -694,8 +694,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_discharge_figs is True) and \
           ('discharge' not in self._save_fig_list.keys()):
             self._save_fig_list['discharge'] = ['qw']
-        elif (save_discharge_figs is False) and \
-          ('discharge' in self._save_fig_list):
+        elif ((save_discharge_figs is False) and
+              ('discharge' in self._save_fig_list)):
             del self._save_fig_list['discharge']
         self._save_discharge_figs = save_discharge_figs
 
@@ -711,8 +711,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_velocity_figs is True) and \
           ('velocity' not in self._save_fig_list.keys()):
             self._save_fig_list['velocity'] = ['uw']
-        elif (save_velocity_figs is False) and \
-          ('velocity' in self._save_fig_list.keys()):
+        elif ((save_velocity_figs is False) and
+              ('velocity' in self._save_fig_list.keys())):
             del self._save_fig_list['sedflux']
         self._save_velocity_figs = save_velocity_figs
 
@@ -728,8 +728,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_sedflux_figs is True) and \
           ('sedflux' not in self._save_fig_list.keys()):
             self._save_fig_list['sedflux'] = ['qs']
-        elif (save_sedflux_figs is False) and \
-          ('sedflux' in self._save_fig_list):
+        elif ((save_sedflux_figs is False) and
+              ('sedflux' in self._save_fig_list)):
             del self._save_fig_list['sedflux']
         self._save_sedflux_figs = save_sedflux_figs
 
@@ -746,8 +746,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         if (save_sandfrac_figs is True) and \
           ('sandfrac' not in self._save_fig_list.keys()):
             self._save_fig_list['sandfrac'] = ['sand_frac']
-        elif (save_sandfrac_figs is False) and \
-          ('sandfrac' in self._save_fig_list):
+        elif ((save_sandfrac_figs is False) and
+              ('sandfrac' in self._save_fig_list)):
             del self._save_fig_list['sandfrac']
         self._save_sandfrac_figs = save_sandfrac_figs
 
@@ -804,8 +804,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
           ('eta' not in self._save_var_list.keys()):
             self._save_var_list['eta'] = ['eta', 'meters', 'f4',
                                           ('total_time', 'length', 'width')]
-        elif (save_eta_grids is False) and \
-          ('eta' in self._save_var_list.keys()):
+        elif ((save_eta_grids is False) and
+              ('eta' in self._save_var_list.keys())):
             del self._save_var_list['eta']
         self._save_eta_grids = save_eta_grids
 
@@ -822,8 +822,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
           ('stage' not in self._save_var_list.keys()):
             self._save_var_list['stage'] = ['stage', 'meters', 'f4',
                                             ('total_time', 'length', 'width')]
-        elif (save_stage_grids is False) and \
-          ('stage' in self._save_var_list.keys()):
+        elif ((save_stage_grids is False) and
+              ('stage' in self._save_var_list.keys())):
             del self._save_var_list['stage']
         self._save_stage_grids = save_stage_grids
 
@@ -840,8 +840,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
           ('depth' not in self._save_var_list.keys()):
             self._save_var_list['depth'] = ['depth', 'meters', 'f4',
                                             ('total_time', 'length', 'width')]
-        elif (save_depth_grids is False) and \
-          ('depth' in self._save_var_list.keys()):
+        elif ((save_depth_grids is False) and
+              ('depth' in self._save_var_list.keys())):
             del self._save_var_list['depth']
         self._save_depth_grids = save_depth_grids
 
@@ -861,8 +861,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
                                                 'f4',
                                                 ('total_time', 'length',
                                                  'width')]
-        elif (save_discharge_grids is False) and \
-          ('discharge' in self._save_var_list.keys()):
+        elif ((save_discharge_grids is False) and
+              ('discharge' in self._save_var_list.keys())):
             del self._save_var_list['discharge']
         self._save_discharge_grids = save_discharge_grids
 
@@ -880,8 +880,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             self._save_var_list['velocity'] = ['uw', 'meters per second', 'f4',
                                                ('total_time', 'length',
                                                 'width')]
-        elif (save_velocity_grids is False) and \
-          ('velocity' in self._save_var_list.keys()):
+        elif ((save_velocity_grids is False) and
+              ('velocity' in self._save_var_list.keys())):
             del self._save_var_list['velocity']
         self._save_velocity_grids = save_velocity_grids
 
@@ -900,8 +900,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
                                               'f4',
                                               ('total_time', 'length',
                                                'width')]
-        elif (save_sedflux_grids is False) and \
-          ('sedflux' in self._save_var_list.keys()):
+        elif ((save_sedflux_grids is False) and
+              ('sedflux' in self._save_var_list.keys())):
             del self._save_var_list['sedflux']
         self._save_sedflux_grids = save_sedflux_grids
 
@@ -920,8 +920,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             self._save_var_list['sandfrac'] = ['sand_frac', 'fraction', 'f4',
                                                ('total_time', 'length',
                                                 'width')]
-        elif (save_sandfrac_grids is False) and \
-          ('sandfrac' in self._save_var_list.keys()):
+        elif ((save_sandfrac_grids is False) and
+              ('sandfrac' in self._save_var_list.keys())):
             del self._save_var_list['sandfrac']
         self._save_sandfrac_grids = save_sandfrac_grids
 

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -150,6 +150,30 @@ class TestModelDomainSetup:
         assert np.any(delta.sfc_sum) == 0
 
 
+class TestCreateBoundaryConditions:
+
+    # base case during init is covered by tests elsewhere!
+
+    def test_change_variable_updated_bcs(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        _delta = DeltaModel(input_file=p)
+
+        # what is Qw0 before?
+        assert _delta.Qw0 == 1250.0
+
+        # change u0
+        _delta.u0 = 2
+
+        # nothing has happened to Qw0 yet
+        assert _delta.u0 == 2
+        assert _delta.Qw0 == 1250.0
+
+        # now call to recreate, see what happened
+        _delta.create_boundary_conditions()
+        assert _delta.u0 == 2
+        assert _delta.Qw0 == 2500.0
+
+
 class TestInitSubsidence:
 
     def test_subsidence_bounds(self, tmp_path):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -476,7 +476,7 @@ class TestPublicSettersAndGetters:
         _delta = DeltaModel(input_file=p)
 
         # mock the init methods
-        _delta.create_other_variables = mock.MagicMock()
+        _delta.create_boundary_conditions = mock.MagicMock()
         _delta.init_sediment_routers = mock.MagicMock()
 
         # check initials
@@ -489,14 +489,14 @@ class TestPublicSettersAndGetters:
         assert _delta.channel_flow_velocity == _delta._u0
 
         # assert reinitializers called
-        assert (_delta.create_other_variables.called is True)
+        assert (_delta.create_boundary_conditions.called is True)
         assert (_delta.init_sediment_routers.called is True)
 
     def test_setting_getting_channel_width(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
         _delta = DeltaModel(input_file=p)
 
-        _delta.create_other_variables = mock.MagicMock()
+        _delta.create_boundary_conditions = mock.MagicMock()
         _delta.init_sediment_routers = mock.MagicMock()
 
         # check initials
@@ -504,14 +504,14 @@ class TestPublicSettersAndGetters:
 
         # change value
         #  the channel width is then changed internally with `N0`, according
-        #  to the `create_other_variables` so no change is actually made
+        #  to the `create_boundary_conditions` so no change is actually made
         #  here.
         with pytest.warns(UserWarning):
             _delta.channel_width = 300
         assert _delta.channel_width == 250  # not changed!
 
         # assert reinitializers called
-        assert (_delta.create_other_variables.called is True)
+        assert (_delta.create_boundary_conditions.called is True)
         assert (_delta.init_sediment_routers.called is True)
 
     def test_setting_getting_flow_depth(self, tmp_path):
@@ -519,7 +519,7 @@ class TestPublicSettersAndGetters:
         _delta = DeltaModel(input_file=p)
 
         # mock the init methods
-        _delta.create_other_variables = mock.MagicMock()
+        _delta.create_boundary_conditions = mock.MagicMock()
         _delta.init_sediment_routers = mock.MagicMock()
 
         # check initials
@@ -532,7 +532,7 @@ class TestPublicSettersAndGetters:
         assert _delta.channel_flow_depth == _delta._h0
 
         # assert reinitializers called
-        assert (_delta.create_other_variables.called is True)
+        assert (_delta.create_boundary_conditions.called is True)
         assert (_delta.init_sediment_routers.called is True)
 
     def test_setting_getting_influx_concentration(self, tmp_path):
@@ -540,7 +540,7 @@ class TestPublicSettersAndGetters:
         _delta = DeltaModel(input_file=p)
 
         # mock the init methods
-        _delta.create_other_variables = mock.MagicMock()
+        _delta.create_boundary_conditions = mock.MagicMock()
         _delta.init_sediment_routers = mock.MagicMock()
 
         # check initials
@@ -551,7 +551,7 @@ class TestPublicSettersAndGetters:
         assert _delta.C0_percent == 0.3
 
         # assert reinitializers called
-        assert (_delta.create_other_variables.called is True)
+        assert (_delta.create_boundary_conditions.called is True)
         assert (_delta.init_sediment_routers.called is True)
 
     def test_getter_nosetter_sea_surface_elevation(self, tmp_path):


### PR DESCRIPTION
This PR completes some refactoring of the initialization sequence, addressing #103.

In the first commit on this branch, I separated out parts of the initialization sequence that depend on the model "boundary conditions", especially those defined at the inlet. This at least makes it easy to call one method after changing boundary conditions.

In implementing though, I've realized though that we don't want the only behavior to be that any boundary condition change triggers a rebuild of the other boundary conditions, because this eliminates the ability to isolate the effect of a single parameter. One option would be to do a rebuild by default, but allow this to be overridden by some mechanism, but that would be very verbose code on our end. The downside of not rebuilding is, of course, that someone may forget to trigger the other boundary conditions to rebuild when they actually wanted them to be rebuilt.

I think this kind of comes down to another "swim at your own risk" situation, where we cannot cover every case and can't guarantee protection from reckless modeling. So the implemented solution is to add an example and documentation about when you need to trigger a rebuild of the boundary conditions, and when you may not want to.


Todo:
- [x] docs with an example of how to rerun the `create_boundary_condition` and an example of how to reimplement just one of the updates within the `create_boundary_condition` method, depending on what you are trying to achieve. 
- [x] a few tests checking that calling the method actually makes the change.
- [x] right now, the named boundary condition variables for the BMI **do** trigger a rebuild by default. Is this the behavior we want to keep? Is that confusing?

closes #103 