### PR TITLE
Bugfix: hooks for parallel jobs, check calls in test

### DIFF
--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -854,8 +854,13 @@ class _ParallelJob(_BaseJob, multiprocessing.Process):
                     self.deltamodel.load_checkpoint(defer_output=False)
                 else:
                     # infrastructure deferred, need to trigger manually
+                    self.deltamodel.hook_init_output_file()
                     self.deltamodel.init_output_file()
+
+                    self.deltamodel.hook_output_data()
                     self.deltamodel.output_data()
+
+                    self.deltamodel.hook_output_checkpoint()
                     self.deltamodel.output_checkpoint()
 
                 # run the simualtion

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1038,6 +1038,12 @@ class TestParallelJob:
         pj.deltamodel.output_checkpoint = mock.MagicMock()
         pj.deltamodel.finalize = mock.MagicMock()
 
+        # mock initialization and their hooks
+        pj.deltamodel.init_output_file = mock.MagicMock()
+        pj.deltamodel.hook_init_output_file = mock.MagicMock()
+        pj.deltamodel.hook_output_data = mock.MagicMock()
+        pj.deltamodel.hook_output_checkpoint = mock.MagicMock()
+
         # run the method (call update 10 times)
         pj.run()
 
@@ -1050,6 +1056,11 @@ class TestParallelJob:
         assert pj.deltamodel.output_data.call_count == 11  # once in init
         assert pj.deltamodel.output_checkpoint.call_count == 11  # once in init
         assert pj.deltamodel.finalize.call_count == 1
+        # hooks/initialization
+        assert pj.deltamodel.init_output_file.call_count == 1
+        assert pj.deltamodel.hook_init_output_file.call_count == 1
+        assert pj.deltamodel.hook_output_data.call_count == 11
+        assert pj.deltamodel.hook_output_checkpoint.call_count == 11
 
         # check the log outputs for successes
         _calls = [mock.call({'job': 0, 'stage': 0, 'code': 0}),


### PR DESCRIPTION
The requirement that we "defer output" for the parallel jobs splits some of the initial output file creation to the preprocessor's ParallelJob. As hooks were added/changed we didn't include these hooks in the ParallelJob code.

This PR provides a fix by adding the hooks, and expanding the corresponding unit test. We could consider lumping these functions and hooks into a single call, but I am not sure it is worth doing for such a small group of functions that are currently well defined. 