### PR TITLE
Logs warnings

### DIFF
--- a/docs/source/guides/advanced_configuration_guide.inc
+++ b/docs/source/guides/advanced_configuration_guide.inc
@@ -242,7 +242,17 @@ However, for stability and forwards-compatibility, you should try to minimize co
 If you identify a location in the model framework where you think adding a hook (for example, another `hook_after_` method), please file an issue on the GitHub and we will be happy to consider.
 
 
+Subclass inputs and outputs
+---------------------------
+
+It is easy to specify additional YAML-based inputs to a custom subclass, and specify additional fields to be added to the output netCDF file.
+
+* :doc:`Adding YAML-based inputs to custom subclasses </examples/custom_yaml>`
+* :doc:`Adding arrays and scalars tot output NetCDF file </examples/custom_saving>`
+
+
 Subclassing examples
 --------------------
 
-We maintain a number of :doc:`examples of pyDeltaRCM use</examples/index>`, which show  DeltaModel subclasses implementing various hooks, and reimplementing existing methods, to achieve complex behavior.
+We maintain a number of additional :doc:`examples of pyDeltaRCM use </examples/index>`, which show  DeltaModel subclasses implementing various hooks, and reimplementing existing methods, to achieve complex behavior.
+We also have the :doc:`Model Zoo </examples/modelzoo>`, which links to examples of the model used in the wild (i.e., in peer-reviewed publications).

--- a/pyDeltaRCM/hook_tools.py
+++ b/pyDeltaRCM/hook_tools.py
@@ -17,7 +17,7 @@ class hook_tools(abc.ABC):
         Therefore, we enforce that no old hooks may be used as method names of
         subclassing models.
 
-        This helper method is early in the `DeltaModel` `__init__` routine.
+        This helper method is called early in the `DeltaModel` `__init__` routine.
         """
         _deprecated_list = {
             "hook_sed_route": "hook_route_sediment",

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -199,11 +199,10 @@ class init_tools(abc.ABC):
         # add custom subclass yaml parameters (yaml or defaults) to input vars
         for k, v in self.subclass_parameters.items():
             if k in input_file_vars:
-                _msg = ("Custom subclass parameter name is already a "
-                        "default yaml parameter of the model, "
-                        "custom parameter value will not be used.")
-                self.log_warning(_msg)
-                warnings.warn(UserWarning(_msg))
+                _msg = (f"Custom subclass parameter '{k}' is already a "
+                        f"default yaml parameter of the model."
+                        f"Choose a different name for custom parameter value.")
+                raise ValueError(_msg)
             elif k in self._user_dict:
                 # get expected types
                 if not type(v["type"]) is list:

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -34,6 +34,12 @@ class init_tools(abc.ABC):
         This method is the first called in the initialization of the
         `DeltaModel`, after the configuration variables have been imported.
         """
+        # must identify out_dir manually, because input file not yet processed to model
+        if "out_dir" in self._user_dict.keys():
+            self.out_dir = self._user_dict["out_dir"]
+        else:
+            self.out_dir = self._default_dict["out_dir"]
+
         # output directory config
         self.prefix = self.out_dir
         self.prefix_abspath = os.path.abspath(self.prefix)
@@ -71,6 +77,9 @@ class init_tools(abc.ABC):
         # add handler to logger object
         self.logger.addHandler(fh)
 
+        # initialize verbosity as full, will get overwritten later
+        self._verbose = 2
+
         _msg = "Output log file initialized"
         self.log_info(_msg, verbosity=0)
 
@@ -88,24 +97,21 @@ class init_tools(abc.ABC):
     def import_files(self, kwargs_dict={}) -> None:
         """Import the input files.
 
-        This method handles the parsing and validation of any options supplied
-        via the configuration.
+        This method handles the parsing of any options supplied via the
+        configuration.
 
         Parameters
         ----------
         kwargs_dict : :obj:`dict`, optional
 
-            A dictionary with keys matching valid model parameter names that
-            can be specified in a configuration YAML file. Keys given in this
+            A dictionary with keys matching valid model parameter names that can
+            be specified in a configuration YAML file. Keys given in this
             dictionary will supercede values specified in the YAML
             configuration.
 
         Returns
         -------
         """
-        # This dictionary serves as a container to hold values for both the
-        # user-specified file and the internal defaults.
-        input_file_vars = dict()
 
         # get the special loader from the shared tools
         loader = custom_yaml_loader()
@@ -132,22 +138,51 @@ class init_tools(abc.ABC):
         else:
             user_dict = dict()
 
+        self._default_dict = default_dict
+        self._user_dict = user_dict
+        self._kwargs_dict = kwargs_dict
+
+
+    def process_input_to_model(self) -> None:
+        """Process input file to model variables.
+
+        Loop through the items specified in the model configuration and
+        determine what configuration to use, then apply them to the model (i.e.,
+        ``self``). Additionally, write the input values specified into the log
+        file.
+
+        .. note::
+
+            If ``self.resume_checkpoint == True``, then the input values are
+            *not* written to the log.
+        """
+        _msg = "Setting up model configuration"
+        self.log_info(_msg, verbosity=0)
+
+        _msg = f"Model type is: {self.__class__.__name__}"
+        self.log_info(_msg, verbosity=0)
+
+        # This dictionary serves as a container to hold values for both the
+        # user-specified file and the internal defaults.
+        input_file_vars = dict()
+
         # replace values in the user yaml file with anything specifed in the
         #   **kwargs input
-        for kwk, kwv in kwargs_dict.items():
-            if kwk in user_dict.keys():
-                _msg = ("A keyword specification was also found in the user specified input YAML file: %s" % kwk)
+        for kwk, kwv in self._kwargs_dict.items():
+            if kwk in self._user_dict.keys():
+                _msg = ("A keyword specification was also found "
+                        "in the user specified input YAML file: %s" % kwk)
                 self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
-            user_dict[kwk] = kwv
+            self._user_dict[kwk] = kwv
 
         # go through and populate input vars with user and default values,
         # checking user values for correct type.
-        for k, v in default_dict.items():
-            if k in user_dict:
+        for k, v in self._default_dict.items():
+            if k in self._user_dict:
                 expected_type = v["type"]
-                if type(user_dict[k]) in expected_type:
-                    input_file_vars[k] = user_dict[k]
+                if type(self._user_dict[k]) in expected_type:
+                    input_file_vars[k] = self._user_dict[k]
                 else:
                     raise TypeError(
                         f"Input for {str(k)} not of the "
@@ -157,7 +192,7 @@ class init_tools(abc.ABC):
                         f"but needs to be {expected_type}."
                     )
             else:
-                input_file_vars[k] = default_dict[k]["default"]
+                input_file_vars[k] = self._default_dict[k]["default"]
 
         # add custom subclass yaml parameters (yaml or defaults) to input vars
         for k, v in self.subclass_parameters.items():
@@ -167,15 +202,15 @@ class init_tools(abc.ABC):
                         "custom parameter value will not be used.")
                 self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
-            elif k in user_dict:
+            elif k in self._user_dict:
                 # get expected types
                 if not type(v["type"]) is list:
                     expected_type = [eval(v["type"])]
                 else:
                     expected_type = [eval(_v) for _v in v["type"]]
                 # evaluate against expected types
-                if type(user_dict[k]) in expected_type:
-                    input_file_vars[k] = user_dict[k]
+                if type(self._user_dict[k]) in expected_type:
+                    input_file_vars[k] = self._user_dict[k]
                 else:
                     raise TypeError(
                         f"Input for {str(k)} not of the "
@@ -188,6 +223,14 @@ class init_tools(abc.ABC):
                 # set using default value
                 input_file_vars[k] = v["default"]
 
+        # save the input file as a hidden attr and grab needed value
+        self._input_file_vars = input_file_vars
+        self.verbose = self._input_file_vars["verbose"]
+        if self._input_file_vars["legacy_netcdf"]:
+            self._netcdf_coords = ("time", "x", "y")
+        else:
+            self._netcdf_coords = ("seconds", "x", "y")
+
         # compare the processed inputs with the total inputs. If any unused
         # parameters exist, we warn the user that they are not being used! A
         # special warning is issued for the Preprocessor advanced config
@@ -196,10 +239,10 @@ class init_tools(abc.ABC):
         # remove special keywords from the dict of user YAML parameters
         # these are keywords related to time or matrix/set expansion
         _no_list = ["timesteps", "time", "time_years", "config", "dryrun", "parallel"]
-        _ = [user_dict.pop(key) for key in _no_list if key in user_dict.keys()]
+        _ = [self._user_dict.pop(key) for key in _no_list if key in self._user_dict.keys()]
         # identify unused parameters
         unused_user_keys = [
-            k for k, v in user_dict.items() if not (k in input_file_vars.keys())
+            k for k, v in self._user_dict.items() if not (k in input_file_vars.keys())
         ]
         if len(unused_user_keys) > 0:
             any_in_preprocessor = [k for k in unused_user_keys if (k in pp_only_kw)]
@@ -220,32 +263,6 @@ class init_tools(abc.ABC):
                 self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
 
-        # save the input file as a hidden attr and grab needed value
-        self._input_file_vars = input_file_vars
-        self.out_dir = self._input_file_vars["out_dir"]
-        self.verbose = self._input_file_vars["verbose"]
-        if self._input_file_vars["legacy_netcdf"]:
-            self._netcdf_coords = ("time", "x", "y")
-        else:
-            self._netcdf_coords = ("seconds", "x", "y")
-
-    def process_input_to_model(self) -> None:
-        """Process input file to model variables.
-
-        Loop through the items specified in the model configuration and apply
-        them to the model (i.e., ``self``). Additionally, write the input
-        values specified into the log file.
-
-        .. note::
-
-            If ``self.resume_checkpoint == True``, then the input values are
-            *not* written to the log.
-        """
-        _msg = "Setting up model configuration"
-        self.log_info(_msg, verbosity=0)
-
-        _msg = f"Model type is: {self.__class__.__name__}"
-        self.log_info(_msg, verbosity=0)
 
         # process the input file to attributes of the model
         for k, v in list(self._input_file_vars.items()):

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -87,7 +87,7 @@ class init_tools(abc.ABC):
         if "out_dir" in self._user_dict.keys():
             self.out_dir = self._user_dict["out_dir"]
         else:
-            self.out_dir = self._default_dict["out_dir"]
+            self.out_dir = self._default_dict["out_dir"]["default"]
 
         # output directory config
         self.prefix = self.out_dir

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -28,6 +28,55 @@ from pyDeltaRCM.sed_tools import (
 
 
 class init_tools(abc.ABC):
+    def import_files(self, kwargs_dict={}) -> None:
+        """Import the input files.
+
+        This method handles the parsing of any options supplied via the
+        configuration.
+
+        Parameters
+        ----------
+        kwargs_dict : :obj:`dict`, optional
+
+            A dictionary with keys matching valid model parameter names that can
+            be specified in a configuration YAML file. Keys given in this
+            dictionary will supercede values specified in the YAML
+            configuration.
+
+        Returns
+        -------
+        """
+
+        # get the special loader from the shared tools
+        loader = custom_yaml_loader()
+
+        # Open and access both yaml files --> put in dictionaries
+        # parse default yaml and find expected types
+        default_file = open(self.default_file, mode="r")
+        default_dict = yaml.load(default_file, Loader=loader)
+        default_file.close()
+        for k, v in default_dict.items():
+            if not type(v["type"]) is list:
+                default_dict[k]["type"] = [eval(v["type"])]
+            else:
+                default_dict[k]["type"] = [eval(_v) for _v in v["type"]]
+
+        # only access the user input file if provided.
+        if self.input_file:
+            try:
+                user_file = open(self.input_file, mode="r")
+                user_dict = yaml.load(user_file, Loader=loader)
+                user_file.close()
+            except ValueError as e:
+                raise e
+        else:
+            user_dict = dict()
+
+        self._default_dict = default_dict
+        self._user_dict = user_dict
+        self._kwargs_dict = kwargs_dict
+
+
     def init_output_infrastructure(self) -> None:
         """Initialize the output infrastructure (folder and save lists).
 
@@ -94,53 +143,6 @@ class init_tools(abc.ABC):
             "Platform: {}".format(platform.platform()), verbosity=0
         )  # log the os
 
-    def import_files(self, kwargs_dict={}) -> None:
-        """Import the input files.
-
-        This method handles the parsing of any options supplied via the
-        configuration.
-
-        Parameters
-        ----------
-        kwargs_dict : :obj:`dict`, optional
-
-            A dictionary with keys matching valid model parameter names that can
-            be specified in a configuration YAML file. Keys given in this
-            dictionary will supercede values specified in the YAML
-            configuration.
-
-        Returns
-        -------
-        """
-
-        # get the special loader from the shared tools
-        loader = custom_yaml_loader()
-
-        # Open and access both yaml files --> put in dictionaries
-        # parse default yaml and find expected types
-        default_file = open(self.default_file, mode="r")
-        default_dict = yaml.load(default_file, Loader=loader)
-        default_file.close()
-        for k, v in default_dict.items():
-            if not type(v["type"]) is list:
-                default_dict[k]["type"] = [eval(v["type"])]
-            else:
-                default_dict[k]["type"] = [eval(_v) for _v in v["type"]]
-
-        # only access the user input file if provided.
-        if self.input_file:
-            try:
-                user_file = open(self.input_file, mode="r")
-                user_dict = yaml.load(user_file, Loader=loader)
-                user_file.close()
-            except ValueError as e:
-                raise e
-        else:
-            user_dict = dict()
-
-        self._default_dict = default_dict
-        self._user_dict = user_dict
-        self._kwargs_dict = kwargs_dict
 
 
     def process_input_to_model(self) -> None:

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -102,6 +102,7 @@ class init_tools(abc.ABC):
         self._save_var_list = dict()  # dict of variables to save
         self._save_var_list["meta"] = dict()  # set up meta dict
 
+
     def init_logger(self) -> None:
         """Initialize a logger.
 
@@ -142,7 +143,6 @@ class init_tools(abc.ABC):
         self.log_info(
             "Platform: {}".format(platform.platform()), verbosity=0
         )  # log the os
-
 
 
     def process_input_to_model(self) -> None:

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -17,12 +17,9 @@ from pyDeltaRCM.shared_tools import (
     custom_yaml_loader,
     set_random_seed,
     set_random_state,
-    ParameterChangedWarning
+    ParameterChangedWarning,
 )
-from pyDeltaRCM.sed_tools import (
-    MudRouter,
-    SandRouter
-)
+from pyDeltaRCM.sed_tools import MudRouter, SandRouter
 
 # tools for initiating deltaRCM model domain
 
@@ -76,7 +73,6 @@ class init_tools(abc.ABC):
         self._user_dict = user_dict
         self._kwargs_dict = kwargs_dict
 
-
     def init_output_infrastructure(self) -> None:
         """Initialize the output infrastructure (folder and save lists).
 
@@ -101,7 +97,6 @@ class init_tools(abc.ABC):
         self._save_fig_list = dict()  # dict of figure variables to save
         self._save_var_list = dict()  # dict of variables to save
         self._save_var_list["meta"] = dict()  # set up meta dict
-
 
     def init_logger(self) -> None:
         """Initialize a logger.
@@ -144,7 +139,6 @@ class init_tools(abc.ABC):
             "Platform: {}".format(platform.platform()), verbosity=0
         )  # log the os
 
-
     def process_input_to_model(self) -> None:
         """Process input file to model variables.
 
@@ -172,8 +166,10 @@ class init_tools(abc.ABC):
         #   **kwargs input
         for kwk, kwv in self._kwargs_dict.items():
             if kwk in self._user_dict.keys():
-                _msg = ("A keyword specification was also found "
-                        "in the user specified input YAML file: %s" % kwk)
+                _msg = (
+                    "A keyword specification was also found "
+                    "in the user specified input YAML file: %s" % kwk
+                )
                 self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
             self._user_dict[kwk] = kwv
@@ -199,9 +195,11 @@ class init_tools(abc.ABC):
         # add custom subclass yaml parameters (yaml or defaults) to input vars
         for k, v in self.subclass_parameters.items():
             if k in input_file_vars:
-                _msg = (f"Custom subclass parameter '{k}' is already a "
-                        f"default yaml parameter of the model."
-                        f"Choose a different name for custom parameter value.")
+                _msg = (
+                    f"Custom subclass parameter '{k}' is already a "
+                    f"default yaml parameter of the model."
+                    f"Choose a different name for custom parameter value."
+                )
                 raise ValueError(_msg)
             elif k in self._user_dict:
                 # get expected types
@@ -240,30 +238,38 @@ class init_tools(abc.ABC):
         # remove special keywords from the dict of user YAML parameters
         # these are keywords related to time or matrix/set expansion
         _no_list = ["timesteps", "time", "time_years", "config", "dryrun", "parallel"]
-        _ = [self._user_dict.pop(key) for key in _no_list if key in self._user_dict.keys()]
+        _ = [
+            self._user_dict.pop(key)
+            for key in _no_list
+            if key in self._user_dict.keys()
+        ]
         # identify unused parameters
         unused_user_keys = [
             k for k, v in self._user_dict.items() if not (k in input_file_vars.keys())
         ]
         if len(unused_user_keys) > 0:
             any_in_preprocessor = [k for k in unused_user_keys if (k in pp_only_kw)]
-            if len(any_in_preprocessor):
-                _msg = ("A Preprocessor-only keyword was specified as input in "
-                        "yaml file or kwargs: {0}. Advanced configurations "
-                        "are only supported by the Preprocessor via the "
-                        "high-level API. Any parameters specified as part of this "
-                        "advanced keyword configuration will not be used!".format(
-                            any_in_preprocessor
-                        ))
+            any_other_unused = [k for k in unused_user_keys if not (k in pp_only_kw)]
+            if len(any_in_preprocessor) > 0:
+                _msg = (
+                    "A Preprocessor-only keyword was specified as input in "
+                    "yaml file or kwargs: {0}. Advanced configurations "
+                    "are only supported by the Preprocessor via the "
+                    "high-level API. Any parameters specified as part of this "
+                    "advanced keyword configuration will not be used!".format(
+                        any_in_preprocessor
+                    )
+                )
                 self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
-            else:
-                _msg = ("One or more inputs in yaml file or kwargs were unused by "
-                        "the model during instantiation. "
-                        "The unused keys are: {0}".format(str(unused_user_keys)))
+            if len(any_other_unused) > 0:
+                _msg = (
+                    "One or more inputs in yaml file or kwargs were unused by "
+                    "the model during instantiation. "
+                    "The unused keys are: {0}".format(str(unused_user_keys))
+                )
                 self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
-
 
         # process the input file to attributes of the model
         for k, v in list(self._input_file_vars.items()):
@@ -453,12 +459,16 @@ class init_tools(abc.ABC):
         self.L0 = max(1, min(int(round(self._L0_meters / self._dx)), self.L // 4))
         self.N0 = max(3, min(int(round(self._N0_meters / self._dx)), self.W // 4))
         if self.L0 * self._dx != _input_L0_meters:
-            pcw = ParameterChangedWarning("L0_meters", _input_L0_meters, self.L0 * self._dx)
+            pcw = ParameterChangedWarning(
+                "L0_meters", _input_L0_meters, self.L0 * self._dx
+            )
             self.log_warning(format(pcw))
             warnings.warn(pcw)
             self.L0_meters = self.L0 * self._dx
         if self.N0 * self._dx != _input_N0_meters:
-            pcw = ParameterChangedWarning("N0_meters", _input_N0_meters, self.N0 * self._dx)
+            pcw = ParameterChangedWarning(
+                "N0_meters", _input_N0_meters, self.N0 * self._dx
+            )
             self.log_warning(format(pcw))
             warnings.warn(pcw)
             self.N0_meters = self.N0 * self._dx
@@ -875,11 +885,13 @@ class init_tools(abc.ABC):
                     __inlist = self._save_var_list["meta"][_val]
                     __varname = _val
                     if __inlist[0] is None:
-                        _msg = ("Specifying `None` for time varying dimensions "
-                                "of model outputs will soon be deprecated. "
-                                "Change to specifying the name of the "
-                                "variable to save a string, and/or convert to "
-                                "dictionary inputs.")
+                        _msg = (
+                            "Specifying `None` for time varying dimensions "
+                            "of model outputs will soon be deprecated. "
+                            "Change to specifying the name of the "
+                            "variable to save a string, and/or convert to "
+                            "dictionary inputs."
+                        )
                         self.log_warning(_msg)
                         warnings.warn(UserWarning(_msg))
                         __varvalue = None

--- a/pyDeltaRCM/init_tools.py
+++ b/pyDeltaRCM/init_tools.py
@@ -54,16 +54,19 @@ class init_tools(abc.ABC):
         The level of information printed to the log depends on the verbosity
         setting.
         """
-        timestamp = time_lib.strftime("%Y%m%d-%H%M%S")
-        self.logger = logging.getLogger(self.prefix_abspath + timestamp)
-        self.logger.setLevel(logging.INFO)
-
         # create the logging file handler
+        timestamp = time_lib.strftime("%Y%m%d-%H%M%S")
         fh = logging.FileHandler(
             os.path.join(self.prefix_abspath, "pyDeltaRCM_" + timestamp + ".log")
         )
         formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
         fh.setFormatter(formatter)
+
+        timestamp = time_lib.strftime("%Y%m%d-%H%M%S")
+        self.logger = logging.getLogger(self.prefix_abspath + timestamp)
+        self.logger.setLevel(logging.INFO)
+
+        self.logger.setLevel(logging.DEBUG)
 
         # add handler to logger object
         self.logger.addHandler(fh)
@@ -133,12 +136,9 @@ class init_tools(abc.ABC):
         #   **kwargs input
         for kwk, kwv in kwargs_dict.items():
             if kwk in user_dict.keys():
-                warnings.warn(
-                    UserWarning(
-                        "A keyword specification was also found in the "
-                        "user specified input YAML file: %s" % kwk
-                    )
-                )
+                _msg = ("A keyword specification was also found in the user specified input YAML file: %s" % kwk)
+                self.log_warning(_msg)
+                warnings.warn(UserWarning(_msg))
             user_dict[kwk] = kwv
 
         # go through and populate input vars with user and default values,
@@ -162,13 +162,11 @@ class init_tools(abc.ABC):
         # add custom subclass yaml parameters (yaml or defaults) to input vars
         for k, v in self.subclass_parameters.items():
             if k in input_file_vars:
-                warnings.warn(
-                    UserWarning(
-                        "Custom subclass parameter name is already a "
+                _msg = ("Custom subclass parameter name is already a "
                         "default yaml parameter of the model, "
-                        "custom parameter value will not be used."
-                    )
-                )
+                        "custom parameter value will not be used.")
+                self.log_warning(_msg)
+                warnings.warn(UserWarning(_msg))
             elif k in user_dict:
                 # get expected types
                 if not type(v["type"]) is list:
@@ -206,28 +204,21 @@ class init_tools(abc.ABC):
         if len(unused_user_keys) > 0:
             any_in_preprocessor = [k for k in unused_user_keys if (k in pp_only_kw)]
             if len(any_in_preprocessor):
-                warnings.warn(
-                    UserWarning(
-                        "A Preprocessor-only keyword was specified as input in "
+                _msg = ("A Preprocessor-only keyword was specified as input in "
                         "yaml file or kwargs: {0}. Advanced configurations "
                         "are only supported by the Preprocessor via the "
                         "high-level API. Any parameters specified as part of this "
                         "advanced keyword configuration will not be used!".format(
                             any_in_preprocessor
-                        )
-                    )
-                )
+                        ))
+                self.log_warning(_msg)
+                warnings.warn(UserWarning(_msg))
             else:
-                warnings.warn(
-                    UserWarning(
-                        "One or more inputs in yaml file or kwargs were unused by "
+                _msg = ("One or more inputs in yaml file or kwargs were unused by "
                         "the model during instantiation. "
-                        "The unused keys are: {0}".format(str(unused_user_keys))
-                    )
-                )
-
-        # note, the specified parameters are assigned to the model object in
-        # the following function `process_input_to_model`.
+                        "The unused keys are: {0}".format(str(unused_user_keys)))
+                self.log_warning(_msg)
+                warnings.warn(UserWarning(_msg))
 
         # save the input file as a hidden attr and grab needed value
         self._input_file_vars = input_file_vars
@@ -313,19 +304,21 @@ class init_tools(abc.ABC):
         self.U_ero_mud = self._coeff_U_ero_mud * self._u0
 
         # Length and Width are rounded so domain is integer number of cells
+        #   check if need to round length, then log and warn and change
         if self._Length % self._dx != 0:
             _new = int(round(self._Length / self._dx)) * self._dx
-            warnings.warn(
-                ParameterChangedWarning("Length", self._Length, _new)
-            )
+            pcw = ParameterChangedWarning("Length", self._Length, _new)
+            self.log_warning(format(pcw))
+            warnings.warn(pcw)
             self._Length = _new
+        #   check if need to round width, then log and warn and change
         if self._Width % self._dx != 0:
             _new = int(round(self._Width / self._dx)) * self._dx
-            warnings.warn(
-                ParameterChangedWarning("Width", self._Width, _new)
-            )
+            pcw = ParameterChangedWarning("Width", self._Width, _new)
+            self.log_warning(format(pcw))
+            warnings.warn(pcw)
             self._Width = _new
-        # now guarenteed to be divisible
+        # now guaranteed to be divisible
         self.L = int(self._Length / self._dx)  # num cells in x
         self.W = int(self._Width / self._dx)  # num cells in y
 
@@ -442,18 +435,14 @@ class init_tools(abc.ABC):
         self.L0 = max(1, min(int(round(self._L0_meters / self._dx)), self.L // 4))
         self.N0 = max(3, min(int(round(self._N0_meters / self._dx)), self.W // 4))
         if self.L0 * self._dx != _input_L0_meters:
-            warnings.warn(
-                ParameterChangedWarning(
-                    "L0_meters", _input_L0_meters, self.L0 * self._dx
-                )
-            )
+            pcw = ParameterChangedWarning("L0_meters", _input_L0_meters, self.L0 * self._dx)
+            self.log_warning(format(pcw))
+            warnings.warn(pcw)
             self.L0_meters = self.L0 * self._dx
         if self.N0 * self._dx != _input_N0_meters:
-            warnings.warn(
-                ParameterChangedWarning(
-                    "N0_meters", _input_N0_meters, self.N0 * self._dx
-                )
-            )
+            pcw = ParameterChangedWarning("N0_meters", _input_N0_meters, self.N0 * self._dx)
+            self.log_warning(format(pcw))
+            warnings.warn(pcw)
             self.N0_meters = self.N0 * self._dx
 
         self.u_max = 2.0 * self._u0  # maximum allowed flow velocity
@@ -709,7 +698,7 @@ class init_tools(abc.ABC):
                 )
             else:
                 _msg = "Output file in legacy schema"
-                warnings.warn(
+                _wmsg = (
                     "Creating output netcdf file in legacy schema. This format is "
                     "provided as a convenience for users who are currently "
                     "relying on workflows that use an old format of netcdf file. "
@@ -717,6 +706,9 @@ class init_tools(abc.ABC):
                     "leverage the sandsuet formatted data specification "
                     "(i.e., `legacy_netcdf=False`)."
                 )
+                self.log_warning(_wmsg)
+                warnings.warn(_wmsg)
+
             self.log_info(_msg, verbosity=1)
 
             if (os.path.exists(file_path)) and (self._clobber_netcdf is False):
@@ -726,7 +718,7 @@ class init_tools(abc.ABC):
                 )
             elif (os.path.exists(file_path)) and (self._clobber_netcdf is True):
                 _msg = "Replacing existing netCDF file"
-                self.logger.warning(_msg)
+                self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
                 os.remove(file_path)
 
@@ -865,15 +857,13 @@ class init_tools(abc.ABC):
                     __inlist = self._save_var_list["meta"][_val]
                     __varname = _val
                     if __inlist[0] is None:
-                        warnings.warn(
-                            UserWarning(
-                                "Specifying `None` for time varying dimensions "
+                        _msg = ("Specifying `None` for time varying dimensions "
                                 "of model outputs will soon be deprecated. "
                                 "Change to specifying the name of the "
                                 "variable to save a string, and/or convert to "
-                                "dictionary inputs."
-                            )
-                        )
+                                "dictionary inputs.")
+                        self.log_warning(_msg)
+                        warnings.warn(UserWarning(_msg))
                         __varvalue = None
                     else:
                         __varvalue = getattr(self, __inlist[0])
@@ -1048,6 +1038,7 @@ class init_tools(abc.ABC):
             _eta0 = checkpoint["eta0"]
         else:
             if not _warned:
+                self.log_warning(_warning_msg)
                 warnings.warn(UserWarning(_warning_msg))
                 _warned = True
             _eta0 = np.full(checkpoint["eta"].shape, np.nan)
@@ -1057,6 +1048,7 @@ class init_tools(abc.ABC):
             _eta_init = checkpoint["eta_init"]
         else:
             if not _warned:
+                self.log_warning(_warning_msg)
                 warnings.warn(UserWarning(_warning_msg))
                 _warned = True
             _eta_init = np.full(checkpoint["eta"].shape, np.nan)
@@ -1148,7 +1140,7 @@ class init_tools(abc.ABC):
                     "NetCDF4 output file not found, but was expected. "
                     "Creating a new output file."
                 )
-                self.logger.warning(_msg)
+                self.log_warning(_msg)
                 warnings.warn(UserWarning(_msg))
 
                 # create a new file

--- a/pyDeltaRCM/iteration_tools.py
+++ b/pyDeltaRCM/iteration_tools.py
@@ -56,7 +56,7 @@ class iteration_tools(abc.ABC):
             "Running `solve_water_and_sediment_timestep` now, but "
             "this will be removed in future release."
         )
-        self.logger.warning(_msg)
+        self.log_warning(_msg)
         warnings.warn(UserWarning(_msg))
         self.solve_water_and_sediment_timestep()
 
@@ -131,6 +131,21 @@ class iteration_tools(abc.ABC):
         if self._verbose >= verbosity:
             self.logger.info(message)
 
+    def log_warning(self, message: str) -> None:
+        """Log warnings.
+
+        We manually log warnings in pyDeltaRCM so that no global settings of the
+        warnings package are affected nor affect this logging.
+
+        Note: `verbosity` not taken as a paramters, we always log warnings.
+
+        Parameters
+        ----------
+        message : :obj:`str`
+            Message string to write to the log as warning.
+        """
+        self.logger.warning(message)
+
     def log_model_time(self) -> None:
         """Log the time of the model.
 
@@ -179,7 +194,8 @@ class iteration_tools(abc.ABC):
                         "entries in the output NetCDF4 after resuming "
                         "the model run."
                     )
-                    self.logger.warning(_msg)
+                    self.log_warning(_msg)
+                    warnings.warn(_msg)
 
                 self._save_time_since_checkpoint = 0
 

--- a/pyDeltaRCM/model.py
+++ b/pyDeltaRCM/model.py
@@ -544,6 +544,7 @@ class DeltaModel(
                 f"lower the value of gamma. See documentation for "
                 f"more information."
             )
+            self.log_warning(_msg)
             warnings.warn(UserWarning(_msg))
         self._gamma = gamma
 
@@ -1429,11 +1430,9 @@ class DeltaModel(
     @time_step.setter
     def time_step(self, new_time_step: float) -> None:
         if new_time_step * self.init_Np_sed < 100:
-            warnings.warn(
-                UserWarning(
-                    "Using a very small time step, " "Delta might evolve very slowly."
-                )
-            )
+            _msg = "Using a very small time step, so the delta might evolve very slowly."
+            self.log_warning(_msg)
+            warnings.warn(UserWarning(_msg))
 
         if self.toggle_subsidence:
             self.sigma = (self.sigma / self._dt) * new_time_step
@@ -1489,14 +1488,6 @@ class DeltaModel(
         self.N0_meters = new_N0_meters
         self.create_boundary_conditions()
         self.init_sediment_routers()
-        if self.channel_width != new_N0_meters:
-            warnings.warn(
-                UserWarning(
-                    "Channel width was updated to {0} m, rather than input {1},"
-                    "due to grid resolution or imposed domain "
-                    "restrictions.".format(self.channel_width, new_N0_meters)
-                )
-            )
 
     @property
     def channel_flow_depth(self) -> float:

--- a/pyDeltaRCM/preprocessor.py
+++ b/pyDeltaRCM/preprocessor.py
@@ -96,7 +96,8 @@ class BasePreprocessor(abc.ABC):
         Parameters
         ----------
         input_file
-            Path to the input file as string, or Pathlib `Path`.
+            Path to the input file as string, or Pathlib `Path`, or a `dict`, as
+            substitute for a yaml file.
 
         Returns
         -------
@@ -131,22 +132,24 @@ class BasePreprocessor(abc.ABC):
         if self._has_ensemble:
             self._expand_ensemble()
 
-        if self._has_ensemble or self._has_set or self._has_matrix:
-            self._prepare_multijob_output()
+        # prepare output folder(s)
+        self._prepare_multijob_output()
 
         # if there is a matrix or set specification
         if self._has_matrix:
             self._expand_matrix()  # creates self.file_list
         elif self._has_set:
             self._expand_set()
-        # otherwise convert to a simple list on input file
+        # otherwise create info for a single job and go to writer
         else:
-            self._file_list = [self._input_file]
-            self._config_list = [self.config_dict]
+            # find job id and create output file
+            ith_id = "job_000"
+            ith_dir = os.path.join(self._jobs_root, ith_id)
+            _ith_config = self.config_dict.copy()
+            _ith_config["out_dir"] = ith_dir
+            self._config_list = [_ith_config]
 
-        # write the job configs to file, if needed
-        if self._has_ensemble or self._has_set or self._has_matrix:
-            self._write_job_configs()
+        self._write_job_configs()
 
     def _prelim_config_parsing(self) -> None:
         """Preliminary configuration parsing.
@@ -508,7 +511,6 @@ class BasePreprocessor(abc.ABC):
         # loop through each job to write out info
         for c, config in enumerate(self.config_list):
             # write out the job specific yaml file
-            # ith_p = self._write_yaml_config(c, config)
             if self.verbose > 0:
                 print("Writing YAML file for job " + str(int(c)))
 
@@ -1170,23 +1172,22 @@ class Preprocessor(BasePreprocessor):
         """Initialize the python preprocessor.
 
         The initialization includes the entire configuration of the job list
-        (parsing, timesteps, etc.). The jobs are *not* run automatically
-        during instantiation of the class.
+        (parsing, timesteps, etc.). The jobs are *not* run automatically during
+        instantiation of the class.
 
-        You must specify timesteps in either the YAML configuration file or
-        via the `timesteps` parameter.
+        You must specify timesteps in either the YAML configuration file or via
+        the `timesteps` parameter.
 
         Parameters
         ----------
         input_file : :obj:`str`, optional
-            Path to an input YAML configuration file. Must include the
-            `timesteps` parameter if you do not specify the `timesteps` as a
-            keyword argument.
+            Path to an input YAML configuration file or dictionary with
+            parameters. Must include the `timesteps` parameter if you do not
+            specify the `timesteps` as a keyword argument.
 
         timesteps : :obj:`int`, optional
             Number of timesteps to run each of the jobs. Must be specified if
-            you do not specify the `timesteps` parameter in the input YAML
-            file.
+            you do not specify the `timesteps` parameter in the input YAML file.
 
         """
         super().__init__()

--- a/pyDeltaRCM/sed_tools.py
+++ b/pyDeltaRCM/sed_tools.py
@@ -9,8 +9,6 @@ from scipy import ndimage
 
 import warnings
 
-# from . import shared_tools
-
 from pyDeltaRCM.shared_tools import (
     get_inlet_weights,
     get_start_indices,
@@ -66,7 +64,7 @@ class sed_tools(abc.ABC):
             "Running `route_sediment` now, but "
             "this will be removed in future release."
         )
-        self.logger.warning(_msg)
+        self.log_warning(_msg)
         warnings.warn(UserWarning(_msg))
         self.route_sediment()
 

--- a/tests/integration/test_checkpointing.py
+++ b/tests/integration/test_checkpointing.py
@@ -272,8 +272,10 @@ class TestCheckpointingIntegrations:
         # modify the checkpoint dt to be different than save_dt
         baseModel._checkpoint_dt = baseModel.save_dt * 0.65
 
-        for _ in range(0, 50):
-            baseModel.update()
+        # CHECK for warning about mismatched intervals!
+        with pytest.warns(UserWarning, match=r"Grid save interval and checkpoint interval"):
+            for _ in range(0, 50):
+                baseModel.update()
         baseModel.finalize()
 
         assert baseModel.time == baseModel._dt * 50

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -35,9 +35,9 @@ class TestCommandLineInterfaceDirectly:
         f.close()
         subprocess.check_output(['pyDeltaRCM',
                                  '--config', str(p)])
-        exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-        exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
-        exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+        exp_path_nc = os.path.join(tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+        exp_path_png0 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00000.png')
+        exp_path_png1 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00001.png')
         assert os.path.isfile(exp_path_nc)
         assert os.path.isfile(exp_path_png0)
         assert os.path.isfile(exp_path_png1)
@@ -64,10 +64,10 @@ class TestCommandLineInterfaceDirectly:
         f.close()
         subprocess.check_output(['python', '-m', 'pyDeltaRCM',
                                  '--config', str(p)])
-        exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-        exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
-        exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
-        exp_path_png2 = os.path.join(tmp_path / 'test', 'eta_00002.png')
+        exp_path_nc = os.path.join(tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+        exp_path_png = os.path.join(tmp_path / 'test', 'job_000', 'eta_00000.png')
+        exp_path_png1 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00001.png')
+        exp_path_png2 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00002.png')
         assert os.path.isfile(exp_path_nc)
         assert os.path.isfile(exp_path_png)
         assert os.path.isfile(exp_path_png1)
@@ -90,8 +90,8 @@ class TestCommandLineInterfaceDirectly:
         subprocess.check_output(['python', '-m', 'pyDeltaRCM',
                                  '--config', str(p),
                                  '--dryrun'])
-        exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-        exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
+        exp_path_nc = os.path.join(tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+        exp_path_png = os.path.join(tmp_path / 'test', 'job_000', 'eta_00000.png')
         assert not os.path.isfile(exp_path_nc)   # does not exist because --dryrun
         assert not os.path.isfile(exp_path_png)  # does not exist because --dryrun
 
@@ -114,8 +114,8 @@ class TestCommandLineInterfaceDirectly:
         subprocess.check_output(['python', '-m', 'pyDeltaRCM',
                                  '--config', str(p),
                                  '--timesteps', '2'])
-        exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-        exp_path_png = os.path.join(tmp_path / 'test', 'eta_00000.png')
+        exp_path_nc = os.path.join(tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+        exp_path_png = os.path.join(tmp_path / 'test', 'job_000', 'eta_00000.png')
         assert os.path.isfile(exp_path_nc)
         assert os.path.isfile(exp_path_png)
 
@@ -149,9 +149,9 @@ class TestCommandLineInterfaceDirectly:
         f.close()
         subprocess.check_output(['pyDeltaRCM',
                                  '--config', str(p), '--timesteps', '2'])
-        exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-        exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
-        exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+        exp_path_nc = os.path.join(tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+        exp_path_png0 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00000.png')
+        exp_path_png1 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00001.png')
         assert os.path.isfile(exp_path_nc)
         assert os.path.isfile(exp_path_png0)
         assert os.path.isfile(exp_path_png1)
@@ -177,9 +177,9 @@ class TestCommandLineInterfaceDirectly:
         f.close()
         subprocess.check_output(['pyDeltaRCM',
                                  '--config', str(p), '--time', '1000'])
-        exp_path_nc = os.path.join(tmp_path / 'test', 'pyDeltaRCM_output.nc')
-        exp_path_png0 = os.path.join(tmp_path / 'test', 'eta_00000.png')
-        exp_path_png1 = os.path.join(tmp_path / 'test', 'eta_00001.png')
+        exp_path_nc = os.path.join(tmp_path / 'test', 'job_000', 'pyDeltaRCM_output.nc')
+        exp_path_png0 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00000.png')
+        exp_path_png1 = os.path.join(tmp_path / 'test', 'job_000', 'eta_00001.png')
         assert os.path.isfile(exp_path_nc)
         assert os.path.isfile(exp_path_png0)
         assert os.path.isfile(exp_path_png1)

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -1619,3 +1619,60 @@ class TestCustomOutputs:
 
         assert "normalized_discharge_x" in data.variables
         assert np.all(data["normalized_discharge_x"][0].data == delta.qxn)
+
+
+class TestCustomInputs:
+    def test_custom_model_inputs(self, tmp_path: Path) -> None:
+        # test that input metadata can be a dict
+        file_name = "user_parameters.yaml"
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
+        utilities.write_parameter_to_file(f, "custom_bool", True) # change from default below
+        utilities.write_parameter_to_file(f, "custom_list", [1, 2, 3]) # change from default below
+        f.close()
+
+        class CustomInputs(DeltaModel):
+            def __init__(self, input_file=None, **kwargs):
+                # inherit base DeltaModel methods
+                super().__init__(input_file, **kwargs)
+
+            def hook_import_files(self):
+                """Define the custom YAML parameters."""
+                # custom boolean parameter
+                self.subclass_parameters['custom_bool'] = {
+                    'type': 'bool', 'default': False
+                }
+
+                # custom numeric parameter
+                self.subclass_parameters['custom_number'] = {
+                    'type': ['int', 'float'], 'default': 42
+                }
+
+                # custom list parameter
+                self.subclass_parameters['custom_list'] = {
+                    'type': ['list'], 'default': []
+                }
+
+        delta = CustomInputs(input_file=p)
+
+        assert delta.custom_bool == True
+        assert delta.custom_number == 42  # default
+        assert delta.custom_list == [1, 2, 3]  # default
+
+    def test_custom_inputs_not_defined_warning(self, tmp_path: Path) -> None:
+        # test that input metadata can be a dict
+        file_name = "user_parameters.yaml"
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
+        utilities.write_parameter_to_file(f, "not_defined_parameter", True) # change from default below
+        f.close()
+
+        class CustomInputs(DeltaModel):
+            def __init__(self, input_file=None, **kwargs):
+                # inherit base DeltaModel methods
+                super().__init__(input_file, **kwargs)
+
+        with pytest.warns(UserWarning, match=r"not_defined_parameter"):
+            delta = CustomInputs(input_file=p)
+
+        assert not hasattr(delta, "not_defined_parameter")

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -1180,6 +1180,16 @@ class TestInputParameterResolution:
         with pytest.warns(UserWarning, match=r"A Preprocessor-only .*set.*"):
             _ = DeltaModel(input_file=p)
 
+    def test_parameter_pp_AND_unused(self, tmp_path):
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"matrix": 0.8, "unused_input_yaml": 42}
+        )
+        with (
+            pytest.warns(UserWarning, match=r"A Preprocessor-only .*matrix.*"),
+            pytest.warns(UserWarning, match=r"One or more .* ['unused_input_yaml']"),
+        ):
+            _ = DeltaModel(input_file=p)
+
     def test_parameter_timesteps_unused_no_warning(self, tmp_path):
         p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"timesteps": 1})
         # ensure no warnings are emitted
@@ -1627,8 +1637,12 @@ class TestCustomInputs:
         file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
         utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
-        utilities.write_parameter_to_file(f, "custom_bool", True) # change from default below
-        utilities.write_parameter_to_file(f, "custom_list", [1, 2, 3]) # change from default below
+        utilities.write_parameter_to_file(
+            f, "custom_bool", True
+        )  # change from default below
+        utilities.write_parameter_to_file(
+            f, "custom_list", [1, 2, 3]
+        )  # change from default below
         f.close()
 
         class CustomInputs(DeltaModel):
@@ -1639,18 +1653,21 @@ class TestCustomInputs:
             def hook_import_files(self):
                 """Define the custom YAML parameters."""
                 # custom boolean parameter
-                self.subclass_parameters['custom_bool'] = {
-                    'type': 'bool', 'default': False
+                self.subclass_parameters["custom_bool"] = {
+                    "type": "bool",
+                    "default": False,
                 }
 
                 # custom numeric parameter
-                self.subclass_parameters['custom_number'] = {
-                    'type': ['int', 'float'], 'default': 42
+                self.subclass_parameters["custom_number"] = {
+                    "type": ["int", "float"],
+                    "default": 42,
                 }
 
                 # custom list parameter
-                self.subclass_parameters['custom_list'] = {
-                    'type': ['list'], 'default': []
+                self.subclass_parameters["custom_list"] = {
+                    "type": ["list"],
+                    "default": [],
                 }
 
         delta = CustomInputs(input_file=p)
@@ -1658,24 +1675,6 @@ class TestCustomInputs:
         assert delta.custom_bool == True
         assert delta.custom_number == 42  # default
         assert delta.custom_list == [1, 2, 3]  # default
-
-    def test_custom_inputs_not_defined_warning(self, tmp_path: Path) -> None:
-        # test that input metadata can be a dict
-        file_name = "user_parameters.yaml"
-        p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
-        utilities.write_parameter_to_file(f, "not_defined_parameter", True) # change from default below
-        f.close()
-
-        class CustomInputs(DeltaModel):
-            def __init__(self, input_file=None, **kwargs):
-                # inherit base DeltaModel methods
-                super().__init__(input_file, **kwargs)
-
-        with pytest.warns(UserWarning, match=r"not_defined_parameter"):
-            delta = CustomInputs(input_file=p)
-
-        assert not hasattr(delta, "not_defined_parameter")
 
     def test_custom_inputs_already_exists(self, tmp_path: Path) -> None:
         # test that input metadata can be a dict
@@ -1691,9 +1690,32 @@ class TestCustomInputs:
 
             def hook_import_files(self):
                 # define a parameter that already exists
-                self.subclass_parameters['theta_water'] = {
-                    'type': 'float', 'default': 10000
+                self.subclass_parameters["theta_water"] = {
+                    "type": "float",
+                    "default": 10000,
                 }
 
-        with pytest.raises(ValueError, match=r"Custom subclass parameter 'theta_water'"):
+        with pytest.raises(
+            ValueError, match=r"Custom subclass parameter 'theta_water'"
+        ):
             delta = CustomInputs(input_file=p)
+
+    def test_custom_model_unused(self, tmp_path: Path) -> None:
+        # test that input metadata can be a dict
+        file_name = "user_parameters.yaml"
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
+        utilities.write_parameter_to_file(
+            f, "unused_input_yaml", True
+        )  # change from default below
+        f.close()
+
+        class CustomInputs(DeltaModel):
+            def __init__(self, input_file=None, **kwargs):
+                # inherit base DeltaModel methods
+                super().__init__(input_file, **kwargs)
+
+        with pytest.warns(UserWarning, match=r"One or more .* ['unused_input_yaml']"):
+            delta = CustomInputs(input_file=p)
+
+        assert not hasattr(delta, "unused_input_yaml")

--- a/tests/test_init_tools.py
+++ b/tests/test_init_tools.py
@@ -1676,3 +1676,24 @@ class TestCustomInputs:
             delta = CustomInputs(input_file=p)
 
         assert not hasattr(delta, "not_defined_parameter")
+
+    def test_custom_inputs_already_exists(self, tmp_path: Path) -> None:
+        # test that input metadata can be a dict
+        file_name = "user_parameters.yaml"
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
+        f.close()
+
+        class CustomInputs(DeltaModel):
+            def __init__(self, input_file=None, **kwargs):
+                # inherit base DeltaModel methods
+                super().__init__(input_file, **kwargs)
+
+            def hook_import_files(self):
+                # define a parameter that already exists
+                self.subclass_parameters['theta_water'] = {
+                    'type': 'float', 'default': 10000
+                }
+
+        with pytest.raises(ValueError, match=r"Custom subclass parameter 'theta_water'"):
+            delta = CustomInputs(input_file=p)

--- a/tests/test_iteration_tools.py
+++ b/tests/test_iteration_tools.py
@@ -238,7 +238,9 @@ class TestOutputCheckpoint:
             "input.yaml",
             {"save_checkpoint": True, "checkpoint_dt": 864000000},
         )
-        _delta = DeltaModel(input_file=p)
+        # issue one warning when initializing
+        with pytest.warns(UserWarning, match=r"interval are not identical"):
+            _delta = DeltaModel(input_file=p)
 
         # force the time to be greater than the checkpoint interval
         _delta._save_time_since_checkpoint = 2 * _delta._checkpoint_dt
@@ -246,11 +248,13 @@ class TestOutputCheckpoint:
         # mock the actual save checkpoint function to see if it was called
         _delta.save_the_checkpoint = mock.MagicMock()
 
-        # this warning is only written to log, so mock the logger
+        # mock the logger for testing in this file
         _delta.logger = mock.MagicMock()
 
-        # run the output checkpoint func
-        _delta.output_checkpoint()
+        # issue second warning when outputting
+        with pytest.warns(UserWarning, match=r"interval are not identical"):
+            # run the output checkpoint func
+            _delta.output_checkpoint()
 
         # assertions
         assert _delta.save_the_checkpoint.call_count == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -181,7 +181,7 @@ class TestLoggerIntegratedDuringInitialization:
         p, f = utilities.create_temporary_file(tmp_path, file_name)
         utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
         utilities.write_parameter_to_file(f, 'verbose', 1)
-        # utilities.write_parameter_to_file(f, 'Width', 10001)
+        utilities.write_parameter_to_file(f, 'Width', 10001)
         f.close()
         delta = DeltaModel(input_file=p)
         _logs = glob.glob(os.path.join(delta.prefix, '*.log'))

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,5 @@
+import pytest
+
 import os
 import sys
 import glob
@@ -6,6 +8,7 @@ from pathlib import Path
 import unittest.mock as mock
 
 from pyDeltaRCM.model import DeltaModel
+from pyDeltaRCM.shared_tools import ParameterChangedWarning
 
 from . import utilities
 
@@ -183,10 +186,13 @@ class TestLoggerIntegratedDuringInitialization:
         utilities.write_parameter_to_file(f, 'verbose', 1)
         utilities.write_parameter_to_file(f, 'Width', 10001)
         f.close()
-        delta = DeltaModel(input_file=p)
+        # check that warning is raised
+        with pytest.warns(ParameterChangedWarning):
+            delta = DeltaModel(input_file=p)
         _logs = glob.glob(os.path.join(delta.prefix, '*.log'))
         assert len(_logs) == 1  # log file exists
         with open(_logs[0], 'r') as _logfile:
             _lines = _logfile.readlines()
             _joinedlines = ' '.join(_lines)  # collapse to a single string
+        # check that warning is logged
         assert "Parameter 'Width' was changed from 10001 to 10000." in _joinedlines

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -175,3 +175,18 @@ class TestLoggerIntegratedDuringInitialization:
                 raise ValueError('Could not convert the seed to int')
 
             assert _intseed >= 0
+
+    def test_logger_capture_changed_parameters_warnings(self, tmp_path: Path) -> None:
+        file_name = 'user_parameters.yaml'
+        p, f = utilities.create_temporary_file(tmp_path, file_name)
+        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'out_dir')
+        utilities.write_parameter_to_file(f, 'verbose', 1)
+        # utilities.write_parameter_to_file(f, 'Width', 10001)
+        f.close()
+        delta = DeltaModel(input_file=p)
+        _logs = glob.glob(os.path.join(delta.prefix, '*.log'))
+        assert len(_logs) == 1  # log file exists
+        with open(_logs[0], 'r') as _logfile:
+            _lines = _logfile.readlines()
+            _joinedlines = ' '.join(_lines)  # collapse to a single string
+        assert "Parameter 'Width' was changed from 10001 to 10000." in _joinedlines

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import unittest.mock as mock
 
 from pyDeltaRCM.model import DeltaModel
-from pyDeltaRCM import shared_tools
+from pyDeltaRCM.shared_tools import (
+    ParameterChangedWarning
+)
 from . import utilities
 
 
@@ -506,15 +508,32 @@ class TestPublicSettersAndGetters:
 
         # change value
         #  the channel width is then changed internally with `N0`, according
-        #  to the `create_boundary_conditions` so no change is actually made
-        #  here.
-        with pytest.warns(UserWarning):
-            _delta.channel_width = 300
-        assert _delta.channel_width == 250  # not changed!
+        #  to the `create_boundary_conditions`
+        _delta.channel_width = 300
+        assert _delta.channel_width == 250  # not changed bc mocked!!
 
         # assert reinitializers called
         assert _delta.create_boundary_conditions.called is True
         assert _delta.init_sediment_routers.called is True
+
+    def test_setting_getting_channel_width_changed_warning(self, tmp_path: Path) -> None:
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
+        _delta = DeltaModel(input_file=p)
+
+        # check initials
+        assert _delta.channel_width == 250
+
+        # change value
+        #  the channel width is then changed internally with `N0`, according
+        #  to the `create_boundary_conditions`
+        _delta.channel_width = 300
+        assert _delta.channel_width == 300  # changed!
+
+        # check that value rounding and warning works
+        with pytest.warns(ParameterChangedWarning):
+            _delta.channel_width = 501
+        assert _delta.channel_width == 500  # changed!
+
 
     def test_setting_getting_flow_depth(self, tmp_path: Path) -> None:
         p = utilities.yaml_from_dict(tmp_path, "input.yaml")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,6 +9,8 @@ import unittest.mock as mock
 
 from pyDeltaRCM.model import DeltaModel
 from pyDeltaRCM.shared_tools import (
+    set_random_seed,
+    get_random_uniform,
     ParameterChangedWarning
 )
 from . import utilities
@@ -122,13 +124,13 @@ class Test__init__:
         utilities.write_parameter_to_file(f, "seed", 9999)
         utilities.write_parameter_to_file(f, "out_dir", tmp_path / "out_dir")
         f.close()
-        shared_tools.set_random_seed(9999)
-        _preval_same = shared_tools.get_random_uniform(1)
-        shared_tools.set_random_seed(5)
-        _preval_diff = shared_tools.get_random_uniform(1)
+        set_random_seed(9999)
+        _preval_same = get_random_uniform(1)
+        set_random_seed(5)
+        _preval_diff = get_random_uniform(1)
         delta = DeltaModel(input_file=p)
         assert delta.seed == 9999
-        _postval_same = shared_tools.get_random_uniform(1)
+        _postval_same = get_random_uniform(1)
         assert _preval_same == _postval_same
         assert delta.seed == 9999
 

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -3,6 +3,7 @@ import pytest
 import platform
 import os
 from pathlib import Path
+import glob
 
 import unittest.mock as mock
 
@@ -733,6 +734,84 @@ class TestPreprocessorParallelJobsSetups:
         assert pp._is_completed is False
 
         assert pp.config_dict["parallel"] == 2
+
+
+class TestPreprocessorCustomSubclasses:
+
+    def test_subclass_parameter_nowarnings(self, tmp_path: Path) -> None:
+        p = utilities.yaml_from_dict(
+            tmp_path,
+            "input.yaml",
+            {
+                "save_eta_figs": True,
+                "timesteps": 2,
+                "custom_bool": True,
+            },  # custom_bool is not default
+        )
+        pp = preprocessor.Preprocessor(p)
+
+        class CustomInputs(DeltaModel):
+            def __init__(self, input_file=None, **kwargs):
+                # inherit base DeltaModel methods
+                super().__init__(input_file, **kwargs)
+
+            def hook_import_files(self):
+                self.subclass_parameters["custom_bool"] = {
+                    "type": "bool",
+                    "default": False,
+                }
+
+        # patch solver for fast run, no warnings issued
+        with mock.patch(
+            "pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep"
+        ) as ptch:
+
+            # run jobs to initialize deltas
+            pp.run_jobs(DeltaModel=CustomInputs)
+
+        # open log and check that True is recorded for custom_bool
+        _logs = glob.glob(os.path.join(tmp_path / "out_dir" / "job_000", "*.log"))
+        assert len(_logs) == 1  # log file exists
+        with open(_logs[0], "r") as _logfile:
+            _lines = _logfile.readlines()
+            _joinedlines = " ".join(_lines)  # collapse to a single string
+            assert "`custom_bool`: True" in _joinedlines
+
+    def test_subclass_parameter_warnunused(self, tmp_path: Path) -> None:
+        p = utilities.yaml_from_dict(
+            tmp_path,
+            "input.yaml",
+            {
+                "save_eta_figs": True,
+                "timesteps": 2,
+                "custom_bool": True,
+                "unused_input_yaml": 42,
+            },
+        )
+        pp = preprocessor.Preprocessor(p)
+
+        class CustomInputs(DeltaModel):
+            def __init__(self, input_file=None, **kwargs):
+                # inherit base DeltaModel methods
+                super().__init__(input_file, **kwargs)
+
+        # patch solver for fast run
+        with mock.patch(
+            "pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep"
+        ) as ptch:
+
+            with pytest.warns(
+                UserWarning, match=r"One or more .* ['unused_input_yaml']"
+            ):
+                # run jobs to initialize deltas
+                pp.run_jobs(DeltaModel=CustomInputs)
+
+        _logs = glob.glob(os.path.join(tmp_path / "out_dir" / "job_000", "*.log"))
+        assert len(_logs) == 1  # log file exists
+        with open(_logs[0], "r") as _logfile:
+            _lines = _logfile.readlines()
+            _joinedlines = " ".join(_lines)  # collapse to a single string
+            assert "`custom_bool`: True" in _joinedlines
 
 
 class TestPreprocessorRunJobs:

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import platform
@@ -9,10 +8,12 @@ import unittest.mock as mock
 
 import pyDeltaRCM
 from pyDeltaRCM.model import DeltaModel
+
 # from pyDeltaRCM import shared_tools
 from pyDeltaRCM import preprocessor
 
 from . import utilities
+
 # from .utilities import test_DeltaModel
 
 
@@ -25,8 +26,7 @@ class TestPreprocessorSingleJobSetups:
 
     def test_py_hlvl_runjobs_simple_param_float(self, tmp_path: Path) -> None:
         # a single parameter float
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'h0': 7.5})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"h0": 7.5})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
@@ -35,8 +35,7 @@ class TestPreprocessorSingleJobSetups:
 
     def test_py_hlvl_runjobs_simple_param_null0(self, tmp_path: Path) -> None:
         # a parameter that takes null as the default
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'hb': 7.5})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"hb": 7.5})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
@@ -45,122 +44,115 @@ class TestPreprocessorSingleJobSetups:
 
     def test_py_hlvl_runjobs_simple_param_null1(self, tmp_path: Path) -> None:
         # a parameter that takes null with null
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'hb': None})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"hb": None})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
-        assert pp._config_list[0]["hb"] == 'None'
+        assert pp._config_list[0]["hb"] == "None"
 
     def test_py_hlvl_runjobs_simple_param_yaml(self, tmp_path: Path) -> None:
         yaml_dict = {
             "out_dir": tmp_path / "out_dir",
             "h0": 7.5,
-            }
-        pp = pyDeltaRCM.Preprocessor(
-            yaml_dict)
+        }
+        pp = pyDeltaRCM.Preprocessor(yaml_dict)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
         assert pp._config_list[0]["h0"] == 7.5
 
-
     def test_py_hlvl_tsteps_yml_runjobs_sngle(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'timesteps': 50})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"timesteps": 50})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['timesteps'] == 50
-        assert not ('time' in pp.config_dict.keys())
-        assert not ('time_years' in pp.config_dict.keys())
+        assert pp.config_dict["timesteps"] == 50
+        assert not ("time" in pp.config_dict.keys())
+        assert not ("time_years" in pp.config_dict.keys())
 
     def test_py_hlvl_time_yml_runjobs_sngle(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'time': 1000})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"time": 1000})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['time'] == 1000
-        assert not ('timesteps' in pp.config_dict.keys())
+        assert pp.config_dict["time"] == 1000
+        assert not ("timesteps" in pp.config_dict.keys())
 
     def test_py_hlvl_time_If_yml_runjobs_sngle(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'time': 10000,
-                                      'If': 0.1})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"time": 10000, "If": 0.1})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['time'] == 10000
-        assert pp.config_dict['If'] == 0.1
-        assert not ('timesteps' in pp.config_dict.keys())
+        assert pp.config_dict["time"] == 10000
+        assert pp.config_dict["If"] == 0.1
+        assert not ("timesteps" in pp.config_dict.keys())
 
     def test_py_hlvl_timeyears_yml_runjobs_sngle(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'time_years': 3.16880878140e-05})
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"time_years": 3.16880878140e-05}
+        )
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['time_years'] == pytest.approx(3.1688087e-05)
-        assert not ('If' in pp.config_dict.keys())
-        assert not ('time' in pp.config_dict.keys())
-        assert not ('timesteps' in pp.config_dict.keys())
+        assert pp.config_dict["time_years"] == pytest.approx(3.1688087e-05)
+        assert not ("If" in pp.config_dict.keys())
+        assert not ("time" in pp.config_dict.keys())
+        assert not ("timesteps" in pp.config_dict.keys())
 
     def test_py_hlvl_timeyears_If_yml_runjobs_sngle(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'time_years': 0.00031688087814,
-                                      'If': 0.1})
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"time_years": 0.00031688087814, "If": 0.1}
+        )
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['time_years'] == pytest.approx(.00031688087814)
-        assert pp.config_dict['If'] == 0.1
-        assert not ('time' in pp.config_dict.keys())
-        assert not ('timesteps' in pp.config_dict.keys())
+        assert pp.config_dict["time_years"] == pytest.approx(0.00031688087814)
+        assert pp.config_dict["If"] == 0.1
+        assert not ("time" in pp.config_dict.keys())
+        assert not ("timesteps" in pp.config_dict.keys())
 
     def test_py_hlvl_timesteps_and_yaml_argument(self, tmp_path: Path) -> None:
         """
         Test that timesteps can come from cli, but others from yaml
         """
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'save_eta_figs': True})
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml", {"save_eta_figs": True})
         pp = preprocessor.Preprocessor(input_file=p, timesteps=2)
 
         assert type(pp.file_list) is list
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['timesteps'] == 2
-        assert (pp.config_dict['save_eta_figs'] is True)
-        assert not ('time' in pp.config_dict.keys())
+        assert pp.config_dict["timesteps"] == 2
+        assert pp.config_dict["save_eta_figs"] is True
+        assert not ("time" in pp.config_dict.keys())
 
     def test_py_hlvl_timesteps_yaml_and_cli(self, tmp_path: Path) -> None:
         """
         Test preference for command line argument
         """
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'save_eta_figs': True,
-                                      'timesteps': 20})
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"save_eta_figs": True, "timesteps": 20}
+        )
         pp = preprocessor.Preprocessor(input_file=p, timesteps=13)
 
         assert type(pp.file_list) is list
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['timesteps'] == 13
-        assert (pp.config_dict['save_eta_figs'] is True)
-        assert not ('time' in pp.config_dict.keys())
+        assert pp.config_dict["timesteps"] == 13
+        assert pp.config_dict["save_eta_figs"] is True
+        assert not ("time" in pp.config_dict.keys())
 
     def test_py_hlvl_timesteps_and_time_yaml_and_cli(self, tmp_path: Path) -> None:
         """
@@ -169,21 +161,22 @@ class TestPreprocessorSingleJobSetups:
         note that time and timesteps both persist, precedence for these args
         is determined at runtime of run_jobs()
         """
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'save_eta_figs': True,
-                                      'timesteps': 20,
-                                      'time': 1000})
+        p = utilities.yaml_from_dict(
+            tmp_path,
+            "input.yaml",
+            {"save_eta_figs": True, "timesteps": 20, "time": 1000},
+        )
         pp = preprocessor.Preprocessor(input_file=p, timesteps=13, time=13000)
 
         assert type(pp.file_list) is list
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['timesteps'] == 13
-        assert pp.config_dict['time'] == 13000
-        assert (pp.config_dict['save_eta_figs'] is True)
-        assert ('time' in pp.config_dict.keys())
-        assert ('timesteps' in pp.config_dict.keys())
+        assert pp.config_dict["timesteps"] == 13
+        assert pp.config_dict["time"] == 13000
+        assert pp.config_dict["save_eta_figs"] is True
+        assert "time" in pp.config_dict.keys()
+        assert "timesteps" in pp.config_dict.keys()
 
     def test_py_hlvl_timesteps_not_writted_to_job(self, tmp_path: Path) -> None:
         """
@@ -192,33 +185,31 @@ class TestPreprocessorSingleJobSetups:
         note that time and timesteps both persist, precedence for these args
         is determined at runtime of run_jobs()
         """
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'save_eta_figs': True,
-                                      'timesteps': 20,
-                                      'time': 1000})
+        p = utilities.yaml_from_dict(
+            tmp_path,
+            "input.yaml",
+            {"save_eta_figs": True, "timesteps": 20, "time": 1000},
+        )
         pp = preprocessor.Preprocessor(input_file=p, timesteps=13, time=13000)
 
         assert type(pp.file_list) is list
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
 
-        assert pp.config_dict['timesteps'] == 13
-        assert pp.config_dict['time'] == 13000
-        assert (pp.config_dict['save_eta_figs'] is True)
-        assert ('time' in pp.config_dict.keys())
-        assert ('timesteps' in pp.config_dict.keys())
-
+        assert pp.config_dict["timesteps"] == 13
+        assert pp.config_dict["time"] == 13000
+        assert pp.config_dict["save_eta_figs"] is True
+        assert "time" in pp.config_dict.keys()
+        assert "timesteps" in pp.config_dict.keys()
 
 
 class TestPreprocessorMatrixJobsSetups:
 
     def test_py_hlvl_mtrx_1list_timesteps_arg(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload'],
-                                       [[0.2, 0.6]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(f, ["f_bedload"], [[0.2, 0.6]])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
@@ -231,16 +222,14 @@ class TestPreprocessorMatrixJobsSetups:
 
         assert sum([j == 0.2 for j in f_bedload_list]) == 1
         assert sum([j == 0.6 for j in f_bedload_list]) == 1
-        assert pp.config_dict['timesteps'] == 3
+        assert pp.config_dict["timesteps"] == 3
 
     def test_py_hlvl_mtrx_1list_tsteps_cfg(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_parameter_to_file(f, 'timesteps', 3)
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload'],
-                                       [[0.2, 0.6]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_parameter_to_file(f, "timesteps", 3)
+        utilities.write_matrix_to_file(f, ["f_bedload"], [[0.2, 0.6]])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
 
@@ -253,16 +242,14 @@ class TestPreprocessorMatrixJobsSetups:
 
         assert sum([j == 0.2 for j in f_bedload_list]) == 1
         assert sum([j == 0.6 for j in f_bedload_list]) == 1
-        assert pp.config_dict['timesteps'] == 3
+        assert pp.config_dict["timesteps"] == 3
 
     def test_py_hlvl_mtrx_smthng_null(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_parameter_to_file(f, 'timesteps', 3)
-        utilities.write_matrix_to_file(f,
-                                       ['hb'],
-                                       [[None, 2, 7]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_parameter_to_file(f, "timesteps", 3)
+        utilities.write_matrix_to_file(f, ["hb"], [[None, 2, 7]])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
 
@@ -273,17 +260,17 @@ class TestPreprocessorMatrixJobsSetups:
 
         hb_list = pp._matrix_table[:, 1]
 
-        assert sum([j == 'None' for j in hb_list]) == 1
+        assert sum([j == "None" for j in hb_list]) == 1
         assert sum([j == 2 for j in hb_list]) == 1
         assert sum([j == 7 for j in hb_list]) == 1
 
     def test_py_hlvl_mtrx_2list(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'u0'],
-                                       [[0.2, 0.5, 0.6], [1.0, 1.5, 2.0]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "u0"], [[0.2, 0.5, 0.6], [1.0, 1.5, 2.0]]
+        )
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
 
@@ -309,12 +296,12 @@ class TestPreprocessorMatrixJobsSetups:
 
     def test_py_hlvl_mtrx_scientificnotation(self, tmp_path: Path) -> None:
         """Test that preprocessor can read and write scinotation"""
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'SLR'],
-                                       [[0.2, 0.5, 0.6], [0.00004, 1e-6]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "SLR"], [[0.2, 0.5, 0.6], [0.00004, 1e-6]]
+        )
         f.close()
 
         # will convert everything to scientific notation
@@ -325,25 +312,20 @@ class TestPreprocessorMatrixJobsSetups:
         assert sum([j == 0.000001 for j in SLR_list]) == 3
 
     def test_py_hlvL_mtrx_needs_out_dir(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
         # missing out_dir in the config will throw an error
         # => utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload'],
-                                       [[0.2, 0.5, 0.6]])
+        utilities.write_matrix_to_file(f, ["f_bedload"], [[0.2, 0.5, 0.6]])
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'You must specify "out_dir" in YAML .*'):
+        with pytest.raises(ValueError, match=r'You must specify "out_dir" in YAML .*'):
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_mtrx_outdir_exists_error(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload'],
-                                       [[0.2, 0.5, 0.6]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(f, ["f_bedload"], [[0.2, 0.5, 0.6]])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
 
@@ -351,25 +333,25 @@ class TestPreprocessorMatrixJobsSetups:
         assert pp._has_matrix is True
 
         # verify the directory exists
-        assert pp._jobs_root == str(tmp_path / 'test')
-        assert (tmp_path / 'test').is_dir()
+        assert pp._jobs_root == str(tmp_path / "test")
+        assert (tmp_path / "test").is_dir()
 
         # try to create another preprocessor at same directory
-        with pytest.raises(FileExistsError,
-                           match=r'Job output directory .*'):
+        with pytest.raises(FileExistsError, match=r"Job output directory .*"):
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_mtrx_bad_len1(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         # bad configuration is a list of length 1
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'u0'],
-                                       [[0.2], [0.5, 0.6, 1.25]])
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "u0"], [[0.2], [0.5, 0.6, 1.25]]
+        )
         f.close()
-        with pytest.warns(UserWarning,
-                          match=r'Length of matrix key "f_bedload" was 1,'):
+        with pytest.warns(
+            UserWarning, match=r'Length of matrix key "f_bedload" was 1,'
+        ):
             pp = preprocessor.Preprocessor(input_file=p)
 
         # check job length
@@ -377,91 +359,92 @@ class TestPreprocessorMatrixJobsSetups:
         assert len(pp.file_list) == 3
 
     def test_py_hlvl_mtrx_bad_listinlist(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         # bad configuration will lead to error
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'u0'],
-                                       [[0.2, [0.5, 0.6]], [0.5, 1.25]])
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "u0"], [[0.2, [0.5, 0.6]], [0.5, 1.25]]
+        )
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'Depth of matrix expansion must not be > 1'):
+        with pytest.raises(
+            ValueError, match=r"Depth of matrix expansion must not be > 1"
+        ):
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_mtrx_bad_samekey(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'f_bedload', 0.3)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "f_bedload", 0.3)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         # bad configuration will lead to error
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'u0'],
-                                       [[0.2, 0.5, 0.6], [0.5, 1.25]])
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "u0"], [[0.2, 0.5, 0.6], [0.5, 1.25]]
+        )
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'You cannot specify the same key '
-                                  'in the matrix .*'):  # noqa: E127
+        with pytest.raises(
+            ValueError, match=r"You cannot specify the same key " "in the matrix .*"
+        ):  # noqa: E127
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_mtrx_bad_colon(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         # bad configuration will lead to error
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'u0:'],
-                                       [[0.2, 0.5], [0.5, 1.25]])
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "u0:"], [[0.2, 0.5], [0.5, 1.25]]
+        )
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'Colon operator found '
-                                  'in matrix expansion key.'):  # noqa: E127
+        with pytest.raises(
+            ValueError, match=r"Colon operator found " "in matrix expansion key."
+        ):  # noqa: E127
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_mtrx_no_out_dir_in_mtrx(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['out_dir', 'f_bedload'],
-                                       [['dir1', 'dir2'], [0.2, 0.5, 0.6]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(
+            f, ["out_dir", "f_bedload"], [["dir1", "dir2"], [0.2, 0.5, 0.6]]
+        )
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'You cannot specify "out_dir" as .*'):
+        with pytest.raises(ValueError, match=r'You cannot specify "out_dir" as .*'):
             _ = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
     def test_python_highlevelapi_matrix_verbosity(self, tmp_path: Path, capsys) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'verbose', 1)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload', 'u0'],
-                                       [[0.2, 0.5, 0.6], [1.5, 2.0]])
+        utilities.write_parameter_to_file(f, "verbose", 1)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(
+            f, ["f_bedload", "u0"], [[0.2, 0.5, 0.6], [1.5, 2.0]]
+        )
         f.close()
         _ = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
         captd = capsys.readouterr()
-        assert 'Timestep: 0.0' not in captd.out
-        assert 'Writing YAML file for job 0' in captd.out
-        assert 'Writing YAML file for job 1' in captd.out
-        assert 'Writing YAML file for job 2' in captd.out
-        assert 'Writing YAML file for job 3' in captd.out
-        assert 'Writing YAML file for job 4' in captd.out
-        assert 'Writing YAML file for job 5' in captd.out
-        assert 'Matrix expansion:' in captd.out
-        assert '  dims 2' in captd.out
-        assert '  jobs 6' in captd.out
+        assert "Timestep: 0.0" not in captd.out
+        assert "Writing YAML file for job 0" in captd.out
+        assert "Writing YAML file for job 1" in captd.out
+        assert "Writing YAML file for job 2" in captd.out
+        assert "Writing YAML file for job 3" in captd.out
+        assert "Writing YAML file for job 4" in captd.out
+        assert "Writing YAML file for job 5" in captd.out
+        assert "Matrix expansion:" in captd.out
+        assert "  dims 2" in captd.out
+        assert "  jobs 6" in captd.out
 
 
 class TestPreprocessorSetJobsSetups:
 
     def test_py_hlvl_set_two_sets(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_set_to_file(f, [{'f_bedload': 0.2, 'u0': 1},
-                                        {'f_bedload': 0.4, 'u0': 2}])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_set_to_file(
+            f, [{"f_bedload": 0.2, "u0": 1}, {"f_bedload": 0.4, "u0": 2}]
+        )
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
@@ -475,13 +458,13 @@ class TestPreprocessorSetJobsSetups:
 
         assert sum([j == 0.2 for j in f_bedload_list]) == 1
         assert sum([j == 0.4 for j in f_bedload_list]) == 1
-        assert pp.config_dict['timesteps'] == 3
+        assert pp.config_dict["timesteps"] == 3
 
     def test_py_hlvl_set_one_sets(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_set_to_file(f, [{'f_bedload': 0.77, 'u0': 1}])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_set_to_file(f, [{"f_bedload": 0.77, "u0": 1}])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
@@ -494,65 +477,64 @@ class TestPreprocessorSetJobsSetups:
         f_bedload_list = pp._matrix_table[:, 1]
 
         assert sum([j == 0.77 for j in f_bedload_list]) == 1
-        assert pp.config_dict['timesteps'] == 3
+        assert pp.config_dict["timesteps"] == 3
 
     def test_py_hlvl_set_two_mismatched_sets(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_set_to_file(f, [{'f_bedload': 0.2, 'u0': 1},
-                                        {'h0': 0.4, 'u0': 2}])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_set_to_file(
+            f, [{"f_bedload": 0.2, "u0": 1}, {"h0": 0.4, "u0": 2}]
+        )
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'All keys in all sets *.'):  # noqa: E127
+        with pytest.raises(ValueError, match=r"All keys in all sets *."):  # noqa: E127
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_set_bad_not_list(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         # utilities.write_set_to_file(f, [{'f_bedload': 0.77, 'u0': 1}])
-        utilities.write_parameter_to_file(f, 'set', 'astring!')
+        utilities.write_parameter_to_file(f, "set", "astring!")
         f.close()
-        with pytest.raises(TypeError,
-                           match=r'Set list must be *.'):
+        with pytest.raises(TypeError, match=r"Set list must be *."):
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_set_bad_colon(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_set_to_file(f, [{'f_bedload:': 0.77, 'u0': 1}])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_set_to_file(f, [{"f_bedload:": 0.77, "u0": 1}])
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'Colon operator found '
-                                  'in matrix expansion key.'):  # noqa: E127
+        with pytest.raises(
+            ValueError, match=r"Colon operator found " "in matrix expansion key."
+        ):  # noqa: E127
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_output_table_correctly(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         utilities.write_set_to_file(
-            f, [{'f_bedload': 0.77, 'u0': 1, 'C0_percent': 0.033}])
+            f, [{"f_bedload": 0.77, "u0": 1, "C0_percent": 0.033}]
+        )
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
         # now check what the file looks like
-        with open(os.path.join(
-                tmp_path, 'test', 'jobs_parameters.txt'), 'r') as tbl:
+        with open(os.path.join(tmp_path, "test", "jobs_parameters.txt"), "r") as tbl:
             Lines = tbl.readlines()
 
-        assert Lines[0] == 'job_id, f_bedload, u0, C0_percent\n'
+        assert Lines[0] == "job_id, f_bedload, u0, C0_percent\n"
 
 
 class TestPreprocessorEnsembleJobsSetups:
 
     def test_py_hlvl_ensemble(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
         # assertions for job creation
@@ -562,12 +544,12 @@ class TestPreprocessorEnsembleJobsSetups:
         assert len(pp.file_list) == 2
 
     def test_py_hlvl_ensemble_1(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 1)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "ensemble", 1)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         f.close()
-        with pytest.warns(UserWarning, match=r'Ensemble was set to 1. *.'):
+        with pytest.warns(UserWarning, match=r"Ensemble was set to 1. *."):
             pp = preprocessor.Preprocessor(input_file=p)
 
         # check that keys were reset and config set correctly
@@ -576,41 +558,41 @@ class TestPreprocessorEnsembleJobsSetups:
         assert len(pp.file_list) == 1
 
     def test_py_hlvl_ensemble_badtype(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2.0)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "ensemble", 2.0)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         f.close()
-        with pytest.raises(TypeError,
-                           match=r'Invalid ensemble type, '
-                                  'must be an integer.'):  # noqa: E127
+        with pytest.raises(
+            TypeError, match=r"Invalid ensemble type, " "must be an integer."
+        ):  # noqa: E127
             _ = preprocessor.Preprocessor(input_file=p)
 
     def test_py_hlvl_ensemble_double_seeds(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'seed', 1)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "seed", 1)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'You cannot specify the same key in the '
-                                  'matrix configuration and '  # noqa: E127
-                                  'fixed configuration. Key "seed" was '
-                                  'specified in both.'):
+        with pytest.raises(
+            ValueError,
+            match=r"You cannot specify the same key in the "
+            "matrix configuration and "  # noqa: E127
+            'fixed configuration. Key "seed" was '
+            "specified in both.",
+        ):
             _ = preprocessor.Preprocessor(input_file=p)
 
 
 class TestPreprocessorMatrixAndEnsembleJobsSetups:
 
     def test_py_hlvl_ensemble_with_matrix(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['f_bedload'],
-                                       [[0.2, 0.5, 0.6]])
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(f, ["f_bedload"], [[0.2, 0.5, 0.6]])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
         # assertions for job creation
@@ -619,29 +601,29 @@ class TestPreprocessorMatrixAndEnsembleJobsSetups:
         assert len(pp.file_list) == 6
 
     def test_py_hlvl_ensemble_matrix_seeds(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_matrix_to_file(f,
-                                       ['seed'],
-                                       [[1, 2]])
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_matrix_to_file(f, ["seed"], [[1, 2]])
         f.close()
-        with pytest.raises(ValueError,
-                           match=r'Random seeds cannot be specified in '
-                                  'the matrix, if an "ensemble" number '  # noqa: E127, E501
-                                  'is specified as well.'):
+        with pytest.raises(
+            ValueError,
+            match=r"Random seeds cannot be specified in "
+            'the matrix, if an "ensemble" number '  # noqa: E127, E501
+            "is specified as well.",
+        ):
             _ = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
 
 class TestPreprocessorSetAndEnsembleJobsSetups:
 
     def test_1_set_ensemble_3(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_parameter_to_file(f, 'ensemble', 3)
-        utilities.write_set_to_file(f, [{'f_bedload': 0.77, 'u0': 1}])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_parameter_to_file(f, "ensemble", 3)
+        utilities.write_set_to_file(f, [{"f_bedload": 0.77, "u0": 1}])
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
@@ -655,23 +637,20 @@ class TestPreprocessorSetAndEnsembleJobsSetups:
         f_bedload_list = pp._matrix_table[:, 1]
 
         assert sum([j == 0.77 for j in f_bedload_list]) == 3
-        assert pp.config_dict['timesteps'] == 3
+        assert pp.config_dict["timesteps"] == 3
 
 
 class TestPreprocessorSetAndMatrixJobsSetups:
 
     def test_not_possible(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_set_to_file(f, [{'f_bedload': 0.77, 'h0': 1}])
-        utilities.write_matrix_to_file(f,
-                                       ['u0'],
-                                       [[0.2, 0.5, 0.6]])
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_set_to_file(f, [{"f_bedload": 0.77, "h0": 1}])
+        utilities.write_matrix_to_file(f, ["u0"], [[0.2, 0.5, 0.6]])
         f.close()
 
-        with pytest.raises(ValueError,
-                           match=r'Cannot use "matrix" and "set" .*'):
+        with pytest.raises(ValueError, match=r'Cannot use "matrix" and "set" .*'):
             _ = preprocessor.Preprocessor(input_file=p, timesteps=3)
 
 
@@ -683,10 +662,10 @@ class TestPreprocessorParallelJobsSetups:
     """
 
     def test_py_hlvl_parallel_works_onejob(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_parameter_to_file(f, 'parallel', True)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_parameter_to_file(f, "parallel", True)
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
         # assertions for job creation
@@ -694,14 +673,14 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 1
         assert pp._has_matrix is False
 
-        assert pp.config_dict['parallel'] is True
+        assert pp.config_dict["parallel"] is True
 
     def test_py_hlvl_parallel_boolean_yaml(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_parameter_to_file(f, 'parallel', True)
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_parameter_to_file(f, "parallel", True)
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
         # assertions for job creation
@@ -709,13 +688,13 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._has_matrix is True
 
-        assert pp.config_dict['parallel'] is True
+        assert pp.config_dict["parallel"] is True
 
     def test_py_hlvl_parallel_boolean_cli(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, parallel=True)
         # assertions for job creation
@@ -723,14 +702,14 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._has_matrix is True
 
-        assert pp.config_dict['parallel'] is True
+        assert pp.config_dict["parallel"] is True
 
     def test_py_hlvl_parallel_integer_yaml(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
-        utilities.write_parameter_to_file(f, 'parallel', 2)
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
+        utilities.write_parameter_to_file(f, "parallel", 2)
         f.close()
         pp = preprocessor.Preprocessor(input_file=p)
         # assertions for job creation
@@ -738,13 +717,13 @@ class TestPreprocessorParallelJobsSetups:
         assert len(pp.file_list) == 2
         assert pp._has_matrix is True
 
-        assert pp.config_dict['parallel'] == 2
+        assert pp.config_dict["parallel"] == 2
 
     def test_py_hlvl_parallel_integer_cli(self, tmp_path: Path) -> None:
-        file_name = 'user_parameters.yaml'
+        file_name = "user_parameters.yaml"
         p, f = utilities.create_temporary_file(tmp_path, file_name)
-        utilities.write_parameter_to_file(f, 'ensemble', 2)
-        utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
+        utilities.write_parameter_to_file(f, "ensemble", 2)
+        utilities.write_parameter_to_file(f, "out_dir", tmp_path / "test")
         f.close()
         pp = preprocessor.Preprocessor(input_file=p, parallel=2)
         # assertions for job creation
@@ -753,13 +732,13 @@ class TestPreprocessorParallelJobsSetups:
         assert pp._has_matrix is True
         assert pp._is_completed is False
 
-        assert pp.config_dict['parallel'] == 2
+        assert pp.config_dict["parallel"] == 2
 
 
 class TestPreprocessorRunJobs:
 
     def test_dryrun(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp = preprocessor.Preprocessor(p)
 
         pp._dryrun = True
@@ -770,11 +749,11 @@ class TestPreprocessorRunJobs:
         assert pp._is_completed is False
 
     def test_run_single_serial_job(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp = preprocessor.Preprocessor(p)
 
         # patch jobs
-        with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
+        with mock.patch("pyDeltaRCM.preprocessor._SerialJob") as ptch:
 
             # run the method
             pp.run_jobs()
@@ -784,13 +763,13 @@ class TestPreprocessorRunJobs:
         assert pp._is_completed is True
 
     def test_run_single_serial_job_wparams_yaml(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
-                                     {'save_eta_figs': True,
-                                     'timesteps': 20})
+        p = utilities.yaml_from_dict(
+            tmp_path, "input.yaml", {"save_eta_figs": True, "timesteps": 20}
+        )
         pp = preprocessor.Preprocessor(p)
 
         # patch jobs
-        with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
+        with mock.patch("pyDeltaRCM.preprocessor._SerialJob") as ptch:
 
             # run the method
             pp.run_jobs()
@@ -805,13 +784,11 @@ class TestPreprocessorRunJobs:
         assert file_count == 1
 
     def test_run_single_serial_job_wparams_dict(self, tmp_path: Path) -> None:
-        p = {'save_eta_figs': True,
-             'timesteps': 20,
-             "out_dir": tmp_path / "out_dir"}
+        p = {"save_eta_figs": True, "timesteps": 20, "out_dir": tmp_path / "out_dir"}
         pp = preprocessor.Preprocessor(p)
 
         # patch jobs
-        with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
+        with mock.patch("pyDeltaRCM.preprocessor._SerialJob") as ptch:
 
             # run the method
             pp.run_jobs()
@@ -826,20 +803,19 @@ class TestPreprocessorRunJobs:
         assert file_count == 1
 
     def test_run_single_serial_job_wparams_dict_nooutdir(self, tmp_path: Path) -> None:
-        p = {'save_eta_figs': True,
-             'timesteps': 20}
+        p = {"save_eta_figs": True, "timesteps": 20}
         with pytest.raises(ValueError, match=r'specify "out_dir"'):
             pp = preprocessor.Preprocessor(p)
 
     def test_run_two_serial_jobs(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp = preprocessor.Preprocessor(p)
 
         pp._file_list = [*pp.file_list] * 2
         pp._config_list = [*pp.config_list] * 2
 
         # patch jobs
-        with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
+        with mock.patch("pyDeltaRCM.preprocessor._SerialJob") as ptch:
 
             # run the method
             pp.run_jobs()
@@ -849,10 +825,10 @@ class TestPreprocessorRunJobs:
         assert pp._is_completed is True
 
     @pytest.mark.skipif(
-        platform.system() != 'Linux',
-        reason='Parallel support only on Linux OS.')
+        platform.system() != "Linux", reason="Parallel support only on Linux OS."
+    )
     def test_run_five_parallel_jobs_bool(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp = preprocessor.Preprocessor(p, parallel=True)
 
         # expand the list to include multiples
@@ -860,8 +836,10 @@ class TestPreprocessorRunJobs:
         pp._config_list = [*pp.config_list] * 5
 
         # patch jobs and semaphore to check number of processes called
-        with mock.patch('pyDeltaRCM.preprocessor._ParallelJob') as ptch, \
-             mock.patch('multiprocessing.Semaphore') as sem:
+        with (
+            mock.patch("pyDeltaRCM.preprocessor._ParallelJob") as ptch,
+            mock.patch("multiprocessing.Semaphore") as sem,
+        ):
 
             # run the method
             pp.run_jobs()
@@ -875,10 +853,10 @@ class TestPreprocessorRunJobs:
         assert pp._is_completed is True
 
     @pytest.mark.skipif(
-        platform.system() != 'Linux',
-        reason='Parallel support only on Linux OS.')
+        platform.system() != "Linux", reason="Parallel support only on Linux OS."
+    )
     def test_run_five_parallel_jobs_int_two(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp = preprocessor.Preprocessor(p, parallel=2)
 
         # expand the list to include multiples
@@ -886,8 +864,10 @@ class TestPreprocessorRunJobs:
         pp._config_list = [*pp.config_list] * 5
 
         # patch jobs and semaphore to check number of processes called
-        with mock.patch('pyDeltaRCM.preprocessor._ParallelJob') as ptch, \
-             mock.patch('multiprocessing.Semaphore') as sem:
+        with (
+            mock.patch("pyDeltaRCM.preprocessor._ParallelJob") as ptch,
+            mock.patch("multiprocessing.Semaphore") as sem,
+        ):
 
             # run the method
             pp.run_jobs()
@@ -899,33 +879,37 @@ class TestPreprocessorRunJobs:
         assert pp._is_completed is True
 
     @pytest.mark.skipif(
-        platform.system() != 'Linux',
-        reason='Parallel support only on Linux OS.')
+        platform.system() != "Linux", reason="Parallel support only on Linux OS."
+    )
     def test_run_five_parallel_jobs_bad_types(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp_float = preprocessor.Preprocessor(p, parallel=3.33)
-        pp_str = preprocessor.Preprocessor(p, parallel='string!')
+        pp_str = preprocessor.Preprocessor(p, parallel="string!")
 
         # patch jobs and semaphore to check number of processes called
-        with mock.patch('pyDeltaRCM.preprocessor._ParallelJob'), \
-             mock.patch('multiprocessing.Semaphore'):
+        with (
+            mock.patch("pyDeltaRCM.preprocessor._ParallelJob"),
+            mock.patch("multiprocessing.Semaphore"),
+        ):
 
-            with pytest.raises(ValueError, match=r'Parallel flag *.'):
+            with pytest.raises(ValueError, match=r"Parallel flag *."):
                 # run the method
                 pp_float.run_jobs()
 
-        with mock.patch('pyDeltaRCM.preprocessor._ParallelJob'), \
-             mock.patch('multiprocessing.Semaphore'):
+        with (
+            mock.patch("pyDeltaRCM.preprocessor._ParallelJob"),
+            mock.patch("multiprocessing.Semaphore"),
+        ):
 
-            with pytest.raises(ValueError, match=r'Parallel flag *.'):
+            with pytest.raises(ValueError, match=r"Parallel flag *."):
                 # run the method
                 pp_str.run_jobs()
 
     @pytest.mark.skipif(
-        platform.system() == 'Linux',
-        reason='Parallel support only on Linux OS.')
+        platform.system() == "Linux", reason="Parallel support only on Linux OS."
+    )
     def test_run_parallel_notimplemented_nonlinux(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp = preprocessor.Preprocessor(p, parallel=True)
 
         # patch jobs and semaphore to check number of processes called
@@ -935,8 +919,7 @@ class TestPreprocessorRunJobs:
             pp.run_jobs()
 
 
-@mock.patch.multiple(pyDeltaRCM.preprocessor._BaseJob,
-                     __abstractmethods__=set())
+@mock.patch.multiple(pyDeltaRCM.preprocessor._BaseJob, __abstractmethods__=set())
 class TestBaseJob:
     """
     To test the BaseJob, we patch the base job with a filled abstract method
@@ -946,33 +929,28 @@ class TestBaseJob:
     """
 
     def test_wo_timesteps(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
-        with pytest.raises(ValueError,
-                           match=r'You must specify a run duration *.'):
-            _ = preprocessor._BaseJob(
-                i=0, input_file=p,
-                config_dict={})
+        with pytest.raises(ValueError, match=r"You must specify a run duration *."):
+            _ = preprocessor._BaseJob(i=0, input_file=p, config_dict={})
 
     def test_timeargs_precedence_tstepsovertime(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
         basej = preprocessor._BaseJob(
-            i=0, input_file=p,
-            config_dict={'time': 10000,
-                         'timesteps': 2})
+            i=0, input_file=p, config_dict={"time": 10000, "timesteps": 2}
+        )
 
         assert isinstance(basej.deltamodel, DeltaModel)
         assert basej._job_end_time == basej.deltamodel._dt * 2
         assert basej._job_end_time != 10000
 
     def test_timeargs_precedence_tstepsovertimeyears(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
         basej = preprocessor._BaseJob(
-            i=0, input_file=p,
-            config_dict={'time_years': 10000,
-                         'timesteps': 2})
+            i=0, input_file=p, config_dict={"time_years": 10000, "timesteps": 2}
+        )
 
         assert isinstance(basej.deltamodel, DeltaModel)
         assert basej._job_end_time == basej.deltamodel._dt * 2
@@ -980,12 +958,11 @@ class TestBaseJob:
         assert basej._job_end_time != 10000 * 365.25
 
     def test_timeargs_precedence_timeovertimeyears(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
         basej = preprocessor._BaseJob(
-            i=0, input_file=p,
-            config_dict={'time_years': 10000,
-                         'time': 900})
+            i=0, input_file=p, config_dict={"time_years": 10000, "time": 900}
+        )
 
         assert isinstance(basej.deltamodel, DeltaModel)
         assert basej._job_end_time == 900
@@ -996,11 +973,9 @@ class TestBaseJob:
 class TestSerialJob:
 
     def test_run(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
-        sj = preprocessor._SerialJob(
-            i=0, input_file=p,
-            config_dict={'timesteps': 10})
+        sj = preprocessor._SerialJob(i=0, input_file=p, config_dict={"timesteps": 10})
 
         # modify the save interval to be twice dt
         sj.deltamodel._save_dt = 2 * sj.deltamodel._dt
@@ -1030,16 +1005,16 @@ class TestSerialJob:
         assert sj.deltamodel.finalize.call_count == 1
 
         # check the log outputs for successes
-        _calls = [mock.call('job: 0, stage: 1, code: 0'),
-                  mock.call('job: 0, stage: 2, code: 0')]
+        _calls = [
+            mock.call("job: 0, stage: 1, code: 0"),
+            mock.call("job: 0, stage: 2, code: 0"),
+        ]
         sj.deltamodel.logger.info.assert_has_calls(_calls)
 
     def test_run_error_update(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
-        sj = preprocessor._SerialJob(
-            i=99, input_file=p,
-            config_dict={'timesteps': 10})
+        sj = preprocessor._SerialJob(i=99, input_file=p, config_dict={"timesteps": 10})
 
         # modify the save interval to be twice dt
         sj.deltamodel._save_dt = 2 * sj.deltamodel._dt
@@ -1053,7 +1028,8 @@ class TestSerialJob:
         sj.deltamodel.logger = mock.MagicMock()
         sj.deltamodel.output_data = mock.MagicMock()
         sj.deltamodel.output_checkpoint = mock.MagicMock(
-            side_effect=RuntimeError('error!'))
+            side_effect=RuntimeError("error!")
+        )
         sj.deltamodel.finalize = mock.MagicMock()
 
         # run the method (error on `output_checkpoint`)
@@ -1070,18 +1046,16 @@ class TestSerialJob:
         assert sj.deltamodel.finalize.call_count == 1
 
         # check the log outputs for success/failure
-        _info_calls = [mock.call('job: 99, stage: 2, code: 0')]
-        _error_calls = [mock.call('job: 99, stage: 1, code: 1, msg: error!')]
+        _info_calls = [mock.call("job: 99, stage: 2, code: 0")]
+        _error_calls = [mock.call("job: 99, stage: 1, code: 1, msg: error!")]
         sj.deltamodel.logger.info.assert_has_calls(_info_calls)
         sj.deltamodel.logger.error.assert_has_calls(_error_calls)
         sj.deltamodel.logger.exception.assert_called_once()
 
     def test_run_error_finalize(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
-        sj = preprocessor._SerialJob(
-            i=0, input_file=p,
-            config_dict={'timesteps': 10})
+        sj = preprocessor._SerialJob(i=0, input_file=p, config_dict={"timesteps": 10})
 
         # modify the save interval to be twice dt
         sj.deltamodel._save_dt = 2 * sj.deltamodel._dt
@@ -1095,8 +1069,7 @@ class TestSerialJob:
         sj.deltamodel.logger = mock.MagicMock()
         sj.deltamodel.output_data = mock.MagicMock()
         sj.deltamodel.output_checkpoint = mock.MagicMock()
-        sj.deltamodel.finalize = mock.MagicMock(
-            side_effect=RuntimeError('error!'))
+        sj.deltamodel.finalize = mock.MagicMock(side_effect=RuntimeError("error!"))
 
         # run the method (error on `output_checkpoint`)
         sj.run()
@@ -1112,8 +1085,8 @@ class TestSerialJob:
         assert sj.deltamodel.finalize.call_count == 1
 
         # check the log outputs for success/failure
-        _info_calls = [mock.call('job: 0, stage: 1, code: 0')]
-        _error_calls = [mock.call('job: 0, stage: 2, code: 1, msg: error!')]
+        _info_calls = [mock.call("job: 0, stage: 1, code: 0")]
+        _error_calls = [mock.call("job: 0, stage: 2, code: 1, msg: error!")]
         sj.deltamodel.logger.info.assert_has_calls(_info_calls)
         sj.deltamodel.logger.error.assert_has_calls(_error_calls)
         sj.deltamodel.logger.exception.assert_called_once()
@@ -1122,14 +1095,14 @@ class TestSerialJob:
 class TestParallelJob:
 
     def test_run(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
         Q = mock.MagicMock()
         S = mock.MagicMock()
 
         pj = preprocessor._ParallelJob(
-            i=0, queue=Q, sema=S, input_file=p,
-            config_dict={'timesteps': 10})
+            i=0, queue=Q, sema=S, input_file=p, config_dict={"timesteps": 10}
+        )
 
         # modify the save interval to be twice dt
         pj.deltamodel._save_dt = 2 * pj.deltamodel._dt
@@ -1170,20 +1143,22 @@ class TestParallelJob:
         assert pj.deltamodel.hook_output_checkpoint.call_count == 11
 
         # check the log outputs for successes
-        _calls = [mock.call({'job': 0, 'stage': 0, 'code': 0}),
-                  mock.call({'job': 0, 'stage': 1, 'code': 0}),
-                  mock.call({'job': 0, 'stage': 2, 'code': 0})]
+        _calls = [
+            mock.call({"job": 0, "stage": 0, "code": 0}),
+            mock.call({"job": 0, "stage": 1, "code": 0}),
+            mock.call({"job": 0, "stage": 2, "code": 0}),
+        ]
         Q.put.assert_has_calls(_calls)
 
     def test_run_error_update(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
         Q = mock.MagicMock()
         S = mock.MagicMock()
 
         pj = preprocessor._ParallelJob(
-            i=99, queue=Q, sema=S, input_file=p,
-            config_dict={'timesteps': 10})
+            i=99, queue=Q, sema=S, input_file=p, config_dict={"timesteps": 10}
+        )
 
         # modify the save interval to be twice dt
         pj.deltamodel._save_dt = 2 * pj.deltamodel._dt
@@ -1194,7 +1169,8 @@ class TestParallelJob:
         pj.deltamodel.apply_subsidence = mock.MagicMock()
         pj.deltamodel.finalize_timestep = mock.MagicMock()
         pj.deltamodel.log_model_time = mock.MagicMock(
-            side_effect=RuntimeError('error!'))
+            side_effect=RuntimeError("error!")
+        )
         pj.deltamodel.logger = mock.MagicMock()
         pj.deltamodel.output_data = mock.MagicMock()
         pj.deltamodel.output_checkpoint = mock.MagicMock()
@@ -1214,25 +1190,25 @@ class TestParallelJob:
         assert pj.deltamodel.finalize.call_count == 1
 
         # check the log outputs for success/failure
-        _info_calls = [mock.call({'job': 99, 'stage': 0, 'code': 0}),
-                       mock.call({'job': 99, 'stage': 2, 'code': 0})]
-        _error_calls = [mock.call({'job': 99, 'stage': 1,
-                                   'code': 1, 'msg': 'error!'})]
+        _info_calls = [
+            mock.call({"job": 99, "stage": 0, "code": 0}),
+            mock.call({"job": 99, "stage": 2, "code": 0}),
+        ]
+        _error_calls = [mock.call({"job": 99, "stage": 1, "code": 1, "msg": "error!"})]
         Q.put.assert_has_calls(_info_calls, any_order=True)
         Q.put.assert_has_calls(_error_calls)
-        pj.deltamodel.logger.error.assert_has_calls(
-            [mock.call('error!')])
+        pj.deltamodel.logger.error.assert_has_calls([mock.call("error!")])
         pj.deltamodel.logger.exception.assert_called_once()
 
     def test_run_error_finalize(self, tmp_path: Path) -> None:
-        p = utilities.yaml_from_dict(tmp_path, 'input.yaml')
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
 
         Q = mock.MagicMock()
         S = mock.MagicMock()
 
         pj = preprocessor._ParallelJob(
-            i=0, queue=Q, sema=S, input_file=p,
-            config_dict={'timesteps': 10})
+            i=0, queue=Q, sema=S, input_file=p, config_dict={"timesteps": 10}
+        )
 
         # modify the save interval to be twice dt
         pj.deltamodel._save_dt = 2 * pj.deltamodel._dt
@@ -1246,8 +1222,7 @@ class TestParallelJob:
         pj.deltamodel.logger = mock.MagicMock()
         pj.deltamodel.output_data = mock.MagicMock()
         pj.deltamodel.output_checkpoint = mock.MagicMock()
-        pj.deltamodel.finalize = mock.MagicMock(
-            side_effect=RuntimeError('error!'))
+        pj.deltamodel.finalize = mock.MagicMock(side_effect=RuntimeError("error!"))
 
         # run the method (error on `output_checkpoint`)
         pj.run()
@@ -1263,14 +1238,14 @@ class TestParallelJob:
         assert pj.deltamodel.finalize.call_count == 1
 
         # check the log outputs for success/failure
-        _info_calls = [mock.call({'job': 0, 'stage': 0, 'code': 0}),
-                       mock.call({'job': 0, 'stage': 1, 'code': 0})]
-        _error_calls = [mock.call({'job': 0, 'stage': 2,
-                                   'code': 1, 'msg': 'error!'})]
+        _info_calls = [
+            mock.call({"job": 0, "stage": 0, "code": 0}),
+            mock.call({"job": 0, "stage": 1, "code": 0}),
+        ]
+        _error_calls = [mock.call({"job": 0, "stage": 2, "code": 1, "msg": "error!"})]
         Q.put.assert_has_calls(_info_calls, any_order=True)
         Q.put.assert_has_calls(_error_calls)
-        pj.deltamodel.logger.error.assert_has_calls(
-            [mock.call('error!')])
+        pj.deltamodel.logger.error.assert_has_calls([mock.call("error!")])
         pj.deltamodel.logger.exception.assert_called_once()
 
 
@@ -1278,88 +1253,92 @@ class TestWriteYamlConfigToFile:
 
     def test_write_single_int(self, tmp_path: Path) -> None:
         # set up what to write
-        file_path = tmp_path / 'output.yml'
-        yaml_dict = {'variable': 1}
+        file_path = tmp_path / "output.yml"
+        yaml_dict = {"variable": 1}
 
         # write the file
         preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
 
         with open(file_path) as f:
-            _returned = ' '.join(f.readlines())
+            _returned = " ".join(f.readlines())
 
-        assert _returned == 'variable: 1\n'
+        assert _returned == "variable: 1\n"
 
     def test_write_single_float(self, tmp_path: Path) -> None:
         # set up what to write
-        file_path = tmp_path / 'output.yml'
-        yaml_dict = {'variable': 1.5}
+        file_path = tmp_path / "output.yml"
+        yaml_dict = {"variable": 1.5}
 
         # write the file
         preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
 
         with open(file_path) as f:
-            _returned = ' '.join(f.readlines())
+            _returned = " ".join(f.readlines())
 
-        assert _returned == 'variable: 1.5\n'
+        assert _returned == "variable: 1.5\n"
 
     def test_write_single_string(self, tmp_path: Path) -> None:
         # set up what to write
-        file_path = tmp_path / 'output.yml'
-        yaml_dict = {'variable': 'a string'}
+        file_path = tmp_path / "output.yml"
+        yaml_dict = {"variable": "a string"}
 
         # write the file
         preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
 
         with open(file_path) as f:
-            _returned = ' '.join(f.readlines())
+            _returned = " ".join(f.readlines())
 
-        assert _returned == 'variable: a string\n'
+        assert _returned == "variable: a string\n"
 
     def test_write_single_bool(self, tmp_path: Path) -> None:
         # set up what to write
-        file_path = tmp_path / 'output.yml'
-        yaml_dict = {'variable': False}
+        file_path = tmp_path / "output.yml"
+        yaml_dict = {"variable": False}
 
         # write the file
         preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
 
         with open(file_path) as f:
-            _returned = ' '.join(f.readlines())
+            _returned = " ".join(f.readlines())
 
-        assert _returned == 'variable: False\n'
+        assert _returned == "variable: False\n"
 
     def test_write_single_null(self, tmp_path: Path) -> None:
         # set up what to write
-        file_path = tmp_path / 'output.yml'
-        yaml_dict = {'variable': None}
+        file_path = tmp_path / "output.yml"
+        yaml_dict = {"variable": None}
 
         # write the file
         preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
 
         with open(file_path) as f:
-            _returned = ' '.join(f.readlines())
+            _returned = " ".join(f.readlines())
 
-        assert _returned == 'variable: null\n'
+        assert _returned == "variable: null\n"
 
     def test_write_multiple_one_each(self, tmp_path: Path) -> None:
         # set up what to write
-        file_path = tmp_path / 'output.yml'
-        yaml_dict = {'variable1': 1,
-                     'variable2': 2.2,
-                     'variable3': 'a string',
-                     'variable4': False,
-                     'variable5': None}
+        file_path = tmp_path / "output.yml"
+        yaml_dict = {
+            "variable1": 1,
+            "variable2": 2.2,
+            "variable3": "a string",
+            "variable4": False,
+            "variable5": None,
+        }
 
         # write the file
         preprocessor._write_yaml_config_to_file(yaml_dict, file_path)
 
         with open(file_path) as f:
-            _returned = ' '.join(f.readlines())
+            _returned = " ".join(f.readlines())
         print(_returned)
 
-        assert _returned == ('variable1: 1\n variable2: 2.2\n '
-                             'variable3: a string\n variable4: False\n '
-                             'variable5: null\n')
+        assert _returned == (
+            "variable1: 1\n variable2: 2.2\n "
+            "variable3: a string\n variable4: False\n "
+            "variable5: null\n"
+        )
 
 
 class TestPreprocessorImported:
@@ -1367,11 +1346,11 @@ class TestPreprocessorImported:
     def test_Preprocessor_toplevelimport(self) -> None:
         import pyDeltaRCM
 
-        assert 'Preprocessor' in dir(pyDeltaRCM)
+        assert "Preprocessor" in dir(pyDeltaRCM)
         assert pyDeltaRCM.Preprocessor is pyDeltaRCM.preprocessor.Preprocessor
 
 
-class TestScaleRelativeSeaLeveLRiseRate():
+class TestScaleRelativeSeaLeveLRiseRate:
 
     def test_scale_If_1(self) -> None:
         scaled = preprocessor.scale_relative_sea_level_rise_rate(5, If=1)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -23,15 +23,17 @@ class TestPreprocessorSingleJobSetups:
         with pytest.raises(ValueError):
             _ = preprocessor.Preprocessor()
 
-    def test_py_hlvl_runjobs_simple_param(self, tmp_path: Path) -> None:
-        # a single parameter
+    def test_py_hlvl_runjobs_simple_param_float(self, tmp_path: Path) -> None:
+        # a single parameter float
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'h0': 7.5})
         pp = preprocessor.Preprocessor(p)
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
+        assert pp._config_list[0]["h0"] == 7.5
 
+    def test_py_hlvl_runjobs_simple_param_null0(self, tmp_path: Path) -> None:
         # a parameter that takes null as the default
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'hb': 7.5})
@@ -39,7 +41,9 @@ class TestPreprocessorSingleJobSetups:
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
+        assert pp._config_list[0]["hb"] == 7.5
 
+    def test_py_hlvl_runjobs_simple_param_null1(self, tmp_path: Path) -> None:
         # a parameter that takes null with null
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
                                      {'hb': None})
@@ -47,6 +51,20 @@ class TestPreprocessorSingleJobSetups:
 
         assert len(pp.file_list) == 1
         assert pp._is_completed is False
+        assert pp._config_list[0]["hb"] == 'None'
+
+    def test_py_hlvl_runjobs_simple_param_yaml(self, tmp_path: Path) -> None:
+        yaml_dict = {
+            "out_dir": tmp_path,
+            "h0": 7.5,
+            }
+        pp = pyDeltaRCM.Preprocessor(
+            yaml_dict)
+
+        assert len(pp.file_list) == 1
+        assert pp._is_completed is False
+        assert pp._config_list[0]["h0"] == 7.5
+
 
     def test_py_hlvl_tsteps_yml_runjobs_sngle(self, tmp_path: Path) -> None:
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
@@ -166,6 +184,30 @@ class TestPreprocessorSingleJobSetups:
         assert (pp.config_dict['save_eta_figs'] is True)
         assert ('time' in pp.config_dict.keys())
         assert ('timesteps' in pp.config_dict.keys())
+
+    def test_py_hlvl_timesteps_not_writted_to_job(self, tmp_path: Path) -> None:
+        """
+        Test that timesteps is not written to the file
+
+        note that time and timesteps both persist, precedence for these args
+        is determined at runtime of run_jobs()
+        """
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_eta_figs': True,
+                                      'timesteps': 20,
+                                      'time': 1000})
+        pp = preprocessor.Preprocessor(input_file=p, timesteps=13, time=13000)
+
+        assert type(pp.file_list) is list
+        assert len(pp.file_list) == 1
+        assert pp._is_completed is False
+
+        assert pp.config_dict['timesteps'] == 13
+        assert pp.config_dict['time'] == 13000
+        assert (pp.config_dict['save_eta_figs'] is True)
+        assert ('time' in pp.config_dict.keys())
+        assert ('timesteps' in pp.config_dict.keys())
+
 
 
 class TestPreprocessorMatrixJobsSetups:
@@ -525,12 +567,12 @@ class TestPreprocessorEnsembleJobsSetups:
         utilities.write_parameter_to_file(f, 'ensemble', 1)
         utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
         f.close()
-        with pytest.warns(UserWarning,
-                          match=r'Ensemble was set to 1. *.'):
-            pp = preprocessor.Preprocessor(input_file=p)
+        # with pytest.warns(UserWarning,
+        #                   match=r'Ensemble was set to 1. *.'):
+        pp = preprocessor.Preprocessor(input_file=p)
 
         # check that keys were reset and config set correctly
-        assert pp._has_ensemble is False
+        assert pp._has_ensemble is True # always true
         assert pp._has_matrix is False
         assert len(pp.file_list) == 1
 
@@ -741,6 +783,54 @@ class TestPreprocessorRunJobs:
         assert ptch.call_count == 1
         assert len(pp.job_list) == 1
         assert pp._is_completed is True
+
+    def test_run_single_serial_job_wparams_yaml(self, tmp_path: Path) -> None:
+        p = utilities.yaml_from_dict(tmp_path, 'input.yaml',
+                                     {'save_eta_figs': True,
+                                     'timesteps': 20})
+        pp = preprocessor.Preprocessor(p)
+
+        # patch jobs
+        with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
+
+            # run the method
+            pp.run_jobs()
+
+        assert ptch.call_count == 1
+        assert len(pp.job_list) == 1
+        assert pp._is_completed is True
+
+        # check that the yaml configs are actually written to the temp directory
+        dir_path = Path(tmp_path / "out_dir" / "job_000")
+        file_count = sum(1 for item in dir_path.iterdir() if item.is_file())
+        assert file_count == 1
+
+    def test_run_single_serial_job_wparams_dict(self, tmp_path: Path) -> None:
+        p = {'save_eta_figs': True,
+             'timesteps': 20,
+             "out_dir": tmp_path / "out_dir"}
+        pp = preprocessor.Preprocessor(p)
+
+        # patch jobs
+        with mock.patch('pyDeltaRCM.preprocessor._SerialJob') as ptch:
+
+            # run the method
+            pp.run_jobs()
+
+        assert ptch.call_count == 1
+        assert len(pp.job_list) == 1
+        assert pp._is_completed is True
+
+        # check that the yaml configs are actually written to the temp directory
+        dir_path = Path(tmp_path / "out_dir" / "job_000")
+        file_count = sum(1 for item in dir_path.iterdir() if item.is_file())
+        assert file_count == 1
+
+    def test_run_single_serial_job_wparams_dict_nooutdir(self, tmp_path: Path) -> None:
+        p = {'save_eta_figs': True,
+             'timesteps': 20}
+        with pytest.raises(ValueError, match=r'specify "out_dir"'):
+            pp = preprocessor.Preprocessor(p)
 
     def test_run_two_serial_jobs(self, tmp_path: Path) -> None:
         p = utilities.yaml_from_dict(tmp_path, 'input.yaml')

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -55,7 +55,7 @@ class TestPreprocessorSingleJobSetups:
 
     def test_py_hlvl_runjobs_simple_param_yaml(self, tmp_path: Path) -> None:
         yaml_dict = {
-            "out_dir": tmp_path,
+            "out_dir": tmp_path / "out_dir",
             "h0": 7.5,
             }
         pp = pyDeltaRCM.Preprocessor(
@@ -567,12 +567,11 @@ class TestPreprocessorEnsembleJobsSetups:
         utilities.write_parameter_to_file(f, 'ensemble', 1)
         utilities.write_parameter_to_file(f, 'out_dir', tmp_path / 'test')
         f.close()
-        # with pytest.warns(UserWarning,
-        #                   match=r'Ensemble was set to 1. *.'):
-        pp = preprocessor.Preprocessor(input_file=p)
+        with pytest.warns(UserWarning, match=r'Ensemble was set to 1. *.'):
+            pp = preprocessor.Preprocessor(input_file=p)
 
         # check that keys were reset and config set correctly
-        assert pp._has_ensemble is True # always true
+        assert pp._has_ensemble is False
         assert pp._has_matrix is False
         assert len(pp.file_list) == 1
 

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -795,6 +795,12 @@ class TestPreprocessorCustomSubclasses:
                 # inherit base DeltaModel methods
                 super().__init__(input_file, **kwargs)
 
+            def hook_import_files(self):
+                self.subclass_parameters["custom_bool"] = {
+                    "type": "bool",
+                    "default": False,
+                }
+
         # patch solver for fast run
         with mock.patch(
             "pyDeltaRCM.iteration_tools.iteration_tools.solve_water_and_sediment_timestep"
@@ -960,29 +966,28 @@ class TestPreprocessorRunJobs:
     @pytest.mark.skipif(
         platform.system() != "Linux", reason="Parallel support only on Linux OS."
     )
-    def test_run_five_parallel_jobs_bad_types(self, tmp_path: Path) -> None:
+    def test_run_five_parallel_jobs_bad_type_string(self, tmp_path: Path) -> None:
+        p = utilities.yaml_from_dict(tmp_path, "input.yaml")
+        pp_str = preprocessor.Preprocessor(p, parallel="string!")
+        with (
+            mock.patch("pyDeltaRCM.preprocessor._ParallelJob"),
+            mock.patch("multiprocessing.Semaphore"),
+        ):
+            with pytest.raises(ValueError, match=r"Parallel flag *."):
+                pp_str.run_jobs()
+
+    @pytest.mark.skipif(
+        platform.system() != "Linux", reason="Parallel support only on Linux OS."
+    )
+    def test_run_five_parallel_jobs_bad_type_float(self, tmp_path: Path) -> None:
         p = utilities.yaml_from_dict(tmp_path, "input.yaml")
         pp_float = preprocessor.Preprocessor(p, parallel=3.33)
-        pp_str = preprocessor.Preprocessor(p, parallel="string!")
-
-        # patch jobs and semaphore to check number of processes called
         with (
             mock.patch("pyDeltaRCM.preprocessor._ParallelJob"),
             mock.patch("multiprocessing.Semaphore"),
         ):
-
             with pytest.raises(ValueError, match=r"Parallel flag *."):
-                # run the method
                 pp_float.run_jobs()
-
-        with (
-            mock.patch("pyDeltaRCM.preprocessor._ParallelJob"),
-            mock.patch("multiprocessing.Semaphore"),
-        ):
-
-            with pytest.raises(ValueError, match=r"Parallel flag *."):
-                # run the method
-                pp_str.run_jobs()
 
     @pytest.mark.skipif(
         platform.system() == "Linux", reason="Parallel support only on Linux OS."

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pytest
 from pyDeltaRCM.model import DeltaModel
-from pyDeltaRCM import shared_tools
+from pyDeltaRCM.shared_tools import get_random_uniform
 
 # utilities for file writing
 
@@ -118,7 +118,7 @@ class FastIteratingDeltaModel:
             field = np.zeros(shp, dtype=np.float32)
             for i in range(shp[0]):
                 for j in range(shp[1]):
-                    field[i, j] = shared_tools.get_random_uniform(1)
+                    field[i, j] = get_random_uniform(1)
             return field
 
         shp = self.eta.shape


### PR DESCRIPTION
significant improvements to logging and warnings.

 - refactor initialization of the model to separate loading the yaml from processing attributes to the DeltaModel object. This allows for proper logging of all warnings during instantiation. **This *could* be a breaking change for certain subclasses that reimplement these methods, so this will be a partially breaking change with v2.2.2.**
 - Everywhere a warning is raised, it is logged to the log file as well. (Except in the preprocessor, there are no logs for the preprocessor at this time). 
- fixes a bug with not properly raising warnings when multiple mistakes are made in configuring the yaml.
- I have tried to reproduce the "timesteps" issue raised in the reopening of #248 through multiple tests of the `preprocessor` and the `init_tools`, but I cannot reproduce this. So until someone can generate a reproducible example of that, this closes #248. 

Todo list:
 - [x] address #248 completely with tests to ensure correct words are not written through `preprocesser` yamls, and any `preprocessor` keywords are flagged with warnings if specified directly to `DeltaModel`
 - [x] reorders components of initialization to other functions. Now `import_files` really just reads the files, and then `process_input_to_model` actually parses these inputs and handles all the warnings etc. This allows the logger to be initialized before processing inputs, which lets us actually record changes to input parameters to the log