### PR TITLE
Allow custom subclass yaml parameters

### DIFF
--- a/docs/source/examples/custom_yaml.rst
+++ b/docs/source/examples/custom_yaml.rst
@@ -1,0 +1,84 @@
+Defining custom YAML parameters
+===============================
+
+.. currentmodule:: pyDeltaRCM.hook_tools
+
+Custom subclasses for the standard ``DeltaModel`` may require additional or custom parameters not listed in the :doc:`/reference/model/yaml_defaults`.
+By using the hook, :obj:`~hook_tools.hook_import_files`, it is straightforward to define custom YAML parameters along with expected types and default values for your subclassed model.
+
+The following subclass model demonstrates this by defining a custom boolean parameter (could be used to toggle some custom functionality on/off), and a custom numeric parameter (could be required for the custom function).
+
+.. doctest::
+
+    >>> import pyDeltaRCM
+
+    >>> class CustomParamsModel(pyDeltaRCM.DeltaModel):
+    ...     """A subclass of DeltaModel with custom YAML parameters.
+    ...
+    ...     This subclass defines custom YAML parameters, their expected types
+    ...     and default values.
+    ...     """
+    ...     def __init__(self, input_file=None, **kwargs):
+    ...
+    ...         # inherit base DeltaModel methods
+    ...         super().__init__(input_file, **kwargs)
+    ...
+    ...     def hook_import_files(self):
+    ...         """Define the custom YAML parameters."""
+    ...         # custom boolean parameter
+    ...         self.subclass_parameters['custom_bool'] = {
+    ...             'type': 'bool', 'default': False
+    ...         }
+    ...
+    ...         # custom numeric parameter
+    ...         self.subclass_parameters['custom_number'] = {
+    ...             'type': ['int', 'float'], 'default': 0
+    ...         }
+
+If the subclass model is loaded with a YAML configuration file that does not explicitly define these custom parameters, then the default values will be assigned as model attributes.
+
+.. code::
+
+    >>> defaults = CustomParamsModel()
+
+.. doctest::
+    :hide:
+
+    >>> with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    ...     defaults = CustomParamsModel(out_dir=output_dir)
+
+.. doctest::
+
+    >>> print(defaults.custom_bool)
+    False
+
+    >>> print(defaults.custom_number)
+    0
+
+.. note::
+
+   Since custom YAML parameters have expected types, ``TypeErrors`` are raised if the custom parameter type provided in the YAML does not agree with what is expected as defined in the subclass.
+
+
+Once the custom parameters have been defined in the subclassed model they can be treated just like the default model parameters, and can be specified in the YAML or as keyword arguments (``**kwargs``).
+
+.. code::
+
+    >>> customized = CustomParamsModel(custom_bool=True, custom_number=15.3)
+
+
+.. doctest::
+    :hide:
+
+    >>> with pyDeltaRCM.shared_tools._docs_temp_directory() as output_dir:
+    ...     customized = CustomParamsModel(out_dir=output_dir,
+    ...                                    custom_bool=True,
+    ...                                    custom_number=15.3)
+
+.. doctest::
+
+    >>> print(customized.custom_bool)
+    True
+
+    >>> print(customized.custom_number)
+    15.3

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -35,18 +35,11 @@ Modifying behavior of the Preprocessor
 
 * none
 
-Modifying variables saved in the output file
---------------------------------------------
-
-.. toctree::
-   :maxdepth: 1
-
-   custom_saving
-
-Defining custom YAML parameters
--------------------------------
+Modifying Model Input/Output
+----------------------------
 
 .. toctree::
    :maxdepth: 1
 
    custom_yaml
+   custom_saving

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -42,3 +42,11 @@ Modifying variables saved in the output file
    :maxdepth: 1
 
    custom_saving
+
+Defining custom YAML parameters
+-------------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   custom_yaml

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -36,15 +36,14 @@ class hook_tools(abc.ABC):
         This is the recommended hook to use for defining custom yaml parameters
         for a subclassed model. To allow the model to successfully load custom
         yaml parameters, expected types and default values need to be provided
-        as a dictionary in a model attribute, `_subclass_parameters`, which
+        as a dictionary in a model attribute, `subclass_parameters`, which
         should be defined here.
 
         The expected format is:
 
         .. code::
 
-            self._subclass_parameters = dict()
-            self._subclass_parameters['custom_param'] = {
+            self.subclass_parameters['custom_param'] = {
                 'type': ['expected_type'], 'default': default_value}  # noqa: E501
 
         """

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -36,8 +36,8 @@ class hook_tools(abc.ABC):
         This is the recommended hook to use for defining custom yaml parameters
         for a subclassed model. To allow the model to successfully load custom
         yaml parameters, expected types and default values need to be provided
-        as a dictionary in a model attribute, `subclass_parameters`, which
-        should be defined here.
+        as dictionary key-value pairs to the model attribute,
+        `subclass_parameters`.
 
         The expected format is:
 

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -32,6 +32,21 @@ class hook_tools(abc.ABC):
 
         Called immediately before
         :obj:`~pyDeltaRCM.init_tools.init_tools.import_files`.
+
+        This is the recommended hook to use for defining custom yaml parameters
+        for a subclassed model. To allow the model to successfully load custom
+        yaml parameters, expected types and default values need to be provided
+        as a dictionary in a model attribute, `_subclass_parameters`, which
+        should be defined here.
+
+        The expected format is:
+
+        .. code::
+
+            self._subclass_parameters = dict()
+            self._subclass_parameters['custom_param'] = {
+                'type': ['expected_type'], 'default': default_value}  # noqa: E501
+
         """
         pass
 
@@ -208,6 +223,19 @@ class hook_tools(abc.ABC):
 
             self._save_var_list['meta']['new_meta_name'] = ['varname', 'units',
                                                             'type', (dimensions)]  # noqa: E501
+
+        Expected format for time-varying metadata entries to the `meta`
+        dictionary nested within the `self._save_var_list` dictionary:
+
+        .. code::
+
+            self._save_var_list['meta']['new_meta_attribute_name'] = [
+                None, 'units', 'type', (dimensions)]  # noqa: E501
+
+        .. note::
+
+            For a vector of time-varying metadata, the dimension
+            should be specified as ('total_time').
 
         Expected format for time varying grid entries as keys within the
         `self._save_var_list` dictionary:

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -109,6 +109,11 @@ class init_tools(abc.ABC):
             else:
                 default_dict[k]['type'] = [eval(_v) for _v in v['type']]
 
+        # merge optional subclass params into defaults (subclass supercedes)
+        if hasattr(self, '_subclass_parameters'):
+            default_dict.update(self._subclass_parameters)
+            delattr(self, '_subclass_parameters')  # dont need attr anymore
+
         # only access the user input file if provided.
         if self.input_file:
             try:

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -109,11 +109,6 @@ class init_tools(abc.ABC):
             else:
                 default_dict[k]['type'] = [eval(_v) for _v in v['type']]
 
-        # merge optional subclass params into defaults (subclass supercedes)
-        if hasattr(self, '_subclass_parameters'):
-            default_dict.update(self._subclass_parameters)
-            delattr(self, '_subclass_parameters')  # dont need attr anymore
-
         # only access the user input file if provided.
         if self.input_file:
             try:
@@ -142,15 +137,40 @@ class init_tools(abc.ABC):
                 if type(user_dict[k]) in expected_type:
                     input_file_vars[k] = user_dict[k]
                 else:
-                    raise TypeError('Input for "{_k}" not of the right type '
-                                    'in yaml configuration file "{_file}". '
-                                    'Input type was "{_wastype}", '
-                                    'but needs to be "{_exptype}".'
-                                    .format(_k=str(k), _file=self.input_file,
-                                            _wastype=type(k).__name__,
-                                            _exptype=expected_type))
+                    raise TypeError(f'Input for {str(k)} not of the '
+                                    'right type in yaml configuration '
+                                    'file {self.input_file}. '
+                                    'Input type was {type(k).__name__}, '
+                                    'but needs to be {expected_type}.')
             else:
                 input_file_vars[k] = default_dict[k]['default']
+
+        # add custom subclass yaml parameters (yaml or defaults) to input vars
+        for k, v in self.subclass_parameters.items():
+            if k in input_file_vars:
+                warnings.warn(UserWarning(
+                    'Custom subclass parameter name is already a '
+                    'default yaml parameter of the model, '
+                    'custom parameter value will not be used.'
+                ))
+            elif k in user_dict:
+                # get expected types
+                if not type(v['type']) is list:
+                    expected_type = [eval(v['type'])]
+                else:
+                    expected_type = [eval(_v) for _v in v['type']]
+                # evaluate against expected types
+                if type(user_dict[k]) in expected_type:
+                    input_file_vars[k] = user_dict[k]
+                else:
+                    raise TypeError(f'Input for {str(k)} not of the '
+                                    'right type in yaml configuration '
+                                    'file {self.input_file}. '
+                                    'Input type was {type(k).__name__}, '
+                                    'but needs to be {expected_type}.')
+            else:
+                # set using default value
+                input_file_vars[k] = v['default']
 
         # save the input file as a hidden attr and grab needed value
         self._input_file_vars = input_file_vars

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -84,6 +84,10 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         _src_dir = os.path.realpath(os.path.dirname(__file__))
         self.default_file = os.path.join(_src_dir, 'default.yml')
 
+        # infrastructure for custom yaml parameters if needed
+        if hasattr(self, 'subclass_parameters') is False:
+            self.subclass_parameters = dict()  # init dict for custom params
+
         # check for any deprecated hooks
         self._check_deprecated_hooks()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -23,6 +23,8 @@ class Test__init__:
 
         assert _delta.time_iter == 0.
         assert _delta._is_finalized is False
+        # check that subclass parameter dictionary has been initialized
+        assert _delta.subclass_parameters == {}
 
     def test_error_if_no_file_found(self):
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
This is a proposal for a method of adding custom yaml parameters when using a model subclass. Aims to close #187.

Idea is that a subclass model establishes the expected `_subclass_parameters` in `hook_import_files`. The expected format is that of the regular `default.yml`-derived parameters so it includes the expected typing and default value for the custom yaml parameter. The amended doc-string for the hook with an example is below:

![image](https://user-images.githubusercontent.com/1770513/118895953-c6053000-b8cc-11eb-95bf-fd72a3c53084.png)

Implementation is pretty simple, the model checks if `_subclass_parameters` is an attribute of the model. If so, it merges that dictionary with the default yaml dictionary prior to reading the user's yaml file. 

Pros:
- Preserves type-checking functionality for custom parameters
- Allows subclass custom parameters to have default values

Cons:
- Forces subclass to use this standardized way of defining the custom parameter, type, and default
- Adds an if-statement to the `import_files` function
- Different syntax from `_save_fig_list` and `_save_var_list` (although all use dictionaries)

---
If this methodology is something we like, still need to do a few things before PR is ready:
- [x] write unit tests
- [x] make an example for subclass documentation
