### PR TITLE
Addtl documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,24 @@ Citing pyDeltaRCM
 
 When citing *pyDeltaRCM*, please cite the `JOSS paper <https://doi.org/10.21105/joss.03398>`_:
 
-Moodie et al., (2021). pyDeltaRCM: a flexible numerical delta model. Journal of Open Source Software, 6(64), 3398, https://doi.org/10.21105/joss.03398::
+	Moodie et al., (2021). pyDeltaRCM: a flexible numerical delta model. Journal of Open Source Software, 6(64), 3398, https://doi.org/10.21105/joss.03398
 	
 If you use BibTeX, you can add *pyDeltaRCM* to your `.bib` file using the following code:
 
-@article{Moodie2021, doi = {10.21105/joss.03398}, url = {https://doi.org/10.21105/joss.03398}, year = {2021}, publisher = {The Open Journal}, volume = {6}, number = {64}, pages = {3398}, author = {Andrew J. Moodie and Jayaram Hariharan and Eric Barefoot and Paola Passalacqua}, title = {*pyDeltaRCM*: a flexible numerical delta model}, journal = {Journal of Open Source Software} }::
+.. code:: console
+
+	@article{Moodie2021,
+	doi = {10.21105/joss.03398},
+	url = {https://doi.org/10.21105/joss.03398},
+	year = {2021},
+	publisher = {The Open Journal},
+	volume = {6},
+	number = {64},
+	pages = {3398},
+	author = {Andrew J. Moodie and Jayaram Hariharan and Eric Barefoot and Paola Passalacqua},
+	title = {*pyDeltaRCM*: a flexible numerical delta model},
+	journal = {Journal of Open Source Software}
+	}
 
 
 Additional notes

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,22 @@ We recommend you check out our `pyDeltaRCM in 10 minutes tutorial <https://delta
 Beyond that brief tutorial, we have a comprehensive `User Documentation <https://deltarcm.org/pyDeltaRCM/index.html#user-documentation>`_ and `Developer Documentation <https://deltarcm.org/pyDeltaRCM/index.html#developer-documentation>`_ to check out.
 
 
+Citing pyDeltaRCM
+#################
+
+When citing *pyDeltaRCM*, please cite the JOSS paper:
+
+.. code:: console
+
+	Moodie et al., (2021). pyDeltaRCM: a flexible numerical delta model. Journal of Open Source Software, 6(64), 3398, https://doi.org/10.21105/joss.03398
+	
+If you use BibTeX, you can add *pyDeltaRCM* to your `.bib` file using the following code:
+
+.. code:: console
+
+	@article{Moodie2021, doi = {10.21105/joss.03398}, url = {https://doi.org/10.21105/joss.03398}, year = {2021}, publisher = {The Open Journal}, volume = {6}, number = {64}, pages = {3398}, author = {Andrew J. Moodie and Jayaram Hariharan and Eric Barefoot and Paola Passalacqua}, title = {*pyDeltaRCM*: a flexible numerical delta model}, journal = {Journal of Open Source Software} }
+
+
 Additional notes
 ################
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ pyDeltaRCM
     :target: https://github.com/DeltaRCM/pyDeltaRCM/actions
 
 .. image:: https://codecov.io/gh/DeltaRCM/pyDeltaRCM/branch/develop/graph/badge.svg
-  :target: https://codecov.io/gh/DeltaRCM/pyDeltaRCM
+    :target: https://codecov.io/gh/DeltaRCM/pyDeltaRCM
 
 .. image:: https://app.codacy.com/project/badge/Grade/1c137d0227914741a9ba09f0b00a49a7
     :target: https://www.codacy.com/gh/DeltaRCM/pyDeltaRCM?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=DeltaRCM/pyDeltaRCM&amp;utm_campaign=Badge_Grade
@@ -60,17 +60,13 @@ Beyond that brief tutorial, we have a comprehensive `User Documentation <https:/
 Citing pyDeltaRCM
 #################
 
-When citing *pyDeltaRCM*, please cite the JOSS paper:
+When citing *pyDeltaRCM*, please cite the `JOSS paper <https://doi.org/10.21105/joss.03398>`_:
 
-.. code:: console
-
-	Moodie et al., (2021). pyDeltaRCM: a flexible numerical delta model. Journal of Open Source Software, 6(64), 3398, https://doi.org/10.21105/joss.03398
+Moodie et al., (2021). pyDeltaRCM: a flexible numerical delta model. Journal of Open Source Software, 6(64), 3398, https://doi.org/10.21105/joss.03398::
 	
 If you use BibTeX, you can add *pyDeltaRCM* to your `.bib` file using the following code:
 
-.. code:: console
-
-	@article{Moodie2021, doi = {10.21105/joss.03398}, url = {https://doi.org/10.21105/joss.03398}, year = {2021}, publisher = {The Open Journal}, volume = {6}, number = {64}, pages = {3398}, author = {Andrew J. Moodie and Jayaram Hariharan and Eric Barefoot and Paola Passalacqua}, title = {*pyDeltaRCM*: a flexible numerical delta model}, journal = {Journal of Open Source Software} }
+@article{Moodie2021, doi = {10.21105/joss.03398}, url = {https://doi.org/10.21105/joss.03398}, year = {2021}, publisher = {The Open Journal}, volume = {6}, number = {64}, pages = {3398}, author = {Andrew J. Moodie and Jayaram Hariharan and Eric Barefoot and Paola Passalacqua}, title = {*pyDeltaRCM*: a flexible numerical delta model}, journal = {Journal of Open Source Software} }::
 
 
 Additional notes

--- a/docs/source/examples/modelzoo.rst
+++ b/docs/source/examples/modelzoo.rst
@@ -5,3 +5,34 @@ Below is a "model zoo" containing a list with links to customized subclasses
 of the *pyDeltaRCM* found "in the wild". If you have a implemented a custom
 subclass of the model and would like us to highlight it here please reach out
 or open a pull request!
+
+VegetationModel
+---------------
+Link: `VegetationModel <https://github.com/amoodie/Vegetation_pyDeltaRCM>`_
+
+This implementation of the *pyDeltaRCM* model is based off of the "DeltaRCM
+Vegetation" model presented in `Lauzon and Murray (2018) <https://doi.org/10.1029/2018GL079405>`_.
+
+MississippiFaultsModel
+----------------------
+Link: `MississippiFaultsModel <https://github.com/amoodie/paper_resources/blob/master/Moodie_faultingsubsidence/model/scripts/mississippi_faults.py>`_
+
+This implementation of the *pyDeltaRCM* model is used in the paper
+`Moodie and Passalacqua (2021) <https://doi.org/10.1029/2021GL095053>`_ to
+simulate a Mississippi River-like delta.
+
+SelengaModel
+------------
+Link: `SelengaModel <https://github.com/amoodie/paper_resources/blob/master/Moodie_faultingsubsidence/model/scripts/selenga_faults.py>`_
+
+This implementation of the *pyDeltaRCM* model is used in the paper
+`Moodie and Passalacqua (2021) <https://doi.org/10.1029/2021GL095053>`_ to
+simulate a Selenga River-like delta.
+
+VariableSLRModel
+----------------
+Link: `VariableSLRModel <https://github.com/elbeejay/variableSLR_pyDeltaRCM>`_
+
+This implementation of the *pyDeltaRCM* model is used in the paper
+`Hariharan et al (2022) <https://doi.org/10.1029/2022JF006762>`_ to simulate
+variable sea level rise scenarios.

--- a/docs/source/examples/modelzoo.rst
+++ b/docs/source/examples/modelzoo.rst
@@ -1,0 +1,7 @@
+Customized Applications of *pyDeltaRCM*
+=======================================
+
+Below is a "model zoo" containing a list with links to customized subclasses
+of the *pyDeltaRCM* found "in the wild". If you have a implemented a custom
+subclass of the model and would like us to highlight it here please reach out
+or open a pull request!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,8 @@ Project information
    meta/contributing
    meta/license
    meta/conduct
+   meta/citing
+   meta/usedby
 
 
 .. _user_documentation:
@@ -47,6 +49,7 @@ User documentation
    guides/user_guide
    info/index
    examples/index
+   examples/modelzoo
 
 
 
@@ -58,12 +61,12 @@ Developer documentation
 
 .. image:: https://github.com/DeltaRCM/pyDeltaRCM/actions/workflows/build.yml/badge.svg
     :target: https://github.com/DeltaRCM/pyDeltaRCM/actions
-    
+
 .. image:: https://codecov.io/gh/DeltaRCM/pyDeltaRCM/branch/develop/graph/badge.svg
   :target: https://codecov.io/gh/DeltaRCM/pyDeltaRCM
 
 .. image:: https://app.codacy.com/project/badge/Grade/1c137d0227914741a9ba09f0b00a49a7
-    :target: https://www.codacy.com/gh/DeltaRCM/pyDeltaRCM?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=DeltaRCM/pyDeltaRCM&amp;utm_campaign=Badge_Grade   
+    :target: https://www.codacy.com/gh/DeltaRCM/pyDeltaRCM?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=DeltaRCM/pyDeltaRCM&amp;utm_campaign=Badge_Grade
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/meta/citing.rst
+++ b/docs/source/meta/citing.rst
@@ -1,0 +1,24 @@
+*******************
+Citing *pyDeltaRCM*
+*******************
+
+When citing *pyDeltaRCM*, please cite the `JOSS paper <https://doi.org/10.21105/joss.03398>`_:
+
+	Moodie et al., (2021). pyDeltaRCM: a flexible numerical delta model. Journal of Open Source Software, 6(64), 3398, https://doi.org/10.21105/joss.03398
+
+If you use BibTeX, you can add *pyDeltaRCM* to your `.bib` file using the following code:
+
+.. code:: console
+
+	@article{Moodie2021,
+	doi = {10.21105/joss.03398},
+	url = {https://doi.org/10.21105/joss.03398},
+	year = {2021},
+	publisher = {The Open Journal},
+	volume = {6},
+	number = {64},
+	pages = {3398},
+	author = {Andrew J. Moodie and Jayaram Hariharan and Eric Barefoot and Paola Passalacqua},
+	title = {*pyDeltaRCM*: a flexible numerical delta model},
+	journal = {Journal of Open Source Software}
+	}

--- a/docs/source/meta/usedby.rst
+++ b/docs/source/meta/usedby.rst
@@ -2,11 +2,15 @@
 Used By
 *******
 
-Below are papers, presentations, and other material that  use *pyDeltaRCM*.
+Below are papers, presentations, and other material that use *pyDeltaRCM*.
 
 Papers
 ------
+.. copied from "Chicago" style within Google Scholar
 
+[1] Moodie, Andrew J., and Paola Passalacqua. "When Does Faulting‐Induced Subsidence Drive Distributary Network Reorganization?." Geophysical Research Letters 48, no. 22 (2021): e2021GL095053.
+
+[2] Hariharan, Jayaram, Paola Passalacqua, Zhongyuan Xu, Holly A. Michael, Elisabeth Steel, Austin Chadwick, Chris Paola, and Andrew J. Moodie. "Modeling the Dynamic Response of River Deltas to Sea‐Level Rise Acceleration." Journal of Geophysical Research: Earth Surface: e2022JF006762.
 
 
 Presentations

--- a/docs/source/meta/usedby.rst
+++ b/docs/source/meta/usedby.rst
@@ -1,0 +1,18 @@
+*******
+Used By
+*******
+
+Below are papers, presentations, and other material that  use *pyDeltaRCM*.
+
+Papers
+------
+
+
+
+Presentations
+-------------
+
+
+
+Other
+-----


### PR DESCRIPTION
Sketching out some potential adds to the documentation to:

- make it easier to cite *pyDeltaRCM*
- list the publications / presentations / other places where the model has been used
- create a list of subclass models with links to their source codes / repositories (we had talked about a "modelzoo" repository which would point to individual subclass code/repos, not sure if that solution, or just having a list in the docs is simpler)

Would be curious to get your input and thoughts on this @amoodie 

closes #256 