### PR TITLE
add an array called 'water_mod' that allows the weighting of water ro…

### DIFF
--- a/docs/source/info/index.rst
+++ b/docs/source/info/index.rst
@@ -19,3 +19,4 @@ All of these questions and more are answered here!
    hydrodynamics
    morphodynamics
    outputfile
+   ../reference/model/model_hooks

--- a/docs/source/info/yamlparameters.rst
+++ b/docs/source/info/yamlparameters.rst
@@ -9,6 +9,12 @@ provided below. The YAML parameters are sorted by "type", for example,
 :ref:`model-domain-parameters` are those parameters which control the
 definition of the pyDeltaRCM model domain.
 
+.. hint::
+
+    View the complete list of default values and expected types
+    here: :doc:`../reference/model/yaml_defaults`.
+
+
 Model Settings
 ==============
 
@@ -34,10 +40,6 @@ Model Domain Parameters
 
 :attr:`pyDeltaRCM.model.DeltaModel.S0`
 
-:attr:`pyDeltaRCM.model.DeltaModel.itermax`
-
-:attr:`pyDeltaRCM.model.DeltaModel.Np_water`
-
 :attr:`pyDeltaRCM.model.DeltaModel.u0`
 
 :attr:`pyDeltaRCM.model.DeltaModel.N0_meters`
@@ -50,15 +52,11 @@ Model Domain Parameters
 
 :attr:`pyDeltaRCM.model.DeltaModel.SLR`
 
-:attr:`pyDeltaRCM.model.DeltaModel.Np_sed`
-
 :attr:`pyDeltaRCM.model.DeltaModel.f_bedload`
-
-:attr:`pyDeltaRCM.model.DeltaModel.active_layer_thickness`
 
 :attr:`pyDeltaRCM.model.DeltaModel.C0_percent`
 
-:attr:`pyDeltaRCM.model.DeltaModel.Csmooth`
+:attr:`pyDeltaRCM.model.DeltaModel.active_layer_thickness`
 
 :attr:`pyDeltaRCM.model.DeltaModel.toggle_subsidence`
 
@@ -120,11 +118,19 @@ Output Settings
 Reduced-Complexity Routing Parameters
 =====================================
 
+:attr:`pyDeltaRCM.model.DeltaModel.Np_sed`
+
+:attr:`pyDeltaRCM.model.DeltaModel.Np_water`
+
 :attr:`pyDeltaRCM.model.DeltaModel.omega_sfc`
 
 :attr:`pyDeltaRCM.model.DeltaModel.omega_flow`
 
+:attr:`pyDeltaRCM.model.DeltaModel.itermax`
+
 :attr:`pyDeltaRCM.model.DeltaModel.Nsmooth`
+
+:attr:`pyDeltaRCM.model.DeltaModel.Csmooth`
 
 :attr:`pyDeltaRCM.model.DeltaModel.theta_water`
 

--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -56,5 +56,5 @@ A complete list of behavior-modifying arrays in the model follows:
     :header: "Array name", "function", "default value"
     :widths: 20, 50, 10
 
-    `water_mod`, modifies the neighbor-weighting of water parcels during routing according to ``(depth * water_mod)**theta_water``, 1
+    `mod_water_weight`, modifies the neighbor-weighting of water parcels during routing according to ``(depth * mod_water_weight)**theta_water``, 1
 

--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -1,11 +1,27 @@
 Available Model Hooks
 =====================
 
+.. important::
+
+    Have a suggestion for another `hook` in the DeltaModel? Get in touch via
+    the GitHub issue tracker!
+
+
+Method hooks
+------------
+
+As described extensively in the :ref:`User Guide on how to customize the model
+<customize_the_model>`, hooks are methods in the model sequence that do
+nothing by default, but can be augmented to provide arbitrary desired
+behavior in the model. Hooks have been integrated throughout the model
+initialization and update sequences, to allow the users to achieve complex
+behavior at various stages of the model sequence.
+
 A complete list of hooks in the model follows:
 
 .. currentmodule:: pyDeltaRCM.hook_tools
 
-.. csv-table:: Available model hooks
+.. csv-table:: Available model method hooks
     :header: "Initializing", "Updating"
     :widths: 40, 40
 
@@ -24,3 +40,21 @@ A complete list of hooks in the model follows:
     , :obj:`~hook_tools.hook_compute_sand_frac`
     , :obj:`~hook_tools.hook_after_route_water`
     , :obj:`~hook_tools.hook_after_route_sediment`
+
+
+Array hooks
+-----------
+
+The `DeltaModel` also incorporates a few arrays that enable a similar effect
+to method hooks. These arrays are initialized with all ``1`` or all ``0``
+values by default (depending on the scenario), and provide a convenient
+location to augment the model with varied behavior.
+
+A complete list of behavior-modifying arrays in the model follows:
+
+.. csv-table:: Available model array hooks
+    :header: "Array name", "function", "default value"
+    :widths: 20, 50, 10
+
+    `water_mod`, modifies the neighbor-weighting of water parcels during routing according to ``(depth * water_mod)**theta_water``, 1
+

--- a/docs/source/reference/model/yaml_defaults.rst
+++ b/docs/source/reference/model/yaml_defaults.rst
@@ -1,7 +1,13 @@
 Default Model Variable Values
 =============================
 
-Default model values are defined as:
+.. hint::
+
+   A complete list of the meaning of each YAML parameter can be found at 
+   :doc:`../info/yaml_parameters`.
+
+
+Default model parameter values are defined as:
 
 .. literalinclude:: ../../../../pyDeltaRCM/default.yml
    :language: yaml

--- a/docs/source/reference/model/yaml_defaults.rst
+++ b/docs/source/reference/model/yaml_defaults.rst
@@ -4,7 +4,7 @@ Default Model Variable Values
 .. hint::
 
    A complete list of the meaning of each YAML parameter can be found at 
-   :doc:`../info/yaml_parameters`.
+   :doc:`../../info/yamlparameters`.
 
 
 Default model parameter values are defined as:

--- a/pyDeltaRCM/_version.py
+++ b/pyDeltaRCM/_version.py
@@ -4,4 +4,4 @@ def __version__() -> str:
     Private version declaration, gets assigned to pyDeltaRCM.__version__
     during import
     """
-    return '2.1.3'
+    return '2.1.4'

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -176,11 +176,12 @@ class init_tools(abc.ABC):
         # parameters exist, we warn the user that they are not being used! A
         # special warning is issued for the Preprocessor advanced config
         # keywords, which cannot be passed directly to the DeltaModel.
+        pp_only_kw = ['matrix', 'ensemble', 'set', 'parallel']
         unused_user_keys = [k for k, v in user_dict.items() if not
                             (k in input_file_vars.keys())]
         if len(unused_user_keys) > 0:
             any_in_preprocessor = [k for k in unused_user_keys if
-                                   (k in ['matrix', 'ensemble', 'set'])]
+                                   (k in pp_only_kw)]
             if len(any_in_preprocessor):
                 warnings.warn(UserWarning(
                     'A Preprocessor-only keyword was specified as input in '

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -497,6 +497,7 @@ class init_tools(abc.ABC):
             (self._Np_water, self.size_indices), dtype=np.int64)
         self.sfc_visit = np.zeros_like(self.depth)
         self.sfc_sum = np.zeros_like(self.depth)
+        self.weight_mod = np.ones_like(self.depth)  # custom water weight modifier
 
         # ---- domain ----
         cell_land = -2

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -498,7 +498,9 @@ class init_tools(abc.ABC):
             (self._Np_water, self.size_indices), dtype=np.int64)
         self.sfc_visit = np.zeros_like(self.depth)
         self.sfc_sum = np.zeros_like(self.depth)
-        self.weight_mod = np.ones_like(self.depth)  # custom water weight modifier
+        
+        # arrays acting as modifying hooks
+        self.mod_water_weight = np.ones_like(self.depth)
 
         # ---- domain ----
         cell_land = -2

--- a/pyDeltaRCM/water_tools.py
+++ b/pyDeltaRCM/water_tools.py
@@ -371,8 +371,8 @@ class water_tools(abc.ABC):
         # compiling the water weight array is handled inside a jitted
         #     function below. ~4x faster.
         self.water_weights = _get_water_weight_array(
-            self.depth, self.stage, self.cell_type, self.qx, self.qy,
-            self.ivec_flat, self.jvec_flat, self.distances_flat,
+            self.depth, self.stage, self.weight_mod, self.cell_type,
+            self.qx, self.qy, self.ivec_flat, self.jvec_flat, self.distances_flat,
             self.dry_depth, self.gamma, self._theta_water)
 
     def update_Q(self, dist, current_inds, next_inds, astep, jstep, istep,
@@ -568,7 +568,8 @@ class water_tools(abc.ABC):
 
 
 @njit
-def _get_weight_at_cell_water(ind, weight_sfc, weight_int, depth_nbrs, ct_nbrs,
+def _get_weight_at_cell_water(ind, weight_sfc, weight_int, depth_nbrs,
+                              weight_mod, ct_nbrs,
                               dry_depth, gamma, theta):
     """Compute water weights for a given cell.
 
@@ -603,7 +604,7 @@ def _get_weight_at_cell_water(ind, weight_sfc, weight_int, depth_nbrs, ct_nbrs,
         weight_int = weight_int / np.sum(weight_int)
 
     weight = gamma * weight_sfc + (1 - gamma) * weight_int
-    weight = (depth_nbrs ** theta) * weight
+    weight = ((depth_nbrs * weight_mod) ** theta) * weight
 
     # enforce disallowed choice to not move
     weight[ctr] = 0
@@ -657,7 +658,7 @@ def _get_weight_at_cell_water(ind, weight_sfc, weight_int, depth_nbrs, ct_nbrs,
 #       'float32[:], float32[:], float32[:],'
 #       'float64, float64, float64)')
 @njit
-def _get_water_weight_array(depth, stage, cell_type, qx, qy,
+def _get_water_weight_array(depth, stage, weight_mod, cell_type, qx, qy,
                             ivec_flat, jvec_flat, distances_flat,
                             dry_depth, gamma, theta_water):
     """Worker for :obj:`_get_water_weight_array`.
@@ -677,6 +678,7 @@ def _get_water_weight_array(depth, stage, cell_type, qx, qy,
     L, W = depth.shape
     pad_stage = shared_tools.custom_pad(stage)
     pad_depth = shared_tools.custom_pad(depth)
+    pad_weight_mod = shared_tools.custom_pad(weight_mod)
     pad_cell_type = shared_tools.custom_pad(cell_type)
 
     water_weights = np.zeros((L, W, 9))
@@ -685,6 +687,7 @@ def _get_water_weight_array(depth, stage, cell_type, qx, qy,
         for j in range(W):
             stage_nbrs = pad_stage[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
             depth_nbrs = pad_depth[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
+            weight_mod_nbrs = pad_weight_mod[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
             ct_nbrs = pad_cell_type[i - 1 + 1:i + 2 + 1, j - 1 + 1:j + 2 + 1]
 
             weight_sfc, weight_int = shared_tools.get_weight_sfc_int(
@@ -694,7 +697,7 @@ def _get_water_weight_array(depth, stage, cell_type, qx, qy,
 
             water_weights[i, j] = _get_weight_at_cell_water(
                 (i, j), weight_sfc, weight_int,
-                depth_nbrs.ravel(), ct_nbrs.ravel(),
+                depth_nbrs.ravel(), weight_mod_nbrs.ravel(), ct_nbrs.ravel(),
                 dry_depth, gamma, theta_water)
 
     return water_weights

--- a/tests/test_water_tools.py
+++ b/tests/test_water_tools.py
@@ -54,11 +54,12 @@ class TestWaterRoutingWeights:
         theta = 1
         weight_sfc = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.float64)
         weight_int = np.array([0, 0, 0, 0, 0, 1, 0, 1, 1], dtype=np.float64)
+        weight_mod = np.array([0, 0, 0, 0, 0, 1, 0, 1, 1], dtype=np.float64)
 
         # get weights back from the test
         wts = water_tools._get_weight_at_cell_water(
             ind, weight_sfc, weight_int, depth,
-            celltype, dry_thresh, gamma, theta)
+            weight_mod, celltype, dry_thresh, gamma, theta)
         assert np.all(wts[[0, 1, 2, 5]] == 0)
         assert wts[4] == 0
         assert np.any(wts[[3, 6, 7, 8]] != 0)


### PR DESCRIPTION
## change
add an array called `mod_water_weight` that allows the weighting of water routing to be modulated by changing the values in this array. 

The weights in water routing are modified according to `(depth*mod_water_weight)**theta` [default is for all `mod_water_weight` values to be `1` and have no effect].

## speed 
Did some basic profiling of the code (10 steps on checkpoint delta from docs), and the speed is not meaningfully impacted. Three runs without this change and three runs after this change: `before [16.081, 16.054, 16.038] sec`, and `after [15.964, 16.062, 16.215] sec`. Note, these "after" runs did not _modify_ the `water_mod` array, just used the default value `1`.

## todo
- [x] needs to be documented somewhere?