### PR TITLE
continuous integration fix?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         pip install -r requirements.txt
     - name: Install pyDeltaRCM
       run: |
-        pip install -e .
+        python setup.py install
     - name: Test with pytest
       run: |
         pytest --mpl --mpl-baseline-path=tests/imgs_baseline
@@ -70,7 +70,7 @@ jobs:
         pip install -r requirements.txt
     - name: Install pyDeltaRCM
       run: |
-        pip install -e .
+        python setup.py install
     - name: Disable jitted for coverage
       run: |
         echo "DISABLE_JIT: 1" > .numba_config.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy
 matplotlib>=3.6.1
 scipy>=1.5
 netCDF4
 pyyaml>=5.1
 numba
+numpy


### PR DESCRIPTION
@amoodie not sure why, but flipping the test installation from `pip install -e .` to `python setup.py install` seems to work... is this a change we're willing to make?