### PR TITLE
push built docs on release only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,12 +121,3 @@ jobs:
         echo ${{ github.event_name == 'push' }}
         echo ${{ github.ref == 'refs/heads/develop' }}
         echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-    - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-      with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-          BRANCH: gh-pages
-          FOLDER: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+# This workflows will build and deploy the documentation on release only
+
+name: docs on release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-docs.txt
+        sudo apt update -y && sudo apt install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended dvipng
+    - name: Install pyDeltaRCM
+      run: |
+        python setup.py install
+    - name: Build and test documentation
+      run: |
+        (cd docs && make docs)
+    - name: Upload log file
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: log-file
+        path: docs/deltaRCM_Output/*.log
+    - name: Debug
+      run: |
+        echo $REF
+        echo $EVENT_NAME
+        echo ${{ github.event_name == 'push' }}
+        echo ${{ github.ref == 'refs/heads/develop' }}
+        echo ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+      with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          BRANCH: gh-pages
+          FOLDER: docs/build/html


### PR DESCRIPTION
separate out docs build to publish docs only on release of a new version. docs still built every PR and merge as part of regular testing. 

This will help get in the habit of regular and frequent small releases (only way to update online docs is with a version release!)