### PR TITLE
Sed end single and mass conservation discussion

### DIFF
--- a/docs/source/examples/verify_mass_conservation.py
+++ b/docs/source/examples/verify_mass_conservation.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import pyDeltaRCM
 
+
 class MassConservationCheck(pyDeltaRCM.DeltaModel):
 
     def __init__(self, input_file, **kwargs):
@@ -10,13 +11,51 @@ class MassConservationCheck(pyDeltaRCM.DeltaModel):
 
         self.inlets_flat = self.inlet
 
+        # trackers for cumulative volume changes
         self.cumulative_input_volume = 0
         self.cumulative_lost_volume = 0
         self.cumulative_exported_volume = 0
+        self.cumulative_inlet_volume = 0
 
-        print(f"|" + 66*"-" + "|")
-        print(f"| vol input     | vol deposit   | % err    | % lost   | % exported | ")
-        print(f"|" + 66*"-" + "|")
+        # some code to help format a nice table
+        self._fields = [
+            f"timestep",
+            f"vol input",
+            f"vol deposit",
+            f"% err",
+            f"% lost",
+            f"% exported",
+            f"% at inlet",
+        ]
+        self._sty0 = ["g", ".1e", ".1e", ".2f", ".2f", ".2f", ".2f"]
+        self._fields_len = [
+            np.maximum(len(s), 8) for s in self._fields
+        ]  # field plus two spaces on each side
+        self._tot_len = (
+            np.sum(self._fields_len)
+            + 2
+            + (len(self._fields) - 1)
+            + 2
+            + 2 * (len(self._fields) - 1)
+        )  # fields + end |s + middle |s + end spcs + middle spcs
+
+        # print table header
+        self._format_table()
+        self._format_table(self._fields)
+
+    def _format_table(self, entry=None):
+
+        if entry is None:
+            print(f"|" + ((self._tot_len - 2) * "-") + "|")
+        else:
+            fl = self._fields_len
+            sty0 = self._sty0
+            # make list of stings
+            row = []
+            for i in np.arange(len(entry)):
+                styi = sty0[i] if not isinstance(entry[i], str) else ""
+                row.append(f"{entry[i]:>{fl[i]}{styi}}")
+            print("| " + " | ".join(row) + " |")
 
     def hook_after_finalize_timestep(self):
         self._verify_mass_conservation()
@@ -33,52 +72,74 @@ class MassConservationCheck(pyDeltaRCM.DeltaModel):
         total amount of landscape change (volume) is close to the total
         amount of sediment put into the domain.
         """
-
-        # check the change in volume of the deposit for this timestep
-        act_deposit_volume = np.sum((self.eta - self.eta_init) * self.dx**2)
+        # calculate change in input sediment and deposit volume
         input_sed_volume = self.Qs0 * self.dt
+        act_deposit_volume = np.sum((self.eta - self.eta_init) * self.dx**2)
 
-        # now check it accounting for whatever was lost or exported
-        exported_volume = self._sr.Vp_exported
-        lost_volume = self._sr.Vp_lost
-        
+        # changes in input, lost, exported, inlet
+        lost_volume = self._sr.Vp_lost + self._mr.Vp_lost
+        exported_volume = self._sr.Vp_exported + self._mr.Vp_exported
+        inlet_volume = self._Vp_inletbc
+
+        # accumulate
+        self.cumulative_input_volume += input_sed_volume
         self.cumulative_lost_volume += lost_volume
         self.cumulative_exported_volume += exported_volume
-        self.cumulative_input_volume += input_sed_volume
+        self.cumulative_inlet_volume += inlet_volume
 
-        cumulative_lost_frac_error = self.cumulative_lost_volume / self.cumulative_input_volume
-        cumulative_exported_frac_error = self.cumulative_exported_volume / self.cumulative_input_volume
+        cumulative_lost_frac_error = (
+            self.cumulative_lost_volume / self.cumulative_input_volume
+        )
+        cumulative_exported_frac_error = (
+            self.cumulative_exported_volume / self.cumulative_input_volume
+        )
+        cumulative_inlet_frac_error = (
+            self.cumulative_inlet_volume / self.cumulative_input_volume
+        )
+        cumulative_deposit_frac_error = (
+            act_deposit_volume - self.cumulative_input_volume
+        ) / self.cumulative_input_volume
 
-        deposit_volume_error = (act_deposit_volume - self.cumulative_input_volume) / self.cumulative_input_volume
-
-        print(f"|{self.cumulative_input_volume:>15.1e}|{act_deposit_volume:>15.2e}|{deposit_volume_error*100:>10.2f}|{cumulative_lost_frac_error*100:>10.2f}|{cumulative_exported_frac_error*100:>12.2f}| ")
+        entry = [
+            self._time_iter,
+            self.cumulative_input_volume,
+            act_deposit_volume,
+            cumulative_deposit_frac_error * 100,
+            cumulative_lost_frac_error * 100,
+            cumulative_exported_frac_error * 100,
+            cumulative_inlet_frac_error * 100,
+        ]
+        self._format_table(entry)
 
     def finalize(self):
-        super().finalize()
-        print(f"|" + 66*"-" + "|")
-        print("")
+        super().finalize()  # .finalize() from base model
+        # print table footer
+        self._format_table()
+        print("")  # blankline
 
 
 if __name__ == "__main__":
-    
-    demo_conditions = dict(f_bedload=1, Np_sed=200, itermax=1)
+
+    demo_conditions = dict(Np_sed=200, itermax=1)
     # normal conditions yield good balance
-    print("A good balance yields:")
+    print("Default parameters yield cumulative volume conservation errors (%):")
     model = MassConservationCheck(input_file=None, **demo_conditions)
     for _ in np.arange(10):
         model.update()
     model.finalize()
 
     # too small of stepmax causes many "lost" partciles
-    print("Too small of stepmax yields:")
+    print("Too small of stepmax yields cumulative volume conservation errors (%):")
     model = MassConservationCheck(input_file=None, **demo_conditions, stepmax=5)
     for _ in np.arange(10):
         model.update()
     model.finalize()
 
     # too small of domain causes many "exported" partciles
-    print("Too small of domain yields:")
-    model = MassConservationCheck(input_file=None, **demo_conditions, Length=500, Width=1000)
+    print("Too small of domain yields cumulative volume conservation errors (%):")
+    model = MassConservationCheck(
+        input_file=None, **demo_conditions, Length=500, Width=1000
+    )
     for _ in np.arange(10):
         model.update()
     model.finalize()

--- a/docs/source/examples/verify_mass_conservation.rst
+++ b/docs/source/examples/verify_mass_conservation.rst
@@ -1,20 +1,73 @@
 Verifying sediment mass conservation 
 ====================================
 
-Here, we check the model for sediment mass conservation. The DeltaRCM
-formulation is not conservative of mass by default; that is, sediment parcels
-may terminate iteration without depositing all stored sediment. For example,
-sediment is "lost" when the maximum number of allowable iterations
-:code:`stepmax` is reached. Additionally, sediment is removed at the inlet
-boundary condition, when bed elevation is updated to :code:`stage - h_0` on each
-iteration. Lastly, sediment parcels that reach the edge of the model domain are
-"exported" and removed from the model; this *is* mass conservative, but may lead
-to unexpected results if the model domain is imrpoperly configured.  
+Here, we learn about the mass conservation principles applied in the model.
 
-The below script generates a table to demonstrate sediment mass conservation in
-the model under these relevant parameters.
+The DeltaRCM formulation is explictly not conservative of mass (neither water
+nor sediment) [1]_. This is generally not a problem, as the model is internally
+consistent, that is, the rules don't change over time or with different
+parameter/boundary conditions. 
+
+However, it is fairly common to have issues with sediment mass conservation in
+atypical model domain configurations. Additionally, some modelers may aim to
+compare with real-world deltas, and therefore aim to keep sediment mass
+conservation as strict as reasonably possible.  
+
+.. note::
+
+   We are not aware of any straightforward way to formulate the model for water
+   mass conservation. Relaxing the requirement for water mass conservation is 
+   part of what makes the DeltaRCM formulation computationally efficient and
+   attractive to many modelers.
+
+There are three primary areas of concern when discussion sediment mass
+conservation in the DeltaRCM framework. With the default :code:`DeltaModel` and
+default model parameters:
+
+1. sediment routing terminates iteration without depositing all stored sediment
+   when :code:`stepmax` iterations are reached,
+2. sediment parcels that reach the edge of the model domain leave the domain
+   without depositing sediment. 
+3. sediment is added or removed at the inlet when bed elevation is updated to
+   :code:`stage - h_0` on each iteration, and
+
+Notably, the second point is consistent with a mass conservation formulation
+that considers the domain the control volume. It is brought up here, however,
+because this can be a source of confusion for new modelers, and is why
+simulations where the delta reaches the edge of the computational domain should
+be discarded. 
+
+Let's examine the magnitude of these "lost", "exported", and "at inlet" sediment
+volumes. The below script generates tables tracking the volume of sediment
+conservation in the model under these relevant parameters. We track volume
+because deposit porosity is neglected in the original DeltaRCM formulation. 
+
 
 .. literalinclude:: verify_mass_conservation.py
    :language: python
 
 .. program-output:: python examples/verify_mass_conservation.py
+
+Here, it is clear that default model parameters lead to an overall high degree
+of sediment mass conservation. Be careful not to have the domain too small, or
+large volumes of sediment will be exported. Similarly, setting :code:`stepmax`
+to too small of a value can lead to large volume of lost sediment. 
+
+.. hint::
+   
+   If the volume of sediment changing lost to :code:`stepmax` iterations, or due to
+   atypical model domain configurations, consider setting the parameter
+   :code:`force_deposit` flag to :code:`True`. This flag forces sediment to deposit
+   in place when `stepmax` iterations are reached; it can create new instabilities,
+   but improves mass conservation.
+
+.. hint::
+   
+   If the volume of sediment changing at the inlet is significant for your
+   modeling, consider reimplementing :code:`finalize_timestep()` to eliminate or
+   modify this boundary condition.
+
+.. [1] A reduced-complexity model for river delta formation --- Part 1: Modeling
+       deltas with channel dynamics, M. Liang, V. R. Voller, and C. Paola, Earth
+       Surf. Dynam., 3, 67--86, 2015. https://doi.org/10.5194/esurf-3-67-2015
+

--- a/pyDeltaRCM/default.yml
+++ b/pyDeltaRCM/default.yml
@@ -175,6 +175,9 @@ alpha:
 stepmax:
   type: ['float', 'int', 'None']
   default: null
+force_deposit:
+  type: ['bool', int]
+  default: False
 sand_frac_bc:
   type: ['float', 'int']
   default: 0

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -423,9 +423,7 @@ class init_tools(abc.ABC):
         # (m) critial depth to switch to "dry" node
         self.dry_depth = min(0.1, 0.1 * self._h0)
 
-        self.gamma = (
-            self.g * self.S0 * self._dx / (self.u0**2)
-        )  # water weighting coeff
+        self.gamma = self.g * self.S0 * self._dx / (self.u0**2)  # water weighting coeff
 
         # (m^3) reference volume, volume to fill cell to characteristic depth
         self.V0 = self.h0 * (self._dx**2)
@@ -530,7 +528,7 @@ class init_tools(abc.ABC):
         self.mod_water_weight = np.ones_like(self.depth)
         self.mod_sed_weight = np.ones_like(self.depth)
         self.mod_erosion = np.ones_like(self.depth)
-        #add array of ones to make stability parameter weighting mutable
+        # add array of ones to make stability parameter weighting mutable
         self.mod_stable_weight = np.ones_like(self.depth)
 
         # ---- domain ----
@@ -615,6 +613,7 @@ class init_tools(abc.ABC):
             self._lambda,
             self._beta,
             self.stepmax,
+            self.force_deposit,
             self.theta_mud,
             self.mod_erosion,
         )
@@ -636,6 +635,7 @@ class init_tools(abc.ABC):
             self.dry_depth,
             self._beta,
             self.stepmax,
+            self.force_deposit,
             self.theta_sand,
             self.mod_erosion,
         )
@@ -1147,9 +1147,10 @@ class init_tools(abc.ABC):
                     self.init_metadata_list()
 
                 # copy data from old netCDF4 into new one
-                with Dataset(_tmp_name) as src, Dataset(
-                    file_path, "w", format="NETCDF4"
-                ) as dst:
+                with (
+                    Dataset(_tmp_name) as src,
+                    Dataset(file_path, "w", format="NETCDF4") as dst,
+                ):
                     # copy attributes
                     for name in src.ncattrs():
                         dst.setncattr(name, src.getncattr(name))

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -109,7 +109,9 @@ class iteration_tools(abc.ABC):
         # apply bed elevation boundary condition at inlet
         #   first, calc the change in eta at inlet
         _eta_change = (self.stage[0, self.inlet] - self._h0) - self.eta[0, self.inlet]
-        self._Vp_inletbc = _eta_change * self._dx * self._dx  # for mass cons checks
+        self._Vp_inletbc = (
+            np.sum(_eta_change) * self._dx * self._dx
+        )  # for mass cons checks
         #   now apply boundary condition
         self.eta[0, self.inlet] += _eta_change
         self.depth[0, self.inlet] = self._h0

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -106,7 +106,12 @@ class iteration_tools(abc.ABC):
         self.stage[:] = np.maximum(self.stage, self._H_SL)
         self.depth[:] = np.maximum(self.stage - self.eta, 0)
 
-        self.eta[0, self.inlet] = self.stage[0, self.inlet] - self._h0
+        # apply bed elevation boundary condition at inlet
+        #   first, calc the change in eta at inlet
+        _eta_change = (self.stage[0, self.inlet] - self._h0) - self.eta[0, self.inlet]
+        self._Vp_inletbc = _eta_change * self._dx * self._dx  # for mass cons checks
+        #   now apply boundary condition
+        self.eta[0, self.inlet] += _eta_change
         self.depth[0, self.inlet] = self._h0
 
         self.hook_compute_sand_frac()

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -1325,6 +1325,30 @@ class DeltaModel(
         self._stepmax = stepmax
 
     @property
+    def force_deposit(self) -> bool:
+        """
+        `force_deposit` is a flag to force mass conservation of sediment parcels
+        that are stuck in loops.
+
+        In the standard DeltaRCM formulation, a sediment parcel that reaches the
+        maximum number of steps with any sediment volume remaining vanishes from
+        the domain, leaving a volume of sediment that entered the domain
+        undeposited. In standard model domain configurations, sediment parcels
+        only rarely become stuck in a loop inside the delta (e.g., a small lake)
+        and meet this condition. Therefore, this modeling choice is a convenient
+        simplification for a small amount of error accrued.
+
+        Optionally, change `force_deposit` to `True` (default is standard
+        behavior `force_deposit=False`)to force all sediment remaining in a
+        parcel to deposit at iteration=`stepmax`.
+        """
+        return self._force_deposit
+
+    @force_deposit.setter
+    def force_deposit(self, force_deposit: bool) -> None:
+        self._force_deposit = force_deposit
+
+    @property
     def clobber_netcdf(self) -> bool:
         """
         Allows overwriting (clobbering) of an existing netCDF output file.

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -744,6 +744,8 @@ class SandRouter(BaseRouter):
         it = 0
         sed_continue = True
 
+        force_mc = False
+
         while sed_continue:
             px0 = px
             py0 = py
@@ -766,6 +768,14 @@ class SandRouter(BaseRouter):
                 )  # add remaining volume to exported
             if it == self.stepmax:
                 sed_continue = False
+                if force_mc:
+                    # force parcel to drop all sediment in place
+                    Vp_change = self.Vp_res
+                    self.Vp_dep_sand[px, py] = self.Vp_dep_sand[px, py] + Vp_change
+                    self.Vp_res = self.Vp_res - Vp_change  # update sed volume in parcel
+                    self._update_fields(
+                        Vp_change, px, py
+                    )  # update other fields as needed
                 self.Vp_lost = (
                     self.Vp_lost + self.Vp_res
                 )  # add remaining volume to lost
@@ -955,6 +965,7 @@ class MudRouter(BaseRouter):
         """Route one parcel."""
         it = 0
         sed_continue = True
+        force_mc = False
 
         while sed_continue:
             # Choose the next location for the parcel to travel
@@ -974,6 +985,13 @@ class MudRouter(BaseRouter):
                 )  # add remaining volume to exported
             if it == self.stepmax:
                 sed_continue = False
+                if force_mc:
+                    Vp_change = self.Vp_res
+                    self.Vp_dep_mud[px, py] = self.Vp_dep_mud[px, py] + Vp_change
+                    self.Vp_res = self.Vp_res - Vp_change  # update sed volume in parcel
+                    self._update_fields(
+                        Vp_change, px, py
+                    )  # update other fields as needed
                 self.Vp_lost = (
                     self.Vp_lost + self.Vp_res
                 )  # add remaining volume to lost

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -3,7 +3,7 @@ from typing import Any, Tuple
 
 import numpy as np
 from numba import njit
-from numba import float32, int64
+from numba import float32, int64, boolean
 from numba.experimental import jitclass
 from scipy import ndimage
 
@@ -319,6 +319,7 @@ r_spec = [
     ("num_starts", int64),
     ("start_indices", int64[:]),
     ("stepmax", float32),
+    ("force_deposit", boolean),
     ("px", int64),
     ("py", int64),
     ("eta", float32[:, :]),
@@ -601,6 +602,7 @@ class SandRouter(BaseRouter):
         dry_depth: float,
         beta: float,
         stepmax,
+        force_deposit,
         theta_sed: float,
         mod_erosion,
     ) -> None:
@@ -627,6 +629,7 @@ class SandRouter(BaseRouter):
         self.dry_depth = dry_depth
         self._beta = beta
         self.stepmax = stepmax
+        self.force_deposit = force_deposit
         self.theta_sed = theta_sed
         self.mod_erosion = mod_erosion
 
@@ -744,8 +747,6 @@ class SandRouter(BaseRouter):
         it = 0
         sed_continue = True
 
-        force_mc = False
-
         while sed_continue:
             px0 = px
             py0 = py
@@ -768,7 +769,7 @@ class SandRouter(BaseRouter):
                 )  # add remaining volume to exported
             if it == self.stepmax:
                 sed_continue = False
-                if force_mc:
+                if self.force_deposit:
                     # force parcel to drop all sediment in place
                     Vp_change = self.Vp_res
                     self.Vp_dep_sand[px, py] = self.Vp_dep_sand[px, py] + Vp_change
@@ -885,6 +886,7 @@ class MudRouter(BaseRouter):
         _lambda,
         beta: float,
         stepmax,
+        force_deposit,
         theta_sed: float,
         mod_erosion,
     ) -> None:
@@ -906,6 +908,7 @@ class MudRouter(BaseRouter):
         self._lambda = _lambda
         self._beta = beta
         self.stepmax = stepmax
+        self.force_deposit = force_deposit
         self.theta_sed = theta_sed
         self.mod_erosion = mod_erosion
 
@@ -965,7 +968,6 @@ class MudRouter(BaseRouter):
         """Route one parcel."""
         it = 0
         sed_continue = True
-        force_mc = False
 
         while sed_continue:
             # Choose the next location for the parcel to travel
@@ -985,7 +987,7 @@ class MudRouter(BaseRouter):
                 )  # add remaining volume to exported
             if it == self.stepmax:
                 sed_continue = False
-                if force_mc:
+                if self.force_deposit:
                     Vp_change = self.Vp_res
                     self.Vp_dep_mud[px, py] = self.Vp_dep_mud[px, py] + Vp_change
                     self.Vp_res = self.Vp_res - Vp_change  # update sed volume in parcel

--- a/tests/test_sed_tools.py
+++ b/tests/test_sed_tools.py
@@ -139,3 +139,30 @@ class TestRouteAllMudParcels:
 
         # stop the patch
         patcher.stop()
+
+
+class TestForceDeposit:
+    """Test the force_deposit flag"""
+
+    def test_force_deposit(self, tmp_path: Path) -> None:
+        # create a small domain with low stepmax
+        p = utilities.yaml_from_dict(
+            tmp_path,
+            "input.yaml",
+            {
+                "Width": 2000,
+                "Length": 1000,
+                "Np_sed": 100,
+                "stepmax": 5,
+                "force_deposit": True,
+            },
+        )
+        _delta = DeltaModel(input_file=p)
+
+        vol_lost = 0
+        for _ in range(10):
+            _delta.update()
+            vol_lost += _delta._sr.Vp_lost + _delta._mr.Vp_lost
+
+        # should be no lost volume since force_deposit = True
+        assert vol_lost == pytest.approx(0)

--- a/tests/test_sed_tools.py
+++ b/tests/test_sed_tools.py
@@ -14,7 +14,7 @@ class TestSedimentRoute:
 
     def test_route_sediment(self, tmp_path: Path) -> None:
         # create a delta with default settings
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         _delta = DeltaModel(input_file=p)
 
         # mock top-level methods
@@ -28,15 +28,15 @@ class TestSedimentRoute:
         _delta.route_sediment()
 
         # methods called
-        assert (_delta.log_info.call_count == 4)
-        assert (_delta.init_sediment_iteration.called is True)
-        assert (_delta.route_all_sand_parcels.called is True)
-        assert (_delta.topo_diffusion.called is True)
-        assert (_delta.route_all_mud_parcels.called is True)
+        assert _delta.log_info.call_count == 4
+        assert _delta.init_sediment_iteration.called is True
+        assert _delta.route_all_sand_parcels.called is True
+        assert _delta.topo_diffusion.called is True
+        assert _delta.route_all_mud_parcels.called is True
 
     def test_sed_route_deprecated(self, tmp_path: Path) -> None:
         # create a delta with default settings
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         _delta = DeltaModel(input_file=p)
 
         # mock top-level methods
@@ -48,14 +48,14 @@ class TestSedimentRoute:
             _delta.sed_route()
 
         # and logged
-        assert (_delta.logger.warning.called is True)
+        assert _delta.logger.warning.called is True
 
 
 class TestInitSedimentIteration:
 
     def test_fields_cleared(self, tmp_path: Path) -> None:
         # create a delta with default settings
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         _delta = DeltaModel(input_file=p)
 
         # alter field for initial values going into function
@@ -70,7 +70,7 @@ class TestInitSedimentIteration:
 
         # assertions
         assert np.all(_delta.pad_depth[1:-1, 1:-1] == _delta.depth)
-        assert np.all(_delta.qs == 0)      # field is cleared
+        assert np.all(_delta.qs == 0)  # field is cleared
         assert np.all(_delta.Vp_dep_sand == 0)
         assert np.all(_delta.Vp_dep_mud == 0)
 
@@ -79,9 +79,9 @@ class TestRouteAllSandParcels:
 
     def test_route_sand_parcels(self, tmp_path: Path) -> None:
         # create a delta with default settings
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'Np_sed': 1000,
-                                      'f_bedload': 0.6})
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"Np_sed": 1000, "f_bedload": 0.6}
+        )
         _delta = DeltaModel(input_file=p)
 
         # mock top-level methods / objects
@@ -93,16 +93,16 @@ class TestRouteAllSandParcels:
             return np.random.randint(0, 5, size=(num_starts,))
 
         patcher = mock.patch(
-            'pyDeltaRCM.shared_tools.get_start_indices',
-            new=_patched_starts)
+            "pyDeltaRCM.shared_tools.get_start_indices", new=_patched_starts
+        )
         patcher.start()
 
         # run the method
         _delta.route_all_sand_parcels()
 
         # methods called
-        assert (_delta._sr.run.call_count == 1)
-        assert (_delta.log_info.call_count == 3)
+        assert _delta._sr.run.call_count == 1
+        assert _delta.log_info.call_count == 3
 
         # stop the patch
         patcher.stop()
@@ -112,9 +112,9 @@ class TestRouteAllMudParcels:
 
     def test_route_mud_parcels(self, tmp_path: Path) -> None:
         # create a delta with default settings
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'Np_sed': 1000,
-                                      'f_bedload': 0.6})
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"Np_sed": 1000, "f_bedload": 0.6}
+        )
         _delta = DeltaModel(input_file=p)
 
         # mock top-level methods / objects
@@ -126,16 +126,16 @@ class TestRouteAllMudParcels:
             return np.random.randint(0, 5, size=(num_starts,))
 
         patcher = mock.patch(
-            'pyDeltaRCM.shared_tools.get_start_indices',
-            new=_patched_starts)
+            "pyDeltaRCM.shared_tools.get_start_indices", new=_patched_starts
+        )
         patcher.start()
 
         # run the method
         _delta.route_all_mud_parcels()
 
         # methods called
-        assert (_delta._mr.run.call_count == 1)
-        assert (_delta.log_info.call_count == 3)
+        assert _delta._mr.run.call_count == 1
+        assert _delta.log_info.call_count == 3
 
         # stop the patch
         patcher.stop()


### PR DESCRIPTION
# force sediment to deposit at `stepmax`

This PR adds a parameter `force_deposit` to the model that **optionally** improves mass conservation in the delta model. 

 In the standard DeltaRCM formulation, a sediment parcel that reaches the maximum number of steps with any sediment volume remaining vanishes from the domain, leaving a volume of sediment that entered the domain undeposited. In standard model domain configurations, sediment parcels only rarely become stuck in a loop inside the delta (e.g., a small lake) and meet this condition. Therefore, this modeling choice is a convenient simplification for a small amount of error accrued.

Optionally, change `force_deposit` to `True` (default is standard behavior `force_deposit=False`)to force all sediment remaining in a parcel to deposit at iteration=`stepmax`.

## Long simulation

| `force_deposit = False` | `force_deposit = True` |
| :--- | :--- | 
| <img width="612" height="361" alt="image" src="https://github.com/user-attachments/assets/038eb6c1-5c39-46f8-8cff-04a68c530da2" /> | <img width="612" height="361" alt="image" src="https://github.com/user-attachments/assets/731d8264-a9fc-448c-a63d-8566e3f40003" /> | 

TODO
- [x] evaluate the long-term stability of this option in normal domain configuration
- [x] improve docs example with mass conservation to address this flag and the cases that may cause issues.
- [x] improve docs example with mass conservation to explain the effect of the inlet boundary condition `stage-h0`  
- [x] add tracker for the inlet boundary condition effect

closes #292 
closes #305 