### PR TITLE
switch docs math to mathjax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.napoleon',
               'sphinx.ext.graphviz',
-              'sphinx.ext.imgmath',
+              'sphinx.ext.mathjax',
               'sphinx.ext.githubpages',
               'matplotlib.sphinxext.plot_directive',
               'sphinx.ext.todo']


### PR DESCRIPTION
This closes #265 by switching the sphinx extension from generating images of the math to generating them using the JavaScript `mathjax` package. There are other math rendering options built into sphinx (https://www.sphinx-doc.org/en/master/usage/extensions/math.html) that we can switch to if/as the need arises.

Math is now displaying properly in my local builds.