### PR TITLE
Joss edits

### DIFF
--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -35,7 +35,11 @@ So, we simply create a `for` loop, and call the `update` function, and then wrap
 
     >>> default_delta.finalize()
 
-That's it! You ran the pyDeltaRCM model for five timesteps, with just five lines of code. 
+.. note::
+
+    Additional calls to update the model can be called up until the model is finalized.
+
+That's it! You ran the pyDeltaRCM model for five timesteps, with just five lines of code.
 
 We can visualize the delta bed elevation, though it's not very exciting after only five timesteps...
 
@@ -54,7 +58,7 @@ The model with set parameters
 -----------------------------
 
 To run a simulation with a non-default set of parameters, we use a configuration file written in the YAML markup language named `10min_tutorial.yaml`.
-This markup file allows us to specify model boundary conditions and input and output settings. 
+This markup file allows us to specify model boundary conditions and input and output settings.
 Anything you set in this file will override the :doc:`default parameters <../reference/model/yaml_defaults>` for the model.
 
 The YAML configuration file is central to managing *pyDeltaRCM* simulations, so we did not create this file for you; you will need to create the YAML file yourself.

--- a/docs/source/meta/installing.rst
+++ b/docs/source/meta/installing.rst
@@ -22,7 +22,7 @@ With Anaconda on Linux:
 
 .. code:: console
 
-    $ conda create -n deltarcm
+    $ conda create -n deltarcm python=3
     $ conda activate deltarcm
 
 For more informtaion, see `this guide <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment>`_ for help on creating and activating a virtual environment with Anaconda on other platforms.
@@ -102,6 +102,4 @@ Dependencies
 ============
 
 .. literalinclude:: ../../../requirements.txt
-   :linenos: 
-
-
+   :linenos:

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -138,10 +138,10 @@ class init_tools(abc.ABC):
                     input_file_vars[k] = user_dict[k]
                 else:
                     raise TypeError(f'Input for {str(k)} not of the '
-                                    'right type in yaml configuration '
-                                    'file {self.input_file}. '
-                                    'Input type was {type(k).__name__}, '
-                                    'but needs to be {expected_type}.')
+                                    f'right type in yaml configuration '
+                                    f'file {self.input_file}. '
+                                    f'Input type was {type(k).__name__}, '
+                                    f'but needs to be {expected_type}.')
             else:
                 input_file_vars[k] = default_dict[k]['default']
 
@@ -164,10 +164,10 @@ class init_tools(abc.ABC):
                     input_file_vars[k] = user_dict[k]
                 else:
                     raise TypeError(f'Input for {str(k)} not of the '
-                                    'right type in yaml configuration '
-                                    'file {self.input_file}. '
-                                    'Input type was {type(k).__name__}, '
-                                    'but needs to be {expected_type}.')
+                                    f'right type in yaml configuration '
+                                    f'file {self.input_file}. '
+                                    f'Input type was {type(k).__name__}, '
+                                    f'but needs to be {expected_type}.')
             else:
                 # set using default value
                 input_file_vars[k] = v['default']

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1224,7 +1224,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         stepmax is the maximum number of jumps a parcel (water or sediment)
         can make. If the parcel reaches the oceanic boundary before stepmax is
         reached, then this condition is not invoked. However if the parcel
-        does not reach the oceaninc bounary but does reach "stepmax" jumps,
+        does not reach the oceanic bounary but does reach "stepmax" jumps,
         then the parcel will just stop moving and disappear.
 
         If stepmax is not specified in the yaml, the default value assigned


### PR DESCRIPTION
This PR tries to address some points made in #219.

---

> The 10-minute tutorial is great, but it would be nice if you made it a bit more obvious how one can generate a nice-looking delta morphology with well-defined channels, e.g., by showing how running the default model for 1000 iterations (which might take a few minutes, but that's OK) gives a nice result.

Adds a note to state that the model can continue to be updated until it is finalized.

> However, I have tried to create an input 'yaml' file with all the parameters and ran into several problems. I have copied the parameter list from here and found that several of the default values listed there give an error message when I am trying to read the file. Also, those error messages look like "input for Np_water not of the right type in yaml configuration file {self.input_file}. Input type was {type(k).name}, but needs to be {expected_type}". I have got it to work in the end, but, long story short, it would be useful to provide an example input file with all the default parameters so that the user can have an overview of all the parameters and start changing them.

Fixes the f-strings so that the error message is actually helpful.

> In the same section, fix the typos in “oceaninc bounary”.

Fixes the typo in the doc-string for the `stepmax` attribute

> The installation instructions: when creating a new conda environment it is a good idea to specify the Python version (at least with my setup).

Revises conda environment instruction to `conda create -n deltarcm python=3`. Only potential issue here is that when a new major version of Python is released, there is some lag before all our dependencies will support it - this could lead to (short) periods of time where this installation process doesn't work.

