### PR TITLE
Fix save_grids()

### DIFF
--- a/pyDeltaRCM/_version.py
+++ b/pyDeltaRCM/_version.py
@@ -4,4 +4,4 @@ def __version__():
     Private version declaration, gets assigned to pyDeltaRCM.__version__
     during import
     """
-    return '2.1.1'
+    return '2.1.2'

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -419,10 +419,11 @@ class iteration_tools(abc.ABC):
         self.log_info(_msg, verbosity=2)
         try:
             self.output_netcdf.variables[var_name][ts, :, :] = var
-        except:
-            _msg = 'Failed to save {var_name} grid to netCDF file.'.format(var_name=var_name)
+        except Exception as e:
+            _msg = (f'Failed to save {var_name} grid to netCDF file, '
+                    f'Exception: {e}')
             self.logger.error(_msg)
-            warnings.warn(UserWarning('Cannot save grid to netCDF file.'))
+            raise Exception(e)
 
     def save_the_checkpoint(self):
         """Save checkpoint files.

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -715,3 +715,22 @@ class TestSaveGrids:
         assert _arr.shape[1] == _delta.qs.shape[0]
         assert _arr.shape[2] == _delta.qs.shape[1]
         assert ('meta' in ds.groups)  # if any grids, save meta too
+
+    def test_save_grids_exception(self, tmp_path):
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml', {'save_dt': 1})
+        _delta = DeltaModel(input_file=p)
+
+        # mock the log_info
+        _delta.log_info = mock.MagicMock()
+
+        # no netcdf will be created
+        exp_path_nc = os.path.join(
+            tmp_path / 'out_dir', 'pyDeltaRCM_output.nc')
+        assert os.path.isfile(exp_path_nc) is False
+
+        # trying to save a grid will raise an exception
+        with pytest.raises(Exception):
+            _delta.save_grids('sedflux', _delta.qs, _delta._save_iter)
+
+        # assert log was called when exception was raised
+        assert (_delta.log_info.call_count == 1)

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -729,7 +729,7 @@ class TestSaveGrids:
         assert os.path.isfile(exp_path_nc) is False
 
         # trying to save a grid will raise an exception
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match=r"DeltaModel' object .*"):
             _delta.save_grids('sedflux', _delta.qs, _delta._save_iter)
 
         # assert log was called when exception was raised


### PR DESCRIPTION
Implements fix discussed in #236. Change logs the error message in the log-file and then raises it. Adds test to make sure error handling works as intended.

edit: so this closes #236