### PR TITLE
fix typo

### DIFF
--- a/pyDeltaRCM/debug_tools.py
+++ b/pyDeltaRCM/debug_tools.py
@@ -184,7 +184,7 @@ class debug_tools(abc.ABC):
             elif ind.ndim > 1:
                 if multiline:
                     # travel along axis, extracting lines
-                    cm = matplotlib.colormaps["tab10"].resample(10)
+                    cm = matplotlib.colormaps["tab10"].resampled(10)
                     lines = []
                     for i in np.arange(ind.shape[1]):
                         _l = plot_line(


### PR DESCRIPTION
broke the tests with my previous update to fix depracated functions. I used `resample` instead of `resampled`. This fixes.