### PR TITLE
add warning that job expansion does not work with low-level api.

### DIFF
--- a/docs/source/guides/advanced_configuration_guide.inc
+++ b/docs/source/guides/advanced_configuration_guide.inc
@@ -7,7 +7,12 @@ Advanced model configurations
 Configuring multiple model runs from a single YAML file
 ==============================================================
 
-Multiple model runs (referred to as "jobs") can be configured by a single `.yml` configuration file, by using the `matrix` and `ensemble` configuration keys.
+Multiple model runs (referred to as "jobs") can be configured by a single `.yml` configuration file and passing the file to the high-level API.
+Multiple runs can be configured by using the `matrix`, `ensemble`, and `set` configuration keys in the `.yml` file.
+
+.. important::
+
+    You cannot use any of `matrix` `ensemble` or `set` with the low-level API. If you need, you could use the high-level API to generate the scripts for each job (e.g., `timesteps: 0`) and then manually generate `DeltaModel` instances from each `.yml` file to then use with the low-level API.
 
 .. _matrix_expansion_tag:
 


### PR DESCRIPTION
adds a simple warning for using job expansion with the low-level api.

closes #248 