### PR TITLE
drop python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
 
     env:
       OS: ${{ matrix.os }}
@@ -55,7 +55,7 @@ jobs:
 
     env:
       OS: ${{ matrix.os }}
-      PYTHON: 3.10
+      PYTHON: '3.10'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,10 +95,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10', '3.11', '3.12']
 
     env:
       OS: ${{ matrix.os }}
@@ -55,7 +55,7 @@ jobs:
 
     env:
       OS: ${{ matrix.os }}
-      PYTHON: 3.9
+      PYTHON: 3.10
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Proposal to consider dropping `3.8`, and picking up `3.11`. Tests pass, including docs and coverage, which are now built on `3.10`.

As an example, Landlab is supporting only 3.9+ now. An alternative would be to just pick up 3.11 and increment the docs to `3.10` for now, then drop `3.8` sometime later, since it is still working.

Thoughts @elbeejay?