### PR TITLE
add python 3.9 to ci build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
Looks like our upstream dependencies support Python 3.9 so we ought to test that version of Python :slightly_smiling_face: 