### PR TITLE
array to spatially modify sediment erodibility

### DIFF
--- a/docs/source/reference/model/model_hooks.rst
+++ b/docs/source/reference/model/model_hooks.rst
@@ -57,4 +57,6 @@ A complete list of behavior-modifying arrays in the model follows:
     :widths: 20, 50, 10
 
     `mod_water_weight`, modifies the neighbor-weighting of water parcels during routing according to ``(depth * mod_water_weight)**theta_water``, 1
+    `mod_sed_weight`, modifies the neighbor-weighting of the sediment parcel routing according to ``(depth * mod_sed_weight)**theta_sed``, 1
+    `mod_erosion`, linearly modifies the "erodibility" of cells according to ``mod_erosion * Vp_sed * (U_loc**beta - U_ero**beta) / U_ero**beta``, 1
 

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -257,7 +257,7 @@ class init_tools(abc.ABC):
 
         Creates variables for model implementation, from specified boundary
         condition variables. This method is run during initial model
-        instantition. Internally, this method calls :obj:`set_constants` and
+        instantiation. Internally, this method calls :obj:`set_constants` and
         :obj:`create_boundary_conditions`.
 
         .. note::
@@ -452,7 +452,7 @@ class init_tools(abc.ABC):
 
             If you need to modify the model domain after it has been created,
             it is probably safe to modify attributes directly, but take care
-            to ensure any dependent fields are also approrpriately changed.
+            to ensure any dependent fields are also appropriately changed.
         """
         _msg = 'Creating model domain'
         self.log_info(_msg, verbosity=1)
@@ -781,7 +781,7 @@ class init_tools(abc.ABC):
 
         As a standard user, you should not need to worry about any of these
         pathways or options. However, if you are developing pyDeltaRCM or
-        customizing the model in any way that involves loadind from
+        customizing the model in any way that involves loading from
         checkpoints, you should be aware of these pathways.
 
         For example, loading from checkpoint will succeed if no netCDF4 file
@@ -791,7 +791,7 @@ class init_tools(abc.ABC):
 
         .. important::
 
-            If you are customing the model and intend to use checkpointing and
+            If you are customizing the model and intend to use checkpointing and
             the :obj:`Preprocessor` parallel infrastructure, be sure that
             parameter :obj:`defer_output` is `True` until the
             :obj:`load_checkpoint` method can be called from the thread the

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -500,6 +500,9 @@ class init_tools(abc.ABC):
         # arrays acting as modifying hooks
         self.mod_water_weight = np.ones_like(self.depth)
 
+        # custom sediment erodibility modifier
+        self.erosion_mod = np.ones_like(self.depth)
+
         # ---- domain ----
         cell_land = -2
         cell_channel = 1
@@ -571,7 +574,7 @@ class init_tools(abc.ABC):
                                        self.iwalk_flat, self.jwalk_flat,
                                        self.distances_flat, self.dry_depth,
                                        self._lambda, self._beta,  self.stepmax,
-                                       self.theta_mud)
+                                       self.theta_mud, self.erosion_mod)
         # initialize the SandRouter object
         self._sr = sed_tools.SandRouter(self._dt, self._dx, self.Vp_sed,
                                         self.u_max, self.qs0, self._u0,
@@ -581,7 +584,7 @@ class init_tools(abc.ABC):
                                         self.iwalk_flat, self.jwalk_flat,
                                         self.distances_flat, self.dry_depth,
                                         self._beta, self.stepmax,
-                                        self.theta_sand)
+                                        self.theta_sand, self.erosion_mod)
 
     def init_output_file(self) -> None:
         """Creates a netCDF file to store output grids.

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -499,9 +499,8 @@ class init_tools(abc.ABC):
         
         # arrays acting as modifying hooks
         self.mod_water_weight = np.ones_like(self.depth)
-
-        # custom sediment erodibility modifier
-        self.erosion_mod = np.ones_like(self.depth)
+        self.mod_sed_weight = np.ones_like(self.depth)
+        self.mod_erosion = np.ones_like(self.depth)
 
         # ---- domain ----
         cell_land = -2
@@ -574,7 +573,7 @@ class init_tools(abc.ABC):
                                        self.iwalk_flat, self.jwalk_flat,
                                        self.distances_flat, self.dry_depth,
                                        self._lambda, self._beta,  self.stepmax,
-                                       self.theta_mud, self.erosion_mod)
+                                       self.theta_mud, self.mod_erosion)
         # initialize the SandRouter object
         self._sr = sed_tools.SandRouter(self._dt, self._dx, self.Vp_sed,
                                         self.u_max, self.qs0, self._u0,
@@ -584,7 +583,7 @@ class init_tools(abc.ABC):
                                         self.iwalk_flat, self.jwalk_flat,
                                         self.distances_flat, self.dry_depth,
                                         self._beta, self.stepmax,
-                                        self.theta_sand, self.erosion_mod)
+                                        self.theta_sand, self.mod_erosion)
 
     def init_output_file(self) -> None:
         """Creates a netCDF file to store output grids.

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -235,8 +235,8 @@ class iteration_tools(abc.ABC):
     def save_grids_and_figs(self) -> None:
         """Save grids and figures.
 
-        Save grids and/or plots of specified variables (``eta``, `discharge``,
-        ``velocity``, ``depth``, and ``stage``, depending on configuration of
+        Save grids and/or plots of specified variables (``eta``, ``discharge``,
+        ``velocity``, ``depth``, and ``stage``), depending on configuration of
         the relevant flags in the YAML configuration file.
 
         .. note:

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -48,7 +48,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             Whether to create the output netCDF file during initialization. In
             most cases, this can be ignored and left to default value `False`.
             However, for parallel simulations it may be necessary to defer the
-            NetCDF file creation unitl the simualtion is assigned to the core
+            NetCDF file creation until the simulation is assigned to the core
             it will compute on, so that the DeltaModel object remains
             pickle-able. Note, you will need to manually trigger the
             :obj:`init_output_file`, :obj:`output_data`, and
@@ -59,7 +59,7 @@ class DeltaModel(iteration_tools, sed_tools, water_tools,
             be passed as a keyword argument to the instantiation of the
             DeltaModel. Keywords will override the specification of any value
             in the YAML file. This functionality is intended for advanced use
-            cases, and should not be preffered to specifying all inputs in a
+            cases, and should not be preferred to specifying all inputs in a
             YAML configuration file.
 
         Returns

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -1127,7 +1127,7 @@ def preprocessor_wrapper() -> None:
 def _write_yaml_config_to_file(_config, _path) -> None:
     """Write a config to file in output folder.
 
-    Write the entire yaml configuation for the configured job out to a
+    Write the entire yaml configuration for the configured job out to a
     file in the job output foler.
 
     .. note::


### PR DESCRIPTION
This PR adds two "method modifying arrays": `mod_erosion` and `mod_sed_weight`. `mod_sed_weight` is analogous modification to #255 except for sediment, while `mod_erosion` can be used to linearly modify the erodibility of cells within the domain. Both arrays are all 1s by default, thus leaving default behavior of the model unchangd. 

Our current formula for erosion is: `Vp_sed * (U_loc**beta - U_ero**beta) / U_ero**beta`

This PR proposes changing that formula to: `mod_erosion * Vp_sed * (U_loc**beta - U_ero**beta) / U_ero**beta`

For weighting we now use the formula: `(depth * mod_sed_weight)**theta_sed` where previously this was just `depth**theta_sed`

---

Toy example of varying sediment erodibility across the basin. The model uses default parameters, except for the two rectangular sections, the red is 10x more erodible than normal, while the blue is 100x less erodible. Below is the topography after running the model for 2000 timesteps.

![erodible_ex](https://user-images.githubusercontent.com/1770513/171287372-9f224a5c-f78d-4c03-8086-6b796f1b9a99.png)

