### PR TITLE
add pyrcm anthology to usedby doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     env:
       OS: ${{ matrix.os }}
@@ -55,7 +55,7 @@ jobs:
 
     env:
       OS: ${{ matrix.os }}
-      PYTHON: 3.8
+      PYTHON: 3.9
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, '3.10']
 
     env:
       OS: ${{ matrix.os }}

--- a/docs/source/meta/usedby.rst
+++ b/docs/source/meta/usedby.rst
@@ -10,7 +10,7 @@ Papers
 
 [1] Moodie, Andrew J., and Paola Passalacqua. "When Does Faulting‐Induced Subsidence Drive Distributary Network Reorganization?." Geophysical Research Letters 48, no. 22 (2021): e2021GL095053.
 
-[2] Hariharan, Jayaram, Paola Passalacqua, Zhongyuan Xu, Holly A. Michael, Elisabeth Steel, Austin Chadwick, Chris Paola, and Andrew J. Moodie. "Modeling the Dynamic Response of River Deltas to Sea‐Level Rise Acceleration." Journal of Geophysical Research: Earth Surface: e2022JF006762.
+[2] Hariharan, Jayaram, Paola Passalacqua, Zhongyuan Xu, Holly A. Michael, Elisabeth Steel, Austin Chadwick, Chris Paola, and Andrew J. Moodie. "Modeling the Dynamic Response of River Deltas to Sea‐Level Rise Acceleration." Journal of Geophysical Research: Earth Surface 127, no. 9 (2022): e2022JF006762.
 
 
 Presentations
@@ -20,3 +20,5 @@ Presentations
 
 Other
 -----
+
+[1] Hariharan, Jayaram. "Exploring *pyDeltaRCM*: A Collection of Numerical Experiments." Zenodo v0.1 (2022), https://zenodo.org/record/7315646.


### PR DESCRIPTION
adds the open-sourced anthology doc ([here](https://github.com/elbeejay/pyDeltaRCMAnthology)) to the "other" category of things that have used the model

also changes the CI to stop testing python version 3.7 as our required matplotlib version is incompatible, and adds version 3.10 as upstream dependencies now all support it

will be merging once tests (except the windows ones) pass