### PR TITLE
prepare for legacy output file deprecation with future version 2.2.

### DIFF
--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1329,10 +1329,8 @@ class DeltaModel(
     def legacy_netcdf(self) -> bool:
         """Enable output in legacy netCDF format.
 
-        .. note:: new in `v2.1.0`.
-
         Default behavior, legacy_netcdf: False, is for the model to use the
-        new `v2.1.0` output netCDF format. The updated format is configured
+        `v2.1.0` output netCDF format. The updated format is configured
         to match the input expected by `xarray`, which eases interaction with
         model outputs. The change in format is from inconsistently named
         dimensions and *coordinate variables*, to homogeneous definitions.
@@ -1341,9 +1339,13 @@ class DeltaModel(
 
         .. important::
 
-            There are no changes to the dimensionality of data such as bed
-            elevation or velocity, only the metadata specifying the location of
-            the data are changed.
+            The behavior of the legacy option, and the new format is expected
+            to change in version 2.2.0 With v2.2.0 the default output file
+            will comply with the sandsuet data specification, and the
+            `legacy_output=True` option will output the current
+            configuration. The core data will not change with v2.2, but the
+            names and attributes of components of the data output is expected
+            to change.
 
         +-------------+-------------------+---------------------------------+
         |             | default           | legacy                          |
@@ -1364,6 +1366,13 @@ class DeltaModel(
 
     @legacy_netcdf.setter
     def legacy_netcdf(self, legacy_netcdf: bool) -> None:
+        if legacy_netcdf:
+            warnings.warn(
+                "The legacy version of the NetCDF output is "
+                "expected to change with v2.2. The old `legagcy` "
+                "file format will no longer be available, and "
+                "will be replaced by the current file format."
+            )
         self._legacy_netcdf = legacy_netcdf
 
     @property


### PR DESCRIPTION
The behavior of the legacy NetCDF output format option, and the new file output format is expected to change in version 2.2.0.

With v2.2.0 the default output file comply with the sandsuet data specification, and the legacy_output=True` option will output the current configuration. The core data will not change with v2.2, but the names and attributes of components of the data output is expected change.

I don't expect dropping the current legacy option to affect any users. Current users will be able to maintain the current file format with `legacy_netcdf=True` for versions moving forward from v2.2. They will be encouraged to adapt scripts to the new format, but we will maintain backwards compatibility.

[See sandsuet data specification for expected file format.](https://github.com/sandpiper-toolchain/sandsuet)