### PR TITLE
add two more "after" hooks

### DIFF
--- a/pyDeltaRCM/_version.py
+++ b/pyDeltaRCM/_version.py
@@ -4,4 +4,4 @@ def __version__():
     Private version declaration, gets assigned to pyDeltaRCM.__version__
     during import
     """
-    return '2.1.2'
+    return '2.1.3'

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -247,6 +247,15 @@ class hook_tools(abc.ABC):
         """
         pass
 
+    def hook_after_create_domain(self):
+        """Hook called *after* :obj:`~pyDeltaRCM.init_tools.init_tools.create_domain`.
+
+        Unlike the standard model hooks, this hook is called *after* the
+        domain has been created with the
+        method :obj:`~pyDeltaRCM.init_tools.init_tools.create_domain`
+        """
+        pass
+
     def hook_after_route_water(self):
         """Hook called *after* :obj:`~pyDeltaRCM.water_tools.water_tools.route_water`.
 
@@ -264,3 +273,16 @@ class hook_tools(abc.ABC):
         method :obj:`~pyDeltaRCM.sed_tools.sed_tools.route_sediment`
         """
         pass
+
+    def hook_after_finalize_timestep(self):
+        """Hook called *after* :obj:`~pyDeltaRCM.iteration_tools.finalize_timestep`.
+
+        Unlike the standard model hooks, this hook is called *after* the
+        finalize timestep method has completed. 
+
+        .. hint::
+
+            This is the last method called before logging and outputting data
+            for each timestep.
+        """
+        pass    

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -285,4 +285,4 @@ class hook_tools(abc.ABC):
             This is the last method called before logging and outputting data
             for each timestep.
         """
-        pass    
+        pass

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -113,6 +113,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
         # create the model domain based on configuration
         self.hook_create_domain()
         self.create_domain()
+        self.hook_after_create_domain()
 
         # initialize the sediment router classes
         self.init_sediment_routers()
@@ -194,6 +195,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
 
         self.hook_finalize_timestep()
         self.finalize_timestep()
+        self.hook_after_finalize_timestep()
 
         # update time-tracking fields
         self._time += self.dt


### PR DESCRIPTION
This PR adds two additional "after" style hooks. These are occurring after the domain setup `hook_after_create_domain` and after the last step of the timestep before saving the outputs `hook_after_finalize_timestep`.