### PR TITLE
Header order

### DIFF
--- a/pyDeltaRCM/_version.py
+++ b/pyDeltaRCM/_version.py
@@ -4,4 +4,4 @@ def __version__():
     Private version declaration, gets assigned to pyDeltaRCM.__version__
     during import
     """
-    return '2.0.0'
+    return '2.0.1'

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -395,7 +395,8 @@ class BasePreprocessor(abc.ABC):
         #   Python preprocessing / postprocessing
         matrix_table_file = os.path.join(
             self._jobs_root, 'jobs_parameters.txt')
-        self._matrix_table_header = ', '.join(['job_id', *set0_set])
+        self._matrix_table_header = ', '.join(
+            ['job_id', *[i for i in _set[0].keys()]])
         np.savetxt(matrix_table_file, self._matrix_table,
                    fmt='%s', delimiter=',', comments='',
                    header=self._matrix_table_header)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -2,6 +2,7 @@
 import pytest
 
 import platform
+import os
 
 import unittest.mock as mock
 
@@ -484,6 +485,22 @@ class TestPreprocessorSetJobsSetups:
                            match=r'Colon operator found '
                                   'in matrix expansion key.'):  # noqa: E127
             _ = preprocessor.Preprocessor(input_file=p)
+
+    def test_output_table_correctly(self, tmp_path):
+        file_name = 'user_parameters.yaml'
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_set_to_file(
+            f, [{'f_bedload': 0.77, 'u0': 1, 'C0_percent': 0.033}])
+        f.close()
+        pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
+
+        # now check what the file looks like
+        with open(os.path.join(
+                tmp_path, 'test', 'jobs_parameters.txt'), 'r') as tbl:
+            Lines = tbl.readlines()
+
+        assert Lines[0] == 'job_id, f_bedload, u0, C0_percent\n'
 
 
 class TestPreprocessorEnsembleJobsSetups:


### PR DESCRIPTION
fixes a minor issue with the table written out by `set` expansion from the preprocessor. The header for the output table from `set` expansion was written by converting a python `set` to a list, but this did not preserve order.

This bug didn't affect the actual runs or the information recorded in the table, so it's just a minor fix.