### PR TITLE
fix error thrown to log during finalize when no output exists.

### DIFF
--- a/docs/source/guides/advanced_configuration_guide.inc
+++ b/docs/source/guides/advanced_configuration_guide.inc
@@ -38,7 +38,7 @@ Each folder will contain a copy of the configuration file used for that job; for
     h0: 1.0
     f_bedload: 0.5
 
-Additionally, a log file for each job is located in the output folder, and any output grid files or images specified by the input configuration will be located in the respective job output folder.
+Additionally, a log file for each job is located in the output folder, and any output grid files or images specified by the input configuration will be located in the respective job output folder (note: there is no output NetCDF4 file for these runs).
 
 .. note:: You must specify the `out_dir` key in the input YAML configuration to use matrix expansion.
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -234,6 +234,8 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             self.output_netcdf.close()
             _msg = 'Closed output NetCDF4 file'
             self.log_info(_msg, verbosity=1)
+        except AttributeError:
+            self.log_info('No output NetCDF4 file to close.')
         except Exception as e:
             self.logger.error('Failed to close output NetCDF4 file')
             self.logger.exception(e)

--- a/tests/integration/test_timing_triggers.py
+++ b/tests/integration/test_timing_triggers.py
@@ -303,7 +303,7 @@ class TestTimingOutputData:
 
         # assert calls
         #   should only hit top-levels
-        assert _delta.log_info.call_count == 1
+        assert _delta.log_info.call_count == 2
         assert _delta.output_data.call_count == 0
         assert _delta.output_checkpoint.call_count == 0
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -423,7 +423,7 @@ class TestFinalize:
 
         # assert calls
         #  should hit all options since no saves
-        assert _delta.log_info.call_count == 1
+        assert _delta.log_info.call_count == 2
 
         # these were originally included in `finalize`, but no longer.
         #   the checks for no call are here to ensure we don't revert


### PR DESCRIPTION
An error is raised during `finalize` if no output file exists. This statement is captured in a `try-except`, so it does not derail the console, but it is recorded to the log for the job. This could lead to some confusion for a user, making them think there was an error with the runs themselves, when it was just a netcdf synching error (e.g., #217).

This PR simply catches an `AttributeError` raised at this point and reports "no file could be found" to the log. Other exceptions are still recorded to the log as-is.